### PR TITLE
WYSIWYG live editor: single renderer, full parity, in-place table editing

### DIFF
--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -53,6 +53,7 @@ fn demo_markdown_style() -> SyntaxStyle {
         code_bg: hsla(0., 0., 1., 0.06),  // faint code chip background
         link: hsla(0.58, 0.75, 0.66, 1.), // blue links / wiki-links
         tag: hsla(0.33, 0.45, 0.62, 1.),  // green tags
+        quote: hsla(0., 0., 0.6, 1.),     // muted blockquote text/border
         mono: font("Menlo"),
     }
 }
@@ -84,7 +85,8 @@ fn main() {
                             inline.\n\nA fenced code block (W4b):\n\n```rust\nfn main() {\n    \
                             println!(\"hello, world\");\n}\n```\n\nA table (W4c):\n\n| Name | \
                             Role | Score |\n| :-- | :--: | --: |\n| Ada | Engineer | 99 |\n\
-                            | Linus | Kernel | 88 |\n\nSpell-check still flags mispelled wrds; \
+                            | Linus | Kernel | 88 |\n\n> A blockquote, *muted* with a left \
+                            border.\n\nSpell-check still flags mispelled wrds; \
                             right-click one for suggestions.";
                 let editor = cx.new(|cx| {
                     EditorState::new(window, cx)

--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -48,12 +48,13 @@ impl Render for Demo {
 /// A dark-theme palette for the live-preview markdown styling.
 fn demo_markdown_style() -> SyntaxStyle {
     SyntaxStyle {
-        marker: hsla(0., 0., 0.5, 0.55),  // dimmed gray syntax markers
-        code: hsla(0.09, 0.6, 0.72, 1.),  // warm inline code text
-        code_bg: hsla(0., 0., 1., 0.06),  // faint code chip background
-        link: hsla(0.58, 0.75, 0.66, 1.), // blue links / wiki-links
-        tag: hsla(0.33, 0.45, 0.62, 1.),  // green tags
-        quote: hsla(0., 0., 0.6, 1.),     // muted blockquote text/border
+        marker: hsla(0., 0., 0.5, 0.55),   // dimmed gray syntax markers
+        code: hsla(0.09, 0.6, 0.72, 1.),   // warm inline code text
+        code_bg: hsla(0., 0., 1., 0.06),   // faint code chip background
+        link: hsla(0.58, 0.75, 0.66, 1.),  // blue links / wiki-links
+        tag: hsla(0.33, 0.45, 0.62, 1.),   // green tags
+        quote: hsla(0., 0., 0.6, 1.),      // muted blockquote text/border
+        mark_bg: hsla(0.13, 1., 0.5, 0.4), // yellow <mark> highlight
         mono: font("Menlo"),
     }
 }
@@ -88,7 +89,10 @@ fn main() {
                             | Linus | Kernel | 88 |\n\n> A blockquote, *muted* with a left \
                             border.\n\n- First bullet\n- Second bullet\n  - Nested bullet\n\n\
                             1. First step\n2. Second step\n\n- [x] Done task\n- [ ] Pending \
-                            task\n\n![](docs/report.pdf)\n\nSpell-check still flags mispelled \
+                            task\n\n![](docs/report.pdf)\n\n---\n\nA footnote reference[^1], a \
+                            [reference link][ref], and <mark>highlighted</mark> text.\n\n\
+                            [^1]: The footnote definition, shown muted.\n\
+                            [ref]: https://example.com\n\nSpell-check still flags mispelled \
                             wrds; right-click one for suggestions.";
                 let editor = cx.new(|cx| {
                     EditorState::new(window, cx)

--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -78,12 +78,12 @@ fn main() {
                 ..Default::default()
             },
             |window, cx| {
-                let text = "# Heading 1\n## Heading 2\n### Heading 3\n\ngpui-editor live-preview \
-                            — headings get bigger as you type (W2).\n\n**Bold**, *italic*, \
-                            ~~strike~~, `inline code`, a [link](https://example.com), a \
-                            [[Wiki Page]], and a #tag all style inline — markers stay, dimmed.\
-                            \n\nSpell-check still flags mispelled wrds; right-click one for \
-                            suggestions.";
+                let text = "# Heading 1\n## Heading 2\n\nHeadings get bigger as you type (W2). \
+                            **Bold**, *italic*, ~~strike~~, `inline code`, a \
+                            [link](https://example.com), a [[Wiki Page]], and a #tag style \
+                            inline.\n\nA fenced code block (W4b):\n\n```rust\nfn main() {\n    \
+                            println!(\"hello, world\");\n}\n```\n\nSpell-check still flags \
+                            mispelled wrds; right-click one for suggestions.";
                 let editor = cx.new(|cx| {
                     EditorState::new(window, cx)
                         .with_placeholder("Type here…")

--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -87,7 +87,8 @@ fn main() {
                             Role | Score |\n| :-- | :--: | --: |\n| Ada | Engineer | 99 |\n\
                             | Linus | Kernel | 88 |\n\n> A blockquote, *muted* with a left \
                             border.\n\n- First bullet\n- Second bullet\n  - Nested bullet\n\n\
-                            1. First step\n2. Second step\n\nSpell-check still flags mispelled \
+                            1. First step\n2. Second step\n\n- [x] Done task\n- [ ] Pending \
+                            task\n\nSpell-check still flags mispelled \
                             wrds; right-click one for suggestions.";
                 let editor = cx.new(|cx| {
                     EditorState::new(window, cx)

--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -78,10 +78,12 @@ fn main() {
                 ..Default::default()
             },
             |window, cx| {
-                let text = "gpui-editor live-preview (W1).\n\n**Bold**, *italic*, ~~strike~~, \
-                            `inline code`, a [link](https://example.com), a [[Wiki Page]], and a \
-                            #tag all style as you type — markers stay, dimmed.\n\nSpell-check still \
-                            flags mispelled wrds; right-click one for suggestions.";
+                let text = "# Heading 1\n## Heading 2\n### Heading 3\n\ngpui-editor live-preview \
+                            — headings get bigger as you type (W2).\n\n**Bold**, *italic*, \
+                            ~~strike~~, `inline code`, a [link](https://example.com), a \
+                            [[Wiki Page]], and a #tag all style inline — markers stay, dimmed.\
+                            \n\nSpell-check still flags mispelled wrds; right-click one for \
+                            suggestions.";
                 let editor = cx.new(|cx| {
                     EditorState::new(window, cx)
                         .with_placeholder("Type here…")

--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -86,8 +86,9 @@ fn main() {
                             println!(\"hello, world\");\n}\n```\n\nA table (W4c):\n\n| Name | \
                             Role | Score |\n| :-- | :--: | --: |\n| Ada | Engineer | 99 |\n\
                             | Linus | Kernel | 88 |\n\n> A blockquote, *muted* with a left \
-                            border.\n\nSpell-check still flags mispelled wrds; \
-                            right-click one for suggestions.";
+                            border.\n\n- First bullet\n- Second bullet\n  - Nested bullet\n\n\
+                            1. First step\n2. Second step\n\nSpell-check still flags mispelled \
+                            wrds; right-click one for suggestions.";
                 let editor = cx.new(|cx| {
                     EditorState::new(window, cx)
                         .with_placeholder("Type here…")

--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -9,8 +9,8 @@
 
 use gpui::{
     App, AppContext, Bounds, Context, Entity, Focusable, IntoElement, KeyBinding, ParentElement,
-    Render, Styled, Subscription, Window, WindowBounds, WindowOptions, actions, div, font, hsla,
-    px, rgb, size,
+    Render, SharedString, Styled, Subscription, Window, WindowBounds, WindowOptions, actions, div,
+    font, hsla, px, rgb, size,
 };
 use gpui_editor::{Diagnostic, EditorEvent, EditorState, SyntaxStyle};
 use spellcheck::SpellChecker;
@@ -88,7 +88,7 @@ fn main() {
                             | Linus | Kernel | 88 |\n\n> A blockquote, *muted* with a left \
                             border.\n\n- First bullet\n- Second bullet\n  - Nested bullet\n\n\
                             1. First step\n2. Second step\n\n- [x] Done task\n- [ ] Pending \
-                            task\n\nSpell-check still flags mispelled \
+                            task\n\n![](docs/report.pdf)\n\nSpell-check still flags mispelled \
                             wrds; right-click one for suggestions.";
                 let editor = cx.new(|cx| {
                     EditorState::new(window, cx)
@@ -102,15 +102,24 @@ fn main() {
                 editor.update(cx, |editor, cx| {
                     editor.on_suggest(|word| SpellChecker::new().suggestions(word));
                     editor.set_markdown_style(demo_markdown_style(), cx);
+                    // Treat a `![](*.pdf)` as a clickable chip (label = file name).
+                    editor.set_block_chip_provider(|src| {
+                        src.ends_with(".pdf")
+                            .then(|| SharedString::from(src.rsplit('/').next().unwrap_or(src)))
+                    });
                     editor.set_diagnostics(diagnostics_for(text), cx);
                 });
 
-                // Re-check on every edit.
+                // Re-check on every edit; log chip opens.
                 let editor_handle = editor.clone();
                 cx.new(|cx| {
                     let _spell_sub = cx.subscribe(
                         &editor_handle,
-                        |_demo: &mut Demo, editor, _: &EditorEvent, cx| {
+                        |_demo: &mut Demo, editor, event: &EditorEvent, cx| {
+                            if let EditorEvent::OpenLink(src) = event {
+                                eprintln!("open link: {src}");
+                                return;
+                            }
                             let text = editor.read(cx).text().to_string();
                             let diagnostics = diagnostics_for(&text);
                             editor.update(cx, |editor, cx| editor.set_diagnostics(diagnostics, cx));

--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -82,8 +82,10 @@ fn main() {
                             **Bold**, *italic*, ~~strike~~, `inline code`, a \
                             [link](https://example.com), a [[Wiki Page]], and a #tag style \
                             inline.\n\nA fenced code block (W4b):\n\n```rust\nfn main() {\n    \
-                            println!(\"hello, world\");\n}\n```\n\nSpell-check still flags \
-                            mispelled wrds; right-click one for suggestions.";
+                            println!(\"hello, world\");\n}\n```\n\nA table (W4c):\n\n| Name | \
+                            Role | Score |\n| :-- | :--: | --: |\n| Ada | Engineer | 99 |\n\
+                            | Linus | Kernel | 88 |\n\nSpell-check still flags mispelled wrds; \
+                            right-click one for suggestions.";
                 let editor = cx.new(|cx| {
                     EditorState::new(window, cx)
                         .with_placeholder("Type here…")

--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -8,9 +8,10 @@
 //! on each edit, and we re-run the checker in response.
 
 use gpui::{
-    App, AppContext, Bounds, Context, Entity, Focusable, IntoElement, KeyBinding, ParentElement,
-    Render, SharedString, Styled, Subscription, Window, WindowBounds, WindowOptions, actions, div,
-    font, hsla, px, rgb, size,
+    App, AppContext, Bounds, Context, Entity, Focusable, InteractiveElement, IntoElement,
+    KeyBinding, ParentElement, Render, ScrollHandle, SharedString, StatefulInteractiveElement,
+    Styled, Subscription, Window, WindowBounds, WindowOptions, actions, div, font, hsla, px, rgb,
+    size,
 };
 use gpui_editor::{Diagnostic, EditorEvent, EditorState, SyntaxStyle};
 use spellcheck::SpellChecker;
@@ -21,6 +22,8 @@ struct Demo {
     editor: Entity<EditorState>,
     /// Held so the change subscription keeps firing for the window's lifetime.
     _spell_sub: Subscription,
+    /// Lets the seeded content (taller than the window) scroll.
+    scroll: ScrollHandle,
 }
 
 impl Render for Demo {
@@ -30,15 +33,22 @@ impl Render for Demo {
             .bg(rgb(0x1e1e22))
             .text_color(rgb(0xe6e6e6))
             .text_size(px(16.))
-            .p(px(28.))
             .child(
                 div()
-                    .bg(rgb(0x111114))
-                    .border_1()
-                    .border_color(rgb(0x333338))
-                    .rounded(px(8.))
-                    .p(px(14.))
-                    .child(self.editor.clone()),
+                    .id("demo-scroll")
+                    .size_full()
+                    .overflow_y_scroll()
+                    .track_scroll(&self.scroll)
+                    .p(px(28.))
+                    .child(
+                        div()
+                            .bg(rgb(0x111114))
+                            .border_1()
+                            .border_color(rgb(0x333338))
+                            .rounded(px(8.))
+                            .p(px(14.))
+                            .child(self.editor.clone()),
+                    ),
             )
     }
 }
@@ -93,7 +103,13 @@ fn main() {
                             [reference link][ref], and <mark>highlighted</mark> text.\n\n\
                             [^1]: The footnote definition, shown muted.\n\
                             [ref]: https://example.com\n\nSpell-check still flags mispelled \
-                            wrds; right-click one for suggestions.";
+                            wrds; right-click one for suggestions.\n\nStriped:\n\
+                            <!-- table:striped -->\n| Name | Role | Score |\n| :-- | :--: | --: |\n\
+                            | Ada | Engineer | 99 |\n| Linus | Kernel | 88 |\n\
+                            | Grace | Compiler | 95 |\n\nHeader:\n<!-- table:header -->\n\
+                            | Name | Role |\n| :-- | :-- |\n| Ada | Engineer |\n| Linus | Kernel |\
+                            \n\nMinimal:\n<!-- table:minimal -->\n| Name | Role |\n| :-- | :-- |\n\
+                            | Ada | Engineer |\n| Linus | Kernel |";
                 let editor = cx.new(|cx| {
                     EditorState::new(window, cx)
                         .with_placeholder("Type here…")
@@ -129,7 +145,11 @@ fn main() {
                             editor.update(cx, |editor, cx| editor.set_diagnostics(diagnostics, cx));
                         },
                     );
-                    Demo { editor, _spell_sub }
+                    Demo {
+                        editor,
+                        _spell_sub,
+                        scroll: ScrollHandle::new(),
+                    }
                 })
             },
         )

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1314,6 +1314,16 @@ struct BlockImg {
     height: Pixels,
 }
 
+/// Per-logical-line shaping output — four parallel vecs of equal length: the
+/// shaped source line, its row height, an optional inline-image widget, and an
+/// optional full-width line background (a fenced code block).
+type ShapedLines = (
+    Vec<WrappedLine>,
+    Vec<Pixels>,
+    Vec<Option<BlockImg>>,
+    Vec<Option<Hsla>>,
+);
+
 /// Fit-to-width display size for an inline image from its natural (device) size:
 /// cap to the content width (or an explicit `{width=N}`), preserving aspect.
 fn block_img(
@@ -1359,18 +1369,36 @@ fn shape_document(
     caret_row: Option<usize>,
     block_image: Option<&BlockImageFn>,
     scale_factor: f32,
-) -> (Vec<WrappedLine>, Vec<Pixels>, Vec<Option<BlockImg>>) {
+) -> ShapedLines {
     let mut wrapped = Vec::new();
     let mut heights = Vec::new();
     let mut widgets = Vec::new();
+    let mut backgrounds = Vec::new();
     let mut line_start = 0;
+    let mut in_fence = false;
     for (idx, line) in content.split('\n').enumerate() {
         let line_end = line_start + line.len();
-        let fs = base_font_size * md.map_or(1.0, |_| markdown_syntax::line_scale(line));
 
-        // Inline image: a standalone image line that isn't the caret's line and
-        // has a decoded image renders as that image, fit to the content width.
-        let widget = if md.is_some()
+        // Fenced code block (W4b): a ``` line toggles the fence; the delimiter
+        // lines + the lines between render as monospace code with a full-width
+        // background (delimiters dimmed). Code is literal — no inline scanning,
+        // no heading size, no squiggles. Styling-mode only.
+        let is_fence = md.is_some() && line.trim_start().starts_with("```");
+        let is_code = md.is_some() && (in_fence || is_fence);
+        if is_fence {
+            in_fence = !in_fence;
+        }
+
+        let fs = if is_code {
+            base_font_size
+        } else {
+            base_font_size * md.map_or(1.0, |_| markdown_syntax::line_scale(line))
+        };
+
+        // Inline image (non-code): a standalone image line that isn't the caret's
+        // line and has a decoded image renders as that image, fit to width.
+        let widget = if !is_code
+            && md.is_some()
             && Some(idx) != caret_row
             && let Some((src, w_attr)) = markdown_syntax::image_line(line)
             && let Some(img) = block_image.and_then(|f| f(src))
@@ -1380,18 +1408,40 @@ fn shape_document(
             None
         };
 
-        // Diagnostics overlapping this line, shifted to line-relative ranges.
-        let line_diags: Vec<Diagnostic> = diagnostics
-            .iter()
-            .filter_map(|d| {
-                let s = d.range.start.max(line_start);
-                let e = d.range.end.min(line_end);
-                (s < e).then(|| Diagnostic {
-                    range: (s - line_start)..(e - line_start),
+        let (runs, bg) = if let Some(st) = md.filter(|_| is_code) {
+            // One monospace run for the whole line; ``` delimiters dimmed.
+            let run = TextRun {
+                len: line.len(),
+                font: st.mono.clone(),
+                color: if is_fence { st.marker } else { st.code },
+                background_color: None,
+                underline: None,
+                strikethrough: None,
+            };
+            let runs = if line.is_empty() {
+                Vec::new()
+            } else {
+                vec![run]
+            };
+            (runs, Some(st.code_bg))
+        } else {
+            // Diagnostics overlapping this line, shifted to line-relative ranges.
+            let line_diags: Vec<Diagnostic> = diagnostics
+                .iter()
+                .filter_map(|d| {
+                    let s = d.range.start.max(line_start);
+                    let e = d.range.end.min(line_end);
+                    (s < e).then(|| Diagnostic {
+                        range: (s - line_start)..(e - line_start),
+                    })
                 })
-            })
-            .collect();
-        let runs = markdown_syntax::styled_runs(line, base_font, base_color, &line_diags, md);
+                .collect();
+            (
+                markdown_syntax::styled_runs(line, base_font, base_color, &line_diags, md),
+                None,
+            )
+        };
+
         let shaped = shape_runs(
             window,
             &SharedString::from(line.to_string()),
@@ -1404,10 +1454,11 @@ fn shape_document(
             wrapped.push(wl);
             heights.push(h);
             widgets.push(widget);
+            backgrounds.push(bg);
         }
         line_start = line_end + 1; // skip the '\n'
     }
-    (wrapped, heights, widgets)
+    (wrapped, heights, widgets, backgrounds)
 }
 
 /// The custom element that lays out + paints the editor's wrapped lines, cursor,
@@ -1425,6 +1476,8 @@ struct PrepaintState {
     line_heights: Vec<Pixels>,
     /// `Some` for a line painted as an inline image instead of its source text.
     widgets: Vec<Option<BlockImg>>,
+    /// Full-width background behind a line (e.g. a fenced code block).
+    backgrounds: Vec<Option<Hsla>>,
     cursor: Option<PaintQuad>,
     selections: Vec<PaintQuad>,
 }
@@ -1488,7 +1541,7 @@ impl Element for EditorElement {
                 // Sum of per-line (variable) heights × each line's wrap rows.
                 let caret_row = editor.row_col(editor.cursor_offset()).0;
                 let sf = window.scale_factor();
-                let (wrapped, heights, _) = shape_document(
+                let (wrapped, heights, _, _) = shape_document(
                     window,
                     &editor.content,
                     &text_style.font(),
@@ -1535,7 +1588,7 @@ impl Element for EditorElement {
         // their own taller rows (W2) and image lines render inline (W4).
         let caret_row = editor.row_col(editor.cursor_offset()).0;
         let sf = window.scale_factor();
-        let (wrapped, line_heights, widgets) = if editor.content.is_empty() {
+        let (wrapped, line_heights, widgets, backgrounds) = if editor.content.is_empty() {
             let w = shape_all(
                 window,
                 &editor.placeholder,
@@ -1544,9 +1597,8 @@ impl Element for EditorElement {
                 hsla(0., 0., 0.5, 0.5),
                 wrap_width,
             );
-            let h = vec![base_lh; w.len()];
-            let g = vec![None; w.len()];
-            (w, h, g)
+            let n = w.len();
+            (w, vec![base_lh; n], vec![None; n], vec![None; n])
         } else {
             shape_document(
                 window,
@@ -1658,6 +1710,7 @@ impl Element for EditorElement {
             line_tops,
             line_heights,
             widgets,
+            backgrounds,
             cursor,
             selections,
         }
@@ -1686,16 +1739,20 @@ impl Element for EditorElement {
 
         let base_lh =
             window.text_style().font_size.to_pixels(window.rem_size()) * LINE_HEIGHT_RATIO;
-        for (((line, top), lh), widget) in prepaint
+        for (i, ((line, top), lh)) in prepaint
             .wrapped
             .iter()
             .zip(prepaint.line_tops.iter())
             .zip(prepaint.line_heights.iter())
-            .zip(prepaint.widgets.iter())
+            .enumerate()
         {
             let origin = point(bounds.origin.x, bounds.origin.y + *top);
-            if let Some(w) = widget {
-                // Inline image (W4): paint the decoded image instead of source.
+            // Full-width background behind the line (a fenced code block — W4b).
+            if let Some(c) = prepaint.backgrounds.get(i).copied().flatten() {
+                window.paint_quad(fill(Bounds::new(origin, size(bounds.size.width, *lh)), c));
+            }
+            if let Some(w) = prepaint.widgets.get(i).and_then(Option::as_ref) {
+                // Inline image (W4a): paint the decoded image instead of source.
                 let img_bounds = Bounds::new(origin, size(w.width, w.height));
                 let _ = window.paint_image(img_bounds, Corners::default(), w.img.clone(), 0, false);
             } else {

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -282,6 +282,15 @@ impl EditorState {
         cx.notify();
     }
 
+    /// Turn off live-preview styling — the editor falls back to plain text
+    /// (spell-check underlines only). Used when the host's WYSIWYG setting is
+    /// switched off; a no-op if styling was already off.
+    pub fn clear_markdown_style(&mut self, cx: &mut Context<Self>) {
+        if self.markdown_style.take().is_some() {
+            cx.notify();
+        }
+    }
+
     /// Install the provider consulted when the user right-clicks a flagged word.
     /// It's handed the offending word and returns replacements (best first).
     /// Kept lazy by design — the OS suggestion call can be slow, so it runs only

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -128,6 +128,10 @@ const CODE_INSET: f32 = 12.;
 /// box doesn't overlap adjacent lines, with no blank line required.
 const CODE_PAD: f32 = 8.;
 
+/// Horizontal inset (px) of blockquote text from the editor's left edge, leaving
+/// room for the left border (2px) + a gap, matching the reading view's `pl(12)`.
+const QUOTE_INSET: f32 = 14.;
+
 /// A restorable editor state, for undo/redo. Stores the caret offset (not a
 /// selection), so undo/redo place the caret rather than re-selecting text.
 #[derive(Clone)]
@@ -215,10 +219,10 @@ pub struct EditorState {
     /// Per-logical-line display→source byte map for rows with hidden markers
     /// (W6); `None` when the painted text equals the source. From the last paint.
     offset_maps: Vec<Option<Vec<usize>>>,
-    /// Per-logical-line flag: this row is inside a fenced code block, so its text
-    /// (and the caret/selection/hit-test on it) is inset by [`CODE_INSET`] to sit
-    /// inside the block's padded box. From the last paint.
-    code_rows: Vec<bool>,
+    /// Per-logical-line horizontal text inset (and so the caret/selection/hit-test
+    /// inset): non-zero for fenced code blocks and gutter marks (blockquotes,
+    /// lists). From the last paint.
+    line_insets: Vec<Pixels>,
     last_bounds: Option<Bounds<Pixels>>,
     line_height: Pixels,
     is_selecting: bool,
@@ -259,7 +263,7 @@ impl EditorState {
             line_heights: Vec::new(),
             widget_rows: Vec::new(),
             offset_maps: Vec::new(),
-            code_rows: Vec::new(),
+            line_insets: Vec::new(),
             last_bounds: None,
             line_height: px(20.),
             is_selecting: false,
@@ -377,15 +381,11 @@ impl EditorState {
             .unwrap_or(self.line_height)
     }
 
-    /// Horizontal text inset for logical line `row`: [`CODE_INSET`] for a fenced
-    /// code-block row (text sits inside the padded box), else zero. Applied to the
-    /// caret, selection, hit-test, and text paint so they all stay aligned.
-    fn code_inset(&self, row: usize) -> Pixels {
-        if self.code_rows.get(row).copied().unwrap_or(false) {
-            px(CODE_INSET)
-        } else {
-            px(0.)
-        }
+    /// Horizontal text inset for logical line `row` (from the last paint): non-zero
+    /// for fenced code blocks + gutter marks. Applied to the caret, selection,
+    /// hit-test, and text paint so they all stay aligned.
+    fn line_inset(&self, row: usize) -> Pixels {
+        self.line_insets.get(row).copied().unwrap_or(px(0.))
     }
 
     /// Window-space bounds of the caret at `offset`, from the last paint's
@@ -398,7 +398,7 @@ impl EditorState {
         let line = self.wrapped.get(row)?;
         let p = line.position_for_index(self.display_col(row, col), lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
-        let x = bounds.left() + p.x + self.code_inset(row);
+        let x = bounds.left() + p.x + self.line_inset(row);
         Some(Bounds::from_corners(point(x, top), point(x, top + lh)))
     }
 
@@ -948,7 +948,7 @@ impl EditorState {
         if self.widget_rows.get(row).copied().unwrap_or(false) {
             return self.line_starts()[row];
         }
-        let x = (rel.x - self.code_inset(row)).max(px(0.));
+        let x = (rel.x - self.line_inset(row)).max(px(0.));
         let line_rel = point(x, rel.y - self.line_tops[row]);
         let col = match self.wrapped[row].closest_index_for_position(line_rel, self.line_h(row)) {
             Ok(i) | Err(i) => i,
@@ -1132,7 +1132,7 @@ impl EntityInputHandler for EditorState {
         let line = self.wrapped.get(row)?;
         let p = line.position_for_index(self.display_col(row, col), lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
-        let x = bounds.left() + p.x + self.code_inset(row);
+        let x = bounds.left() + p.x + self.line_inset(row);
         Some(Bounds::from_corners(point(x, top), point(x, top + lh)))
     }
 
@@ -1390,10 +1390,29 @@ struct TableRow {
     border: Hsla,
 }
 
-/// Per-logical-line shaping output — five parallel vecs of equal length: the
-/// shaped source line, its row height, an optional inline-image widget, an
-/// optional full-width line background (a fenced code block), and an optional
-/// table-row grid.
+/// A per-line "gutter" decoration: a left-margin treatment that hides its source
+/// marker and renders something in its place, with the body text inset to make
+/// room. Covers blockquotes now; list bullets + task checkboxes reuse it.
+#[derive(Clone, Copy)]
+enum LineMark {
+    /// Blockquote: a muted left border; the `>` markers are hidden and the body
+    /// text is muted (`SyntaxStyle::quote`).
+    Quote(Hsla),
+}
+
+impl LineMark {
+    /// Horizontal inset (px) applied to the body text + caret for this mark.
+    fn inset(self) -> Pixels {
+        match self {
+            LineMark::Quote(_) => px(QUOTE_INSET),
+        }
+    }
+}
+
+/// Per-logical-line shaping output — parallel vecs of equal length: the shaped
+/// source line, its row height, an optional inline-image widget, an optional
+/// fenced-code-block background, an optional table-row grid, the display→source
+/// map, and an optional gutter decoration (blockquote / list / checkbox).
 type ShapedLines = (
     Vec<WrappedLine>,
     Vec<Pixels>,
@@ -1403,6 +1422,7 @@ type ShapedLines = (
     // Per-line display→source byte map for lines with markers hidden (W6); `None`
     // when the displayed text equals the source (revealed / code / widget lines).
     Vec<Option<Vec<usize>>>,
+    Vec<Option<LineMark>>,
 );
 
 /// Fit-to-width display size for an inline image from its natural (device) size:
@@ -1440,6 +1460,17 @@ fn display_col_in(map: Option<&Vec<usize>>, source_col: usize) -> usize {
             Ok(d) | Err(d) => d,
         },
         None => source_col,
+    }
+}
+
+/// Horizontal text inset for a row from its decorations: [`CODE_INSET`] inside a
+/// fenced code block, else the gutter mark's inset (blockquote/list), else zero.
+/// At most one applies per line.
+fn row_inset(bg: Option<CodeBg>, mark: Option<LineMark>) -> Pixels {
+    if bg.is_some() {
+        px(CODE_INSET)
+    } else {
+        mark.map_or(px(0.), LineMark::inset)
     }
 }
 
@@ -1489,6 +1520,7 @@ fn shape_document(
     let mut backgrounds: Vec<Option<CodeBg>> = Vec::new();
     let mut tables = Vec::new();
     let mut maps = Vec::new();
+    let mut marks: Vec<Option<LineMark>> = Vec::new();
     let lines: Vec<&str> = content.split('\n').collect();
     // Fenced-code-block regions; a block's ``` fence lines collapse (W6) unless
     // the caret is inside that block (then they show, so they stay editable).
@@ -1620,6 +1652,24 @@ fn shape_document(
                 })
             })
             .collect();
+        // Gutter decoration (blockquote for now): a non-code/widget/table line
+        // beginning with `>`. The decoration (muted text + left border, `>`
+        // hidden) shows only while the caret is OFF the line; on the line it reads
+        // as plain source with the `>` revealed (a line-level reveal — the whole
+        // prefix shows wherever the caret sits on the line, unlike inline #5).
+        let quote_prefix = md
+            .filter(|_| !is_code && widget.is_none() && table.is_none())
+            .and_then(|_| markdown_syntax::blockquote_prefix(line));
+        let caret_here = caret_col.is_some();
+        let mark = quote_prefix
+            .filter(|_| !caret_here && !full_source)
+            .and(md)
+            .map(|st| LineMark::Quote(st.quote));
+        let reveal_prefix = quote_prefix.filter(|_| caret_here).unwrap_or(0);
+        let line_base = match mark {
+            Some(LineMark::Quote(c)) => c,
+            None => base_color,
+        };
         let (shaped_text, runs, bg, map) = if collapse_fence {
             // Hidden ``` fence line: nothing painted, zero height.
             (String::new(), Vec::new(), None, None)
@@ -1658,9 +1708,10 @@ fn shape_document(
             let (disp, runs, m) = markdown_syntax::hidden_runs(
                 line,
                 base_font,
-                base_color,
+                line_base,
                 &line_diags,
                 caret_col,
+                reveal_prefix,
                 st,
             );
             (disp, runs, None, Some(m))
@@ -1668,16 +1719,18 @@ fn shape_document(
             // Full source with diagnostics (the caret/selected line, or md off).
             (
                 line.to_string(),
-                markdown_syntax::styled_runs(line, base_font, base_color, &line_diags, md),
+                markdown_syntax::styled_runs(line, base_font, line_base, &line_diags, md),
                 None,
                 None,
             )
         };
 
-        // Code lines are painted inset by CODE_INSET on each side, so they wrap at
-        // a correspondingly narrower width to stay inside the box.
+        // Code lines are inset by CODE_INSET on each side; a gutter mark insets the
+        // left only. Either wraps at a correspondingly narrower width.
         let line_wrap = if is_code {
             wrap_width.map(|w| (w - px(2. * CODE_INSET)).max(px(0.)))
+        } else if let Some(m) = mark {
+            wrap_width.map(|w| (w - m.inset()).max(px(0.)))
         } else {
             wrap_width
         };
@@ -1705,6 +1758,7 @@ fn shape_document(
             backgrounds.push(bg);
             tables.push(table);
             maps.push(map);
+            marks.push(mark);
             // Track a (visible) code line + its width so the block's box can be
             // sized to its widest line and its last line marked.
             if is_code && !collapse_fence {
@@ -1726,7 +1780,7 @@ fn shape_document(
             }
         }
     }
-    (wrapped, heights, widgets, backgrounds, tables, maps)
+    (wrapped, heights, widgets, backgrounds, tables, maps, marks)
 }
 
 /// Content-fit column widths for a table region (W4c): each column sized to its
@@ -1899,6 +1953,8 @@ struct PrepaintState {
     tables: Vec<Option<TableRow>>,
     /// Per-line display→source byte map for marker-hidden rows (W6).
     maps: Vec<Option<Vec<usize>>>,
+    /// Per-line gutter decoration (blockquote / list / checkbox).
+    marks: Vec<Option<LineMark>>,
     cursor: Option<PaintQuad>,
     selections: Vec<PaintQuad>,
 }
@@ -1962,7 +2018,7 @@ impl Element for EditorElement {
                 // Sum of per-line (variable) heights × each line's wrap rows.
                 let caret_row = editor.row_col(editor.cursor_offset()).0;
                 let sf = window.scale_factor();
-                let (wrapped, heights, _, backgrounds, _, _) = shape_document(
+                let (wrapped, heights, _, backgrounds, _, _, _) = shape_document(
                     window,
                     &editor.content,
                     &text_style.font(),
@@ -2014,7 +2070,7 @@ impl Element for EditorElement {
         // their own taller rows (W2) and image lines render inline (W4).
         let caret_row = editor.row_col(editor.cursor_offset()).0;
         let sf = window.scale_factor();
-        let (wrapped, line_heights, widgets, backgrounds, tables, maps) =
+        let (wrapped, line_heights, widgets, backgrounds, tables, maps, marks) =
             if editor.content.is_empty() {
                 let w = shape_all(
                     window,
@@ -2028,6 +2084,7 @@ impl Element for EditorElement {
                 (
                     w,
                     vec![base_lh; n],
+                    vec![None; n],
                     vec![None; n],
                     vec![None; n],
                     vec![None; n],
@@ -2072,17 +2129,16 @@ impl Element for EditorElement {
             |top: Pixels, p: Point<Pixels>| point(bounds.left() + p.x, bounds.top() + top + p.y);
 
         // Caret/selection positioning must use THIS frame's fresh per-row data —
-        // `editor.offset_maps`/`code_rows` aren't committed until paint, so the
+        // `editor.offset_maps`/`line_insets` aren't committed until paint, so the
         // method forms would lag a frame (a one-frame caret jump after an edit
         // that hides/reveals markers).
         let disp_col =
             |row: usize, sc: usize| display_col_in(maps.get(row).and_then(Option::as_ref), sc);
         let code_inset = |row: usize| {
-            if backgrounds.get(row).is_some_and(Option::is_some) {
-                px(CODE_INSET)
-            } else {
-                px(0.)
-            }
+            row_inset(
+                backgrounds.get(row).copied().flatten(),
+                marks.get(row).copied().flatten(),
+            )
         };
 
         let (cursor, selections) = if editor.content.is_empty() {
@@ -2181,6 +2237,7 @@ impl Element for EditorElement {
             backgrounds,
             tables,
             maps,
+            marks,
             cursor,
             selections,
         }
@@ -2241,6 +2298,11 @@ impl Element for EditorElement {
                     fill(Bounds::new(box_origin, box_size), cb.color).corner_radii(corners),
                 );
             }
+            // Blockquote: a muted 2px left border down the line (the body is inset
+            // past it by QUOTE_INSET).
+            if let Some(LineMark::Quote(c)) = prepaint.marks.get(i).copied().flatten() {
+                window.paint_quad(fill(Bounds::new(origin, size(px(2.), *lh)), c));
+            }
             if let Some(t) = prepaint.tables.get(i).and_then(Option::as_ref) {
                 // Table grid row (W4c): cells + borders instead of source.
                 paint_table_row(
@@ -2251,13 +2313,13 @@ impl Element for EditorElement {
                 let img_bounds = Bounds::new(origin, size(w.width, w.height));
                 let _ = window.paint_image(img_bounds, Corners::default(), w.img.clone(), 0, false);
             } else {
-                // Code lines inset their text to sit inside the block's padded box
-                // (kept in sync with `EditorState::code_inset`).
-                let text_origin = if prepaint.backgrounds.get(i).copied().flatten().is_some() {
-                    point(origin.x + px(CODE_INSET), origin.y)
-                } else {
-                    origin
-                };
+                // Code blocks + gutter marks inset their text (kept in sync with
+                // `EditorState::line_inset` / the fresh prepaint inset).
+                let inset = row_inset(
+                    prepaint.backgrounds.get(i).copied().flatten(),
+                    prepaint.marks.get(i).copied().flatten(),
+                );
+                let text_origin = point(origin.x + inset, origin.y);
                 // Run backgrounds (the inline-code highlight) paint separately from
                 // the glyphs — `paint` alone wouldn't show them.
                 let _ = line.paint_background(
@@ -2288,14 +2350,19 @@ impl Element for EditorElement {
             .enumerate()
             .map(|(i, w)| w.is_some() || prepaint.tables.get(i).is_some_and(Option::is_some))
             .collect();
-        let code_rows: Vec<bool> = prepaint.backgrounds.iter().map(Option::is_some).collect();
+        let line_insets: Vec<Pixels> = prepaint
+            .backgrounds
+            .iter()
+            .zip(prepaint.marks.iter())
+            .map(|(bg, mark)| row_inset(*bg, *mark))
+            .collect();
         self.editor.update(cx, |editor, _| {
             editor.wrapped = wrapped;
             editor.line_tops = line_tops;
             editor.line_heights = line_heights;
             editor.widget_rows = widget_rows;
             editor.offset_maps = offset_maps;
-            editor.code_rows = code_rows;
+            editor.line_insets = line_insets;
             editor.last_bounds = Some(bounds);
             editor.line_height = base_lh;
         });

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -122,6 +122,10 @@ const UNDO_LIMIT: usize = 256;
 /// editor text). 1.25 matches the spacing the editor replaced.
 const LINE_HEIGHT_RATIO: f32 = 1.25;
 
+/// Caret thickness (px) — thin like a native text caret, so it doesn't blend into
+/// the first glyph at the start of a line/cell.
+const CARET_WIDTH: f32 = 1.0;
+
 /// Horizontal inset (px) of fenced-code-block text from the box's left edge, so
 /// code sits inside the padded box rather than flush against it. Mirrors the old
 /// renderer's `px(12)` left padding.
@@ -244,6 +248,9 @@ pub struct EditorState {
     /// a taller row (W2); `line_height` is the base/fallback for the empty doc
     /// and any row without a recorded height.
     line_heights: Vec<Pixels>,
+    /// Per-logical-line table-grid row (from the last paint), so a click /
+    /// Tab / caret hit-tests against cells instead of the raw source line.
+    table_rows: Vec<Option<TableRow>>,
     /// Per-logical-line flag: this row is painted as an inline image (W4), so a
     /// click on it places the caret at the line start instead of hit-testing
     /// source text. From the last paint.
@@ -308,6 +315,7 @@ impl EditorState {
             widget_rows: Vec::new(),
             offset_maps: Vec::new(),
             line_insets: Vec::new(),
+            table_rows: Vec::new(),
             last_bounds: None,
             line_height: px(20.),
             is_selecting: false,
@@ -613,6 +621,13 @@ impl EditorState {
     /// spaces at the line start, caret shifts with it); elsewhere insert that many
     /// spaces at the caret (replacing any selection).
     fn indent(&mut self, _: &Indent, window: &mut Window, cx: &mut Context<Self>) {
+        // In a table, Tab moves to the next cell rather than indenting.
+        if self.caret_in_table() {
+            if let Some(offset) = self.table_cell_nav(true) {
+                self.move_to(offset, cx);
+            }
+            return;
+        }
         let cursor = self.cursor_offset();
         let line_start = self.content[..cursor].rfind('\n').map_or(0, |i| i + 1);
         let line_end = self.content[line_start..]
@@ -641,6 +656,13 @@ impl EditorState {
     /// Shift+Tab: outdent the caret's line — remove up to `tab_indent` leading
     /// spaces (or one leading tab) from the line start. No-op if there's none.
     fn outdent(&mut self, _: &Outdent, _: &mut Window, cx: &mut Context<Self>) {
+        // In a table, Shift+Tab moves to the previous cell rather than outdenting.
+        if self.caret_in_table() {
+            if let Some(offset) = self.table_cell_nav(false) {
+                self.move_to(offset, cx);
+            }
+            return;
+        }
         let cursor = self.cursor_offset();
         let line_start = self.content[..cursor].rfind('\n').map_or(0, |i| i + 1);
         let line = &self.content[line_start..];
@@ -767,14 +789,23 @@ impl EditorState {
 
     // --- Mouse ---------------------------------------------------------------
 
-    fn on_mouse_down(&mut self, event: &MouseDownEvent, _: &mut Window, cx: &mut Context<Self>) {
+    fn on_mouse_down(
+        &mut self,
+        event: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         // Left-click a file chip (e.g. a PDF embed) opens it rather than editing —
         // the host handles the link. Right-click edits (see on_right_mouse_down).
         if let Some(src) = self.chip_at(event.position) {
             cx.emit(EditorEvent::OpenLink(src));
             return;
         }
-        let offset = self.index_for_mouse_position(event.position);
+        // A click on a table cell drops the caret inside the cell, not in the raw
+        // `| … |` source.
+        let offset = self
+            .table_offset_at(event.position, window)
+            .unwrap_or_else(|| self.index_for_mouse_position(event.position));
         self.menu = None;
         self.goal_x = None;
         self.last_edit = EditKind::Other;
@@ -811,9 +842,17 @@ impl EditorState {
         self.is_selecting = false;
     }
 
-    fn on_mouse_move(&mut self, event: &MouseMoveEvent, _: &mut Window, cx: &mut Context<Self>) {
+    fn on_mouse_move(
+        &mut self,
+        event: &MouseMoveEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if self.is_selecting {
-            self.select_to(self.index_for_mouse_position(event.position), cx);
+            let offset = self
+                .table_offset_at(event.position, window)
+                .unwrap_or_else(|| self.index_for_mouse_position(event.position));
+            self.select_to(offset, cx);
         }
     }
 
@@ -1092,6 +1131,108 @@ impl EditorState {
             }
         }
         self.chip_rows.get(row).and_then(Option::clone)
+    }
+
+    /// If `position` lands on a table grid row (not the separator), the source
+    /// byte offset of the closest cell-content position — so a click puts the
+    /// caret inside the cell rather than in the raw `| … |` source. `None`
+    /// otherwise (the caller falls back to [`Self::index_for_mouse_position`]).
+    fn table_offset_at(&self, position: Point<Pixels>, window: &mut Window) -> Option<usize> {
+        if self.wrapped.is_empty() || self.table_rows.iter().all(Option::is_none) {
+            return None;
+        }
+        let bounds = self.last_bounds.as_ref()?;
+        let rel = point(position.x - bounds.left(), position.y - bounds.top());
+        let mut row = self.wrapped.len() - 1;
+        for i in 0..self.wrapped.len() {
+            let h = self.line_h(i) * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
+            if rel.y < self.line_tops[i] + h {
+                row = i;
+                break;
+            }
+        }
+        let t = self.table_rows.get(row).and_then(Option::as_ref)?;
+        if t.is_separator || t.col_widths.is_empty() {
+            return None;
+        }
+        let style = window.text_style();
+        let font = style.font();
+        let font_size = style.font_size.to_pixels(window.rem_size());
+        let pad = px(TABLE_CELL_PAD);
+        // Column the click is in, and its left x.
+        let last = t.col_widths.len() - 1;
+        let mut cx = px(0.);
+        let mut cell = 0;
+        for (c, &cw) in t.col_widths.iter().enumerate() {
+            if rel.x < cx + cw || c == last {
+                cell = c;
+                break;
+            }
+            cx += cw;
+        }
+        let content = t.cells.get(cell)?;
+        let cw = t.col_widths[cell];
+        let cf = cell_font(&font, t.is_header);
+        let full_w = measure_width(window, content, &cf, font_size);
+        let avail = (cw - pad * 2.).max(px(0.));
+        let align_off = match t.aligns.get(cell) {
+            Some(markdown_syntax::Align::Center) => (avail - full_w).max(px(0.)) / 2.,
+            Some(markdown_syntax::Align::Right) => (avail - full_w).max(px(0.)),
+            _ => px(0.),
+        };
+        let target = (rel.x - cx - pad - align_off).max(px(0.));
+        let in_cell = cell_offset_for_x(content, target, &cf, font_size, window);
+        Some(self.line_starts()[row] + t.cell_ranges.get(cell)?.start + in_cell)
+    }
+
+    /// Whether the caret is currently inside an editable table cell (not the
+    /// separator) — so Tab navigates cells instead of indenting.
+    fn caret_in_table(&self) -> bool {
+        let (row, _) = self.row_col(self.cursor_offset());
+        self.table_rows
+            .get(row)
+            .and_then(Option::as_ref)
+            .is_some_and(|t| !t.is_separator)
+    }
+
+    /// Target source offset to move the caret to the next (`forward`) / previous
+    /// table cell, crossing rows (skipping the separator). Stays put at the table's
+    /// final/first cell. `None` when the caret isn't in a table cell.
+    fn table_cell_nav(&self, forward: bool) -> Option<usize> {
+        let (row, col) = self.row_col(self.cursor_offset());
+        let t = self.table_rows.get(row).and_then(Option::as_ref)?;
+        if t.is_separator {
+            return None;
+        }
+        let cell = table_cell_at(t, col);
+        let starts = self.line_starts();
+        let usable = |tr: &TableRow| !tr.is_separator && !tr.cell_ranges.is_empty();
+        if forward {
+            if cell + 1 < t.cell_ranges.len() {
+                return Some(starts[row] + t.cell_ranges[cell + 1].start);
+            }
+            for (r, slot) in self.table_rows.iter().enumerate().skip(row + 1) {
+                match slot.as_ref() {
+                    Some(nt) if usable(nt) => return Some(starts[r] + nt.cell_ranges[0].start),
+                    Some(_) => continue,
+                    None => break,
+                }
+            }
+        } else {
+            if cell > 0 {
+                return Some(starts[row] + t.cell_ranges[cell - 1].start);
+            }
+            for (r, slot) in self.table_rows.iter().enumerate().take(row).rev() {
+                match slot.as_ref() {
+                    Some(pt) if usable(pt) => {
+                        return Some(starts[r] + pt.cell_ranges[pt.cell_ranges.len() - 1].start);
+                    }
+                    Some(_) => continue,
+                    None => break,
+                }
+            }
+        }
+        Some(self.cursor_offset()) // at the boundary — no-op move (don't indent)
     }
 
     fn index_for_mouse_position(&self, position: Point<Pixels>) -> usize {
@@ -1604,6 +1745,10 @@ struct CodeBg {
 #[derive(Clone)]
 struct TableRow {
     cells: Vec<SharedString>,
+    /// Byte range of each cell's trimmed content within its source line — for
+    /// placing the caret inside a cell + hit-testing a click back to a source
+    /// offset (in-cell editing).
+    cell_ranges: Vec<Range<usize>>,
     aligns: Vec<markdown_syntax::Align>,
     col_widths: Vec<Pixels>,
     is_header: bool,
@@ -1913,12 +2058,14 @@ fn shape_document(
             None
         };
 
-        // Table row (W4c): a line inside a detected table region renders as a
-        // grid row — unless the caret is in that table (then it shows source).
+        // Table row (W4c + cell editing): renders as a grid row; the caret on a
+        // header/body row edits in place (caret rendered inside the cell). Only the
+        // caret on the `|---|` separator drops the whole table to raw source (to
+        // edit alignment), avoiding a broken outer box around a half-raw table.
         let table = regions
             .iter()
             .position(|r| r.lines.contains(&idx))
-            .filter(|&ri| !is_code && !caret_row.is_some_and(|cr| regions[ri].lines.contains(&cr)))
+            .filter(|&ri| !is_code && caret_row != Some(regions[ri].lines.start + 1))
             .map(|ri| {
                 let r = &regions[ri];
                 TableRow {
@@ -1926,6 +2073,7 @@ fn shape_document(
                         .into_iter()
                         .map(|c| SharedString::from(c.to_string()))
                         .collect(),
+                    cell_ranges: markdown_syntax::table_cell_ranges(line),
                     aligns: r.aligns.clone(),
                     col_widths: region_cols[ri].clone(),
                     is_header: idx == r.lines.start,
@@ -2199,7 +2347,7 @@ fn table_column_widths(
     wrap_width: Option<Pixels>,
 ) -> Vec<Pixels> {
     let cols = region.aligns.len().max(1);
-    let pad = px(8.);
+    let pad = px(TABLE_CELL_PAD);
     let mut widths = vec![px(0.); cols];
     for li in region.lines.clone() {
         if li == region.lines.start + 1 {
@@ -2253,6 +2401,121 @@ fn table_column_widths(
     widths
 }
 
+/// Horizontal inset (px) of a table cell's text from its column's left edge.
+const TABLE_CELL_PAD: f32 = 10.;
+
+/// The font a table cell is rendered with — bold in the header row.
+fn cell_font(font: &Font, is_header: bool) -> Font {
+    let mut f = font.clone();
+    if is_header {
+        f.weight = gpui::FontWeight::BOLD;
+    }
+    f
+}
+
+/// Shape a table cell's `content` into a single (unwrapped) line, for exact
+/// caret / hit-test geometry that matches the kerned glyphs `paint_table_row`
+/// renders (measuring prefixes in isolation drifts by their kerning).
+fn shape_cell(
+    window: &mut Window,
+    content: &str,
+    font: &Font,
+    font_size: Pixels,
+) -> Option<WrappedLine> {
+    let run = TextRun {
+        len: content.len(),
+        font: font.clone(),
+        color: Hsla::default(),
+        background_color: None,
+        underline: None,
+        strikethrough: None,
+    };
+    let runs: &[TextRun] = if content.is_empty() {
+        &[]
+    } else {
+        std::slice::from_ref(&run)
+    };
+    window
+        .text_system()
+        .shape_text(
+            SharedString::from(content.to_string()),
+            font_size,
+            runs,
+            None,
+            None,
+        )
+        .ok()?
+        .into_iter()
+        .next()
+}
+
+/// The cell a source column `col` (line-local) falls in for a table row — clamped
+/// to the nearest cell when `col` is in a pipe/space between cells.
+fn table_cell_at(t: &TableRow, col: usize) -> usize {
+    t.cell_ranges
+        .iter()
+        .position(|r| col <= r.end)
+        .unwrap_or(t.cell_ranges.len().saturating_sub(1))
+}
+
+/// Screen position of the caret at source column `col` (line-local) inside a
+/// table row's rendered cells: `(x, cell_index, in_cell_offset)`. Mirrors
+/// `paint_table_row`'s layout (cumulative column widths + pad + alignment).
+fn table_caret_pos(
+    t: &TableRow,
+    col: usize,
+    left: Pixels,
+    font: &Font,
+    font_size: Pixels,
+    window: &mut Window,
+) -> Option<(Pixels, usize, usize)> {
+    if t.cell_ranges.is_empty() {
+        return None;
+    }
+    let pad = px(TABLE_CELL_PAD);
+    let cell = table_cell_at(t, col);
+    let range = t.cell_ranges.get(cell)?;
+    let content = t.cells.get(cell)?;
+    let in_cell = col.saturating_sub(range.start).min(content.len());
+    let cell_x = left + t.col_widths[..cell].iter().fold(px(0.), |a, &w| a + w);
+    let cw = t.col_widths.get(cell).copied().unwrap_or(px(0.));
+    // The header is bold, so shape with the bold font or the caret lands left of
+    // the (wider) bold glyphs; position_for_index gives the exact kerned x.
+    let cf = cell_font(font, t.is_header);
+    let line_h = font_size * LINE_HEIGHT_RATIO;
+    let wl = shape_cell(window, content, &cf, font_size)?;
+    let prefix_w = wl
+        .position_for_index(in_cell, line_h)
+        .map_or(px(0.), |p| p.x);
+    let full_w = wl.width();
+    let avail = (cw - pad * 2.).max(px(0.));
+    let align_off = match t.aligns.get(cell) {
+        Some(markdown_syntax::Align::Center) => (avail - full_w).max(px(0.)) / 2.,
+        Some(markdown_syntax::Align::Right) => (avail - full_w).max(px(0.)),
+        _ => px(0.),
+    };
+    Some((cell_x + pad + align_off + prefix_w, cell, in_cell))
+}
+
+/// The byte offset within `content` whose rendered x (from the text's left edge)
+/// is closest to `target` — hit-tests a click inside a table cell, using the
+/// shaped line so it matches the kerned glyphs.
+fn cell_offset_for_x(
+    content: &str,
+    target: Pixels,
+    font: &Font,
+    font_size: Pixels,
+    window: &mut Window,
+) -> usize {
+    let line_h = font_size * LINE_HEIGHT_RATIO;
+    let Some(wl) = shape_cell(window, content, font, font_size) else {
+        return 0;
+    };
+    match wl.closest_index_for_position(point(target, line_h / 2.), line_h) {
+        Ok(i) | Err(i) => i,
+    }
+}
+
 /// Paint a table row as a grid (W4c): a top border (+ bottom on the last row),
 /// a left border per column + a right outer border, and each cell's text aligned
 /// within its (content-fit) column. A separator row is a single horizontal rule.
@@ -2280,7 +2543,7 @@ fn paint_table_row(
     if !t.is_header {
         window.paint_quad(fill(Bounds::new(origin, size(table_w, thick)), t.border));
     }
-    let pad = px(10.);
+    let pad = px(TABLE_CELL_PAD);
     let mut cell_font = font.clone();
     if t.is_header {
         cell_font.weight = gpui::FontWeight::BOLD;
@@ -2557,24 +2820,44 @@ impl Element for EditorElement {
 
         let (cursor, selections) = if editor.content.is_empty() {
             let c = fill(
-                Bounds::new(point(bounds.left(), bounds.top()), size(px(2.), base_lh)),
+                Bounds::new(
+                    point(bounds.left(), bounds.top()),
+                    size(px(CARET_WIDTH), base_lh),
+                ),
                 text_color,
             );
             (Some(c), Vec::new())
         } else if editor.selected_range.is_empty() {
             let (row, col) = editor.row_col(editor.cursor_offset());
             let lh = line_heights.get(row).copied().unwrap_or(base_lh);
-            let p = wrapped
-                .get(row)
-                .and_then(|l| l.position_for_index(disp_col(row, col), lh))
-                .unwrap_or_default();
             let top = line_tops.get(row).copied().unwrap_or(px(0.));
-            let inset = code_inset(row);
-            let c = fill(
-                Bounds::new(to_screen(top, point(p.x + inset, p.y)), size(px(2.), lh)),
-                text_color,
-            );
-            (Some(c), Vec::new())
+            // Caret inside a table cell: position it within the rendered cell
+            // (centered vertically like the cell text), not by the raw source line.
+            if let Some(t) = tables.get(row).and_then(Option::as_ref)
+                && let Some((x, _, _)) =
+                    table_caret_pos(t, col, bounds.left(), &font, font_size, window)
+            {
+                let y = bounds.top() + top + (lh - base_lh) / 2.;
+                let c = fill(
+                    Bounds::new(point(x, y), size(px(CARET_WIDTH), base_lh)),
+                    text_color,
+                );
+                (Some(c), Vec::new())
+            } else {
+                let p = wrapped
+                    .get(row)
+                    .and_then(|l| l.position_for_index(disp_col(row, col), lh))
+                    .unwrap_or_default();
+                let inset = code_inset(row);
+                let c = fill(
+                    Bounds::new(
+                        to_screen(top, point(p.x + inset, p.y)),
+                        size(px(CARET_WIDTH), lh),
+                    ),
+                    text_color,
+                );
+                (Some(c), Vec::new())
+            }
         } else {
             let (s, e) = (editor.selected_range.start, editor.selected_range.end);
             let starts = editor.line_starts();
@@ -2589,10 +2872,29 @@ impl Element for EditorElement {
                 };
                 let lh = line_heights.get(row).copied().unwrap_or(base_lh);
                 let top = line_tops[row];
-                let inset = code_inset(row);
                 let line_start = starts[row];
                 let a = s.max(line_start) - line_start;
                 let b = e.min(editor.line_end(row)) - line_start;
+                // Table row: highlight between the cell positions of the selection
+                // ends (not raw-source geometry).
+                if let Some(t) = tables.get(row).and_then(Option::as_ref) {
+                    if let (Some((xa, ..)), Some((xb, ..))) = (
+                        table_caret_pos(t, a, bounds.left(), &font, font_size, window),
+                        table_caret_pos(t, b, bounds.left(), &font, font_size, window),
+                    ) {
+                        let (lo, hi) = (xa.min(xb), xa.max(xb));
+                        let cy = bounds.top() + top + (lh - base_lh) / 2.;
+                        sels.push(fill(
+                            Bounds::from_corners(
+                                point(lo, cy),
+                                point(hi.max(lo + px(2.)), cy + base_lh),
+                            ),
+                            color,
+                        ));
+                    }
+                    continue;
+                }
+                let inset = code_inset(row);
                 let pa = line
                     .position_for_index(disp_col(row, a), lh)
                     .unwrap_or_default();
@@ -2899,6 +3201,7 @@ impl Element for EditorElement {
             .enumerate()
             .map(|(i, w)| w.is_some() || prepaint.tables.get(i).is_some_and(Option::is_some))
             .collect();
+        let table_rows = std::mem::take(&mut prepaint.tables);
         let line_insets: Vec<Pixels> = prepaint
             .backgrounds
             .iter()
@@ -2921,6 +3224,7 @@ impl Element for EditorElement {
             editor.offset_maps = offset_maps;
             editor.chip_rows = chip_rows;
             editor.line_insets = line_insets;
+            editor.table_rows = table_rows;
             editor.last_bounds = Some(bounds);
             editor.line_height = base_lh;
         });

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1315,15 +1315,14 @@ struct BlockImg {
 }
 
 /// A table row rendered as a grid (W4c): its cells, per-column alignment, the
-/// shared (equal) column width, header/separator/last-row flags, and the border
-/// color. Built only when the caret is outside the table — the caret's table
-/// shows source instead ("raw on caret").
+/// content-fit per-column widths (shared across the table), header/separator/
+/// last-row flags, and the border color. Built only when the caret is outside
+/// the table — the caret's table shows source instead ("raw on caret").
 #[derive(Clone)]
 struct TableRow {
     cells: Vec<SharedString>,
     aligns: Vec<markdown_syntax::Align>,
-    cols: usize,
-    col_width: Pixels,
+    col_widths: Vec<Pixels>,
     is_header: bool,
     is_separator: bool,
     is_last: bool,
@@ -1338,7 +1337,7 @@ type ShapedLines = (
     Vec<WrappedLine>,
     Vec<Pixels>,
     Vec<Option<BlockImg>>,
-    Vec<Option<Hsla>>,
+    Vec<Option<(Hsla, Pixels)>>,
     Vec<Option<TableRow>>,
 );
 
@@ -1393,25 +1392,55 @@ fn shape_document(
     let mut widgets = Vec::new();
     let mut backgrounds = Vec::new();
     let mut tables = Vec::new();
-    // Table regions (W4c) for the whole doc; equal-width columns, raw-on-caret.
+    let lines: Vec<&str> = content.split('\n').collect();
+    // Table regions (W4c); content-fit column widths shared by each region's rows.
     let regions = md
         .map(|_| markdown_syntax::table_regions(content))
         .unwrap_or_default();
+    let mut region_cols: Vec<Vec<Pixels>> = Vec::with_capacity(regions.len());
+    for r in &regions {
+        region_cols.push(table_column_widths(
+            &lines,
+            r,
+            window,
+            base_font,
+            base_font_size,
+            base_color,
+            wrap_width,
+        ));
+    }
     let table_row_h = base_font_size * LINE_HEIGHT_RATIO + px(12.);
     let table_sep_h = px(8.);
+    // Fenced-code-block tracking: collect a block's background indices + its
+    // widest line, then back-patch every line's bg width so the block is a
+    // content-fit box (W4c refinement) rather than a full-width band.
+    let mut code_block: Vec<usize> = Vec::new();
+    let mut code_w = px(0.);
     let mut line_start = 0;
     let mut in_fence = false;
-    for (idx, line) in content.split('\n').enumerate() {
+    for (idx, &line) in lines.iter().enumerate() {
         let line_end = line_start + line.len();
 
         // Fenced code block (W4b): a ``` line toggles the fence; the delimiter
-        // lines + the lines between render as monospace code with a full-width
+        // lines + the lines between render as monospace code over a content-fit
         // background (delimiters dimmed). Code is literal — no inline scanning,
         // no heading size, no squiggles. Styling-mode only.
         let is_fence = md.is_some() && line.trim_start().starts_with("```");
         let is_code = md.is_some() && (in_fence || is_fence);
         if is_fence {
             in_fence = !in_fence;
+        }
+
+        // Leaving a code block: back-patch its lines to the block's box width.
+        if !is_code && !code_block.is_empty() {
+            let box_w = (code_w + px(12.)).min(wrap_width.unwrap_or(code_w + px(12.)));
+            for &bi in &code_block {
+                if let Some((_, w)) = &mut backgrounds[bi] {
+                    *w = box_w;
+                }
+            }
+            code_block.clear();
+            code_w = px(0.);
         }
 
         let fs = if is_code {
@@ -1437,18 +1466,17 @@ fn shape_document(
         // grid row — unless the caret is in that table (then it shows source).
         let table = regions
             .iter()
-            .find(|r| r.lines.contains(&idx))
-            .filter(|r| !is_code && !caret_row.is_some_and(|cr| r.lines.contains(&cr)))
-            .map(|r| {
-                let cols = r.aligns.len().max(1);
+            .position(|r| r.lines.contains(&idx))
+            .filter(|&ri| !is_code && !caret_row.is_some_and(|cr| regions[ri].lines.contains(&cr)))
+            .map(|ri| {
+                let r = &regions[ri];
                 TableRow {
                     cells: markdown_syntax::table_cells(line)
                         .into_iter()
                         .map(|c| SharedString::from(c.to_string()))
                         .collect(),
                     aligns: r.aligns.clone(),
-                    cols,
-                    col_width: wrap_width.map_or(px(160.), |w| w) / cols as f32,
+                    col_widths: region_cols[ri].clone(),
                     is_header: idx == r.lines.start,
                     is_separator: idx == r.lines.start + 1,
                     is_last: idx + 1 == r.lines.end,
@@ -1471,7 +1499,7 @@ fn shape_document(
             } else {
                 vec![run]
             };
-            (runs, Some(st.code_bg))
+            (runs, Some((st.code_bg, px(0.))))
         } else {
             // Diagnostics overlapping this line, shifted to line-relative ranges.
             let line_diags: Vec<Diagnostic> = diagnostics
@@ -1503,20 +1531,103 @@ fn shape_document(
                 Some(_) => table_row_h,
                 None => widget.as_ref().map_or(fs * LINE_HEIGHT_RATIO, |w| w.height),
             };
+            let line_w = wl.width();
             wrapped.push(wl);
             heights.push(h);
             widgets.push(widget);
             backgrounds.push(bg);
             tables.push(table);
+            // Accumulate this code line into the current block for box sizing.
+            if is_code {
+                code_block.push(backgrounds.len() - 1);
+                code_w = code_w.max(line_w);
+            }
         }
         line_start = line_end + 1; // skip the '\n'
+    }
+    // Back-patch a code block that runs to the end of the document.
+    if !code_block.is_empty() {
+        let box_w = (code_w + px(12.)).min(wrap_width.unwrap_or(code_w + px(12.)));
+        for &bi in &code_block {
+            if let Some((_, w)) = &mut backgrounds[bi] {
+                *w = box_w;
+            }
+        }
     }
     (wrapped, heights, widgets, backgrounds, tables)
 }
 
+/// Content-fit column widths for a table region (W4c): each column sized to its
+/// widest cell (header measured bold) + padding, with a minimum, and the whole
+/// table scaled down proportionally to fit `wrap_width` if it would overflow.
+#[allow(clippy::too_many_arguments)]
+fn table_column_widths(
+    lines: &[&str],
+    region: &markdown_syntax::TableRegion,
+    window: &mut Window,
+    base_font: &Font,
+    font_size: Pixels,
+    color: Hsla,
+    wrap_width: Option<Pixels>,
+) -> Vec<Pixels> {
+    let cols = region.aligns.len().max(1);
+    let pad = px(8.);
+    let mut widths = vec![px(0.); cols];
+    for li in region.lines.clone() {
+        if li == region.lines.start + 1 {
+            continue; // skip the |---| separator
+        }
+        let header = li == region.lines.start;
+        for (c, cell) in markdown_syntax::table_cells(lines[li])
+            .iter()
+            .enumerate()
+            .take(cols)
+        {
+            if cell.is_empty() {
+                continue;
+            }
+            let mut font = base_font.clone();
+            if header {
+                font.weight = gpui::FontWeight::BOLD;
+            }
+            let run = TextRun {
+                len: cell.len(),
+                font,
+                color,
+                background_color: None,
+                underline: None,
+                strikethrough: None,
+            };
+            let w = window
+                .text_system()
+                .shape_line(
+                    SharedString::from(cell.to_string()),
+                    font_size,
+                    &[run],
+                    None,
+                )
+                .width();
+            widths[c] = widths[c].max(w + pad * 2.);
+        }
+    }
+    for w in &mut widths {
+        *w = (*w).max(px(48.));
+    }
+    if let Some(avail) = wrap_width {
+        let total = widths.iter().fold(px(0.), |a, &w| a + w);
+        if total > avail && total > px(0.) {
+            let scale = f32::from(avail) / f32::from(total);
+            for w in &mut widths {
+                *w *= scale;
+            }
+        }
+    }
+    widths
+}
+
 /// Paint a table row as a grid (W4c): a top border (+ bottom on the last row),
 /// a left border per column + a right outer border, and each cell's text aligned
-/// within its column. A separator row renders as a single horizontal divider.
+/// within its (content-fit) column. A separator row is a single horizontal rule.
 #[allow(clippy::too_many_arguments)]
 fn paint_table_row(
     t: &TableRow,
@@ -1530,7 +1641,7 @@ fn paint_table_row(
     cx: &mut App,
 ) {
     let thick = px(1.);
-    let table_w = t.col_width * t.cols as f32;
+    let table_w = t.col_widths.iter().fold(px(0.), |a, &w| a + w);
     if t.is_separator {
         let y = origin.y + (row_h - thick) / 2.;
         window.paint_quad(fill(
@@ -1555,10 +1666,10 @@ fn paint_table_row(
     if t.is_header {
         cell_font.weight = gpui::FontWeight::BOLD;
     }
-    for c in 0..t.cols {
-        let cx0 = origin.x + t.col_width * c as f32;
+    let mut x = origin.x;
+    for (c, &cw) in t.col_widths.iter().enumerate() {
         window.paint_quad(fill(
-            Bounds::new(point(cx0, origin.y), size(thick, row_h)),
+            Bounds::new(point(x, origin.y), size(thick, row_h)),
             t.border,
         ));
         if let Some(cell) = t.cells.get(c).filter(|s| !s.is_empty()) {
@@ -1579,17 +1690,18 @@ fn paint_table_row(
                 _ => gpui::TextAlign::Left,
             };
             let _ = shaped.paint(
-                point(cx0 + pad, origin.y + (row_h - line_h) / 2.),
+                point(x + pad, origin.y + (row_h - line_h) / 2.),
                 line_h,
                 align,
-                Some(t.col_width - pad * 2.),
+                Some(cw - pad * 2.),
                 window,
                 cx,
             );
         }
+        x += cw;
     }
     window.paint_quad(fill(
-        Bounds::new(point(origin.x + table_w, origin.y), size(thick, row_h)),
+        Bounds::new(point(x, origin.y), size(thick, row_h)),
         t.border,
     ));
 }
@@ -1609,8 +1721,8 @@ struct PrepaintState {
     line_heights: Vec<Pixels>,
     /// `Some` for a line painted as an inline image instead of its source text.
     widgets: Vec<Option<BlockImg>>,
-    /// Full-width background behind a line (e.g. a fenced code block).
-    backgrounds: Vec<Option<Hsla>>,
+    /// Background behind a line + its width (a content-fit fenced code block).
+    backgrounds: Vec<Option<(Hsla, Pixels)>>,
     /// `Some` for a line painted as a table-grid row instead of source.
     tables: Vec<Option<TableRow>>,
     cursor: Option<PaintQuad>,
@@ -1892,9 +2004,9 @@ impl Element for EditorElement {
             .enumerate()
         {
             let origin = point(bounds.origin.x, bounds.origin.y + *top);
-            // Full-width background behind the line (a fenced code block — W4b).
-            if let Some(c) = prepaint.backgrounds.get(i).copied().flatten() {
-                window.paint_quad(fill(Bounds::new(origin, size(bounds.size.width, *lh)), c));
+            // Content-fit background behind the line (a fenced code block — W4b/c).
+            if let Some((c, w)) = prepaint.backgrounds.get(i).copied().flatten() {
+                window.paint_quad(fill(Bounds::new(origin, size(w, *lh)), c));
             }
             if let Some(t) = prepaint.tables.get(i).and_then(Option::as_ref) {
                 // Table grid row (W4c): cells + borders instead of source.

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -21,13 +21,13 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use gpui::{
-    App, AvailableSpace, Bounds, ClipboardItem, Context, Corners, CursorStyle, Element, ElementId,
-    ElementInputHandler, Entity, EntityInputHandler, EventEmitter, FocusHandle, Focusable, Font,
-    GlobalElementId, Hsla, InspectorElementId, InteractiveElement, IntoElement, KeyBinding,
-    LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, ParentElement,
-    Pixels, Point, Render, RenderImage, ScrollHandle, SharedString, StatefulInteractiveElement,
-    Style, Styled, TextRun, UTF16Selection, Window, WrappedLine, actions, div, fill, hsla, point,
-    px, relative, rgb, rgba, size,
+    App, AvailableSpace, BorderStyle, Bounds, ClipboardItem, Context, Corners, CursorStyle, Edges,
+    Element, ElementId, ElementInputHandler, Entity, EntityInputHandler, EventEmitter, FocusHandle,
+    Focusable, Font, GlobalElementId, Hsla, InspectorElementId, InteractiveElement, IntoElement,
+    KeyBinding, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad,
+    ParentElement, PathBuilder, Pixels, Point, Render, RenderImage, ScrollHandle, SharedString,
+    StatefulInteractiveElement, Style, Styled, TextRun, UTF16Selection, Window, WrappedLine,
+    actions, div, fill, hsla, point, px, relative, rgb, rgba, size,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -1410,6 +1410,13 @@ enum LineMark {
         num: u32,
         color: Hsla,
     },
+    /// GFM task item: a painted ☐/☑ box at `indent`, muted; the source marker +
+    /// checkbox are hidden and the body inset past the bullet column.
+    Check {
+        indent: Pixels,
+        checked: bool,
+        color: Hsla,
+    },
 }
 
 impl LineMark {
@@ -1417,7 +1424,9 @@ impl LineMark {
     fn inset(self) -> Pixels {
         match self {
             LineMark::Quote(_) => px(QUOTE_INSET),
-            LineMark::List { indent, .. } => indent + px(BULLET_COL),
+            LineMark::List { indent, .. } | LineMark::Check { indent, .. } => {
+                indent + px(BULLET_COL)
+            }
         }
     }
 }
@@ -1673,15 +1682,24 @@ fn shape_document(
         let gutter: Option<(usize, LineMark)> = md
             .filter(|_| !is_code && widget.is_none() && table.is_none())
             .and_then(|st| {
+                let indent_px = |indent: usize| px(indent as f32 * f32::from(fs) * 0.5);
                 if let Some(plen) = markdown_syntax::blockquote_prefix(line) {
                     Some((plen, LineMark::Quote(st.quote)))
+                } else if let Some((plen, indent, checked)) = markdown_syntax::task_prefix(line) {
+                    Some((
+                        plen,
+                        LineMark::Check {
+                            indent: indent_px(indent),
+                            checked,
+                            color: st.quote,
+                        },
+                    ))
                 } else {
                     markdown_syntax::list_prefix(line).map(|(plen, indent, ordered, num)| {
-                        let indent_px = px(indent as f32 * f32::from(fs) * 0.5);
                         (
                             plen,
                             LineMark::List {
-                                indent: indent_px,
+                                indent: indent_px(indent),
                                 ordered,
                                 num,
                                 color: st.quote,
@@ -2334,7 +2352,7 @@ impl Element for EditorElement {
             if let Some(LineMark::Quote(c)) = prepaint.marks.get(i).copied().flatten() {
                 window.paint_quad(fill(Bounds::new(origin, size(px(2.), *lh)), c));
             }
-            // List item: a muted bullet (`•`) or number (`N.`) at the item's
+            // List item: a muted bullet (`•`) or number (`N.`) glyph at the item's
             // indent; the body is inset past it (the source marker is hidden).
             if let Some(LineMark::List {
                 indent,
@@ -2367,6 +2385,36 @@ impl Element for EditorElement {
                     window,
                     cx,
                 );
+            }
+            // Task item: a crisp cap-height box (custom-drawn, not a font glyph so
+            // it reads at the text's size) with a checkmark when done.
+            if let Some(LineMark::Check {
+                indent,
+                checked,
+                color,
+            }) = prepaint.marks.get(i).copied().flatten()
+            {
+                let sz = font_size * 0.78; // ~cap height
+                let bx = origin.x + indent;
+                let by = origin.y + (*lh - sz) / 2.; // vertically centered on the line
+                window.paint_quad(PaintQuad {
+                    bounds: Bounds::new(point(bx, by), size(sz, sz)),
+                    corner_radii: Corners::all(px(3.)),
+                    background: hsla(0., 0., 0., 0.).into(),
+                    border_widths: Edges::all(px(1.5)),
+                    border_color: color,
+                    border_style: BorderStyle::Solid,
+                });
+                if checked {
+                    let s = f32::from(sz);
+                    let mut pb = PathBuilder::stroke(px(1.6));
+                    pb.move_to(point(bx + px(s * 0.24), by + px(s * 0.52)));
+                    pb.line_to(point(bx + px(s * 0.42), by + px(s * 0.70)));
+                    pb.line_to(point(bx + px(s * 0.76), by + px(s * 0.28)));
+                    if let Ok(path) = pb.build() {
+                        window.paint_path(path, color);
+                    }
+                }
             }
             if let Some(t) = prepaint.tables.get(i).and_then(Option::as_ref) {
                 // Table grid row (W4c): cells + borders instead of source.

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1314,14 +1314,32 @@ struct BlockImg {
     height: Pixels,
 }
 
-/// Per-logical-line shaping output — four parallel vecs of equal length: the
-/// shaped source line, its row height, an optional inline-image widget, and an
-/// optional full-width line background (a fenced code block).
+/// A table row rendered as a grid (W4c): its cells, per-column alignment, the
+/// shared (equal) column width, header/separator/last-row flags, and the border
+/// color. Built only when the caret is outside the table — the caret's table
+/// shows source instead ("raw on caret").
+#[derive(Clone)]
+struct TableRow {
+    cells: Vec<SharedString>,
+    aligns: Vec<markdown_syntax::Align>,
+    cols: usize,
+    col_width: Pixels,
+    is_header: bool,
+    is_separator: bool,
+    is_last: bool,
+    border: Hsla,
+}
+
+/// Per-logical-line shaping output — five parallel vecs of equal length: the
+/// shaped source line, its row height, an optional inline-image widget, an
+/// optional full-width line background (a fenced code block), and an optional
+/// table-row grid.
 type ShapedLines = (
     Vec<WrappedLine>,
     Vec<Pixels>,
     Vec<Option<BlockImg>>,
     Vec<Option<Hsla>>,
+    Vec<Option<TableRow>>,
 );
 
 /// Fit-to-width display size for an inline image from its natural (device) size:
@@ -1374,6 +1392,13 @@ fn shape_document(
     let mut heights = Vec::new();
     let mut widgets = Vec::new();
     let mut backgrounds = Vec::new();
+    let mut tables = Vec::new();
+    // Table regions (W4c) for the whole doc; equal-width columns, raw-on-caret.
+    let regions = md
+        .map(|_| markdown_syntax::table_regions(content))
+        .unwrap_or_default();
+    let table_row_h = base_font_size * LINE_HEIGHT_RATIO + px(12.);
+    let table_sep_h = px(8.);
     let mut line_start = 0;
     let mut in_fence = false;
     for (idx, line) in content.split('\n').enumerate() {
@@ -1407,6 +1432,29 @@ fn shape_document(
         } else {
             None
         };
+
+        // Table row (W4c): a line inside a detected table region renders as a
+        // grid row — unless the caret is in that table (then it shows source).
+        let table = regions
+            .iter()
+            .find(|r| r.lines.contains(&idx))
+            .filter(|r| !is_code && !caret_row.is_some_and(|cr| r.lines.contains(&cr)))
+            .map(|r| {
+                let cols = r.aligns.len().max(1);
+                TableRow {
+                    cells: markdown_syntax::table_cells(line)
+                        .into_iter()
+                        .map(|c| SharedString::from(c.to_string()))
+                        .collect(),
+                    aligns: r.aligns.clone(),
+                    cols,
+                    col_width: wrap_width.map_or(px(160.), |w| w) / cols as f32,
+                    is_header: idx == r.lines.start,
+                    is_separator: idx == r.lines.start + 1,
+                    is_last: idx + 1 == r.lines.end,
+                    border: md.map_or(base_color, |m| m.marker),
+                }
+            });
 
         let (runs, bg) = if let Some(st) = md.filter(|_| is_code) {
             // One monospace run for the whole line; ``` delimiters dimmed.
@@ -1450,15 +1498,100 @@ fn shape_document(
             wrap_width,
         );
         if let Some(wl) = shaped.into_iter().next() {
-            let h = widget.as_ref().map_or(fs * LINE_HEIGHT_RATIO, |w| w.height);
+            let h = match &table {
+                Some(t) if t.is_separator => table_sep_h,
+                Some(_) => table_row_h,
+                None => widget.as_ref().map_or(fs * LINE_HEIGHT_RATIO, |w| w.height),
+            };
             wrapped.push(wl);
             heights.push(h);
             widgets.push(widget);
             backgrounds.push(bg);
+            tables.push(table);
         }
         line_start = line_end + 1; // skip the '\n'
     }
-    (wrapped, heights, widgets, backgrounds)
+    (wrapped, heights, widgets, backgrounds, tables)
+}
+
+/// Paint a table row as a grid (W4c): a top border (+ bottom on the last row),
+/// a left border per column + a right outer border, and each cell's text aligned
+/// within its column. A separator row renders as a single horizontal divider.
+#[allow(clippy::too_many_arguments)]
+fn paint_table_row(
+    t: &TableRow,
+    origin: Point<Pixels>,
+    row_h: Pixels,
+    font: &Font,
+    font_size: Pixels,
+    line_h: Pixels,
+    color: Hsla,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let thick = px(1.);
+    let table_w = t.col_width * t.cols as f32;
+    if t.is_separator {
+        let y = origin.y + (row_h - thick) / 2.;
+        window.paint_quad(fill(
+            Bounds::new(point(origin.x, y), size(table_w, thick)),
+            t.border,
+        ));
+        return;
+    }
+    // Horizontal borders: top on every row; bottom only on the last.
+    window.paint_quad(fill(Bounds::new(origin, size(table_w, thick)), t.border));
+    if t.is_last {
+        window.paint_quad(fill(
+            Bounds::new(
+                point(origin.x, origin.y + row_h - thick),
+                size(table_w, thick),
+            ),
+            t.border,
+        ));
+    }
+    let pad = px(8.);
+    let mut cell_font = font.clone();
+    if t.is_header {
+        cell_font.weight = gpui::FontWeight::BOLD;
+    }
+    for c in 0..t.cols {
+        let cx0 = origin.x + t.col_width * c as f32;
+        window.paint_quad(fill(
+            Bounds::new(point(cx0, origin.y), size(thick, row_h)),
+            t.border,
+        ));
+        if let Some(cell) = t.cells.get(c).filter(|s| !s.is_empty()) {
+            let run = TextRun {
+                len: cell.len(),
+                font: cell_font.clone(),
+                color,
+                background_color: None,
+                underline: None,
+                strikethrough: None,
+            };
+            let shaped = window
+                .text_system()
+                .shape_line(cell.clone(), font_size, &[run], None);
+            let align = match t.aligns.get(c) {
+                Some(markdown_syntax::Align::Center) => gpui::TextAlign::Center,
+                Some(markdown_syntax::Align::Right) => gpui::TextAlign::Right,
+                _ => gpui::TextAlign::Left,
+            };
+            let _ = shaped.paint(
+                point(cx0 + pad, origin.y + (row_h - line_h) / 2.),
+                line_h,
+                align,
+                Some(t.col_width - pad * 2.),
+                window,
+                cx,
+            );
+        }
+    }
+    window.paint_quad(fill(
+        Bounds::new(point(origin.x + table_w, origin.y), size(thick, row_h)),
+        t.border,
+    ));
 }
 
 /// The custom element that lays out + paints the editor's wrapped lines, cursor,
@@ -1478,6 +1611,8 @@ struct PrepaintState {
     widgets: Vec<Option<BlockImg>>,
     /// Full-width background behind a line (e.g. a fenced code block).
     backgrounds: Vec<Option<Hsla>>,
+    /// `Some` for a line painted as a table-grid row instead of source.
+    tables: Vec<Option<TableRow>>,
     cursor: Option<PaintQuad>,
     selections: Vec<PaintQuad>,
 }
@@ -1541,7 +1676,7 @@ impl Element for EditorElement {
                 // Sum of per-line (variable) heights × each line's wrap rows.
                 let caret_row = editor.row_col(editor.cursor_offset()).0;
                 let sf = window.scale_factor();
-                let (wrapped, heights, _, _) = shape_document(
+                let (wrapped, heights, _, _, _) = shape_document(
                     window,
                     &editor.content,
                     &text_style.font(),
@@ -1588,7 +1723,7 @@ impl Element for EditorElement {
         // their own taller rows (W2) and image lines render inline (W4).
         let caret_row = editor.row_col(editor.cursor_offset()).0;
         let sf = window.scale_factor();
-        let (wrapped, line_heights, widgets, backgrounds) = if editor.content.is_empty() {
+        let (wrapped, line_heights, widgets, backgrounds, tables) = if editor.content.is_empty() {
             let w = shape_all(
                 window,
                 &editor.placeholder,
@@ -1598,7 +1733,13 @@ impl Element for EditorElement {
                 wrap_width,
             );
             let n = w.len();
-            (w, vec![base_lh; n], vec![None; n], vec![None; n])
+            (
+                w,
+                vec![base_lh; n],
+                vec![None; n],
+                vec![None; n],
+                vec![None; n],
+            )
         } else {
             shape_document(
                 window,
@@ -1711,6 +1852,7 @@ impl Element for EditorElement {
             line_heights,
             widgets,
             backgrounds,
+            tables,
             cursor,
             selections,
         }
@@ -1737,8 +1879,11 @@ impl Element for EditorElement {
             window.paint_quad(sel);
         }
 
-        let base_lh =
-            window.text_style().font_size.to_pixels(window.rem_size()) * LINE_HEIGHT_RATIO;
+        let style = window.text_style();
+        let font = style.font();
+        let text_color = style.color;
+        let font_size = style.font_size.to_pixels(window.rem_size());
+        let base_lh = font_size * LINE_HEIGHT_RATIO;
         for (i, ((line, top), lh)) in prepaint
             .wrapped
             .iter()
@@ -1751,7 +1896,12 @@ impl Element for EditorElement {
             if let Some(c) = prepaint.backgrounds.get(i).copied().flatten() {
                 window.paint_quad(fill(Bounds::new(origin, size(bounds.size.width, *lh)), c));
             }
-            if let Some(w) = prepaint.widgets.get(i).and_then(Option::as_ref) {
+            if let Some(t) = prepaint.tables.get(i).and_then(Option::as_ref) {
+                // Table grid row (W4c): cells + borders instead of source.
+                paint_table_row(
+                    t, origin, *lh, &font, font_size, base_lh, text_color, window, cx,
+                );
+            } else if let Some(w) = prepaint.widgets.get(i).and_then(Option::as_ref) {
                 // Inline image (W4a): paint the decoded image instead of source.
                 let img_bounds = Bounds::new(origin, size(w.width, w.height));
                 let _ = window.paint_image(img_bounds, Corners::default(), w.img.clone(), 0, false);
@@ -1769,7 +1919,12 @@ impl Element for EditorElement {
         let wrapped = std::mem::take(&mut prepaint.wrapped);
         let line_tops = std::mem::take(&mut prepaint.line_tops);
         let line_heights = std::mem::take(&mut prepaint.line_heights);
-        let widget_rows: Vec<bool> = prepaint.widgets.iter().map(Option::is_some).collect();
+        let widget_rows: Vec<bool> = prepaint
+            .widgets
+            .iter()
+            .enumerate()
+            .map(|(i, w)| w.is_some() || prepaint.tables.get(i).is_some_and(Option::is_some))
+            .collect();
         self.editor.update(cx, |editor, _| {
             editor.wrapped = wrapped;
             editor.line_tops = line_tops;

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -194,6 +194,18 @@ pub enum EditorEvent {
     /// A file chip (e.g. a PDF embed) was left-clicked — the host opens its
     /// `src`. The chip itself stays in the document; this is a navigation hint.
     OpenLink(SharedString),
+    /// The caret / selection moved without a text change — so a host can update a
+    /// caret-anchored affordance (e.g. the table-alignment toolbar).
+    SelectionChanged,
+}
+
+/// A table column's text alignment, for the host-driven alignment toolbar
+/// ([`EditorState::caret_table_align`] / [`EditorState::set_caret_table_align`]).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CellAlign {
+    Left,
+    Center,
+    Right,
 }
 
 /// Provides replacement suggestions for a flagged word (best first); set by the
@@ -543,6 +555,7 @@ impl EditorState {
         // Set the caret directly (not via `move_to`) to keep the goal column.
         self.selected_range = off..off;
         self.last_edit = EditKind::Other;
+        cx.emit(EditorEvent::SelectionChanged);
         cx.notify();
     }
 
@@ -550,6 +563,7 @@ impl EditorState {
         let off = self.move_vertical(1);
         self.selected_range = off..off;
         self.last_edit = EditKind::Other;
+        cx.emit(EditorEvent::SelectionChanged);
         cx.notify();
     }
 
@@ -948,6 +962,7 @@ impl EditorState {
         // vertical-movement goal column.
         self.last_edit = EditKind::Other;
         self.goal_x = None;
+        cx.emit(EditorEvent::SelectionChanged);
         cx.notify();
     }
 
@@ -969,6 +984,7 @@ impl EditorState {
             self.selection_reversed = !self.selection_reversed;
             self.selected_range = self.selected_range.end..self.selected_range.start;
         }
+        cx.emit(EditorEvent::SelectionChanged);
         cx.notify();
     }
 
@@ -1251,6 +1267,84 @@ impl EditorState {
             }
         }
         Some(self.cursor_offset()) // at the boundary — no-op move (don't indent)
+    }
+
+    /// The alignment of the table column the caret sits in — but only while the
+    /// caret is in the table's HEADER row (the toolbar lives there; alignment is a
+    /// per-column property, set once from the header). `None` otherwise. Read from
+    /// the current content, since the painted `table_rows` lag a frame right after
+    /// a separator rewrite (which would highlight the just-changed-from button).
+    pub fn caret_table_align(&self) -> Option<CellAlign> {
+        let (row, col) = self.row_col(self.cursor_offset());
+        // Fast-reject via the paint: only a header row gets the toolbar.
+        let t = self.table_rows.get(row).and_then(Option::as_ref)?;
+        if !t.is_header {
+            return None;
+        }
+        let cell = table_cell_at(t, col);
+        let regions = markdown_syntax::table_regions(&self.content);
+        let region = regions.iter().find(|r| r.lines.contains(&row))?;
+        Some(match region.aligns.get(cell) {
+            Some(markdown_syntax::Align::Center) => CellAlign::Center,
+            Some(markdown_syntax::Align::Right) => CellAlign::Right,
+            _ => CellAlign::Left,
+        })
+    }
+
+    /// Set the alignment of the caret's table column by rewriting that table's
+    /// `|---|` separator row; the caret stays put. No-op outside a table cell.
+    pub fn set_caret_table_align(&mut self, align: CellAlign, cx: &mut Context<Self>) {
+        let (row, col) = self.row_col(self.cursor_offset());
+        let Some(t) = self.table_rows.get(row).and_then(Option::as_ref) else {
+            return;
+        };
+        if t.is_separator {
+            return;
+        }
+        let cell = table_cell_at(t, col);
+        // Read the table's columns from the current content (fresh), so repeated
+        // clicks build on the latest alignment, not a stale painted snapshot.
+        let regions = markdown_syntax::table_regions(&self.content);
+        let Some(region) = regions.iter().find(|r| r.lines.contains(&row)) else {
+            return;
+        };
+        let mut aligns = region.aligns.clone();
+        if cell >= aligns.len() {
+            return;
+        }
+        aligns[cell] = match align {
+            CellAlign::Left => markdown_syntax::Align::Left,
+            CellAlign::Center => markdown_syntax::Align::Center,
+            CellAlign::Right => markdown_syntax::Align::Right,
+        };
+        let sep_row = region.lines.start + 1;
+        let mut new_sep = String::from("|");
+        for a in &aligns {
+            new_sep.push_str(match a {
+                markdown_syntax::Align::Left => " :-- |",
+                markdown_syntax::Align::Center => " :-: |",
+                markdown_syntax::Align::Right => " --: |",
+            });
+        }
+        let starts = self.line_starts();
+        let sep_start = starts[sep_row];
+        let sep_end = starts
+            .get(sep_row + 1)
+            .map_or(self.content.len(), |&s| s - 1);
+        let old_caret = self.cursor_offset();
+        let range = sep_start..sep_end;
+        self.record_edit(&range, &new_sep);
+        self.content = self.content[..sep_start].to_owned() + &new_sep + &self.content[sep_end..];
+        let delta = new_sep.len() as isize - (sep_end - sep_start) as isize;
+        let caret = if old_caret >= sep_end {
+            (old_caret as isize + delta).max(0) as usize
+        } else {
+            old_caret
+        };
+        self.selected_range = caret..caret;
+        self.remap_diagnostics(&range, new_sep.len());
+        cx.emit(EditorEvent::Changed);
+        cx.notify();
     }
 
     fn index_for_mouse_position(&self, position: Point<Pixels>) -> usize {

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -65,6 +65,8 @@ actions!(
         WordRight,
         SelectWordLeft,
         SelectWordRight,
+        Indent,
+        Outdent,
         Dismiss,
     ]
 );
@@ -87,6 +89,8 @@ pub fn bind_keys(cx: &mut App) {
         KeyBinding::new("shift-up", SelectUp, ctx),
         KeyBinding::new("shift-down", SelectDown, ctx),
         KeyBinding::new("enter", Newline, ctx),
+        KeyBinding::new("tab", Indent, ctx),
+        KeyBinding::new("shift-tab", Outdent, ctx),
         KeyBinding::new("cmd-a", SelectAll, ctx),
         KeyBinding::new("ctrl-a", SelectAll, ctx),
         KeyBinding::new("cmd-c", Copy, ctx),
@@ -131,10 +135,6 @@ const CODE_PAD: f32 = 8.;
 /// Horizontal inset (px) of blockquote text from the editor's left edge, leaving
 /// room for the left border (2px) + a gap, matching the reading view's `pl(12)`.
 const QUOTE_INSET: f32 = 14.;
-
-/// Width (px) of a list item's bullet/number column — the body text is inset this
-/// far past the item's indent, leaving room for the painted `•` / `N.` + a gap.
-const BULLET_COL: f32 = 22.;
 
 /// Vertical padding (px) inside a file chip (e.g. a PDF embed), above + below its
 /// label, so the chip box reads as a button rather than a bare line of text.
@@ -261,6 +261,9 @@ pub struct EditorState {
     undo_stack: Vec<Snapshot>,
     redo_stack: Vec<Snapshot>,
     last_edit: EditKind,
+    /// Spaces inserted per Tab / one list-nesting level (`Indent`/`Outdent`); set
+    /// by the host via [`Self::set_tab_indent`] to match its list-indent setting.
+    tab_indent: usize,
     /// The target x for vertical (Up/Down) movement, so the caret keeps its
     /// column across short lines. `Some` only during a run of Up/Down.
     goal_x: Option<Pixels>,
@@ -311,6 +314,7 @@ impl EditorState {
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
             last_edit: EditKind::Other,
+            tab_indent: 4,
             goal_x: None,
             diagnostics: Vec::new(),
             markdown_style: None,
@@ -418,6 +422,12 @@ impl EditorState {
         provider: impl Fn(&str) -> Option<Arc<RenderImage>> + 'static,
     ) {
         self.block_mermaid = Some(Box::new(provider));
+    }
+
+    /// Spaces inserted per Tab / list-nesting level (`Indent`/`Outdent`). The host
+    /// keeps this in sync with its list-indent setting so nesting is configurable.
+    pub fn set_tab_indent(&mut self, spaces: usize) {
+        self.tab_indent = spaces.max(1);
     }
 
     /// The caret's byte offset into [`Self::text`] (the moving end of any
@@ -597,6 +607,64 @@ impl EditorState {
 
     fn newline(&mut self, _: &Newline, window: &mut Window, cx: &mut Context<Self>) {
         self.replace_text_in_range(None, "\n", window, cx);
+    }
+
+    /// Tab: on a list/quote item, indent the whole item one level (`tab_indent`
+    /// spaces at the line start, caret shifts with it); elsewhere insert that many
+    /// spaces at the caret (replacing any selection).
+    fn indent(&mut self, _: &Indent, window: &mut Window, cx: &mut Context<Self>) {
+        let cursor = self.cursor_offset();
+        let line_start = self.content[..cursor].rfind('\n').map_or(0, |i| i + 1);
+        let line_end = self.content[line_start..]
+            .find('\n')
+            .map_or(self.content.len(), |i| line_start + i);
+        let line = &self.content[line_start..line_end];
+        let is_item = markdown_syntax::list_prefix(line).is_some()
+            || markdown_syntax::blockquote_prefix(line).is_some();
+        let indent = " ".repeat(self.tab_indent);
+        if !is_item {
+            self.replace_text_in_range(None, &indent, window, cx);
+            return;
+        }
+        let range = line_start..line_start;
+        self.record_edit(&range, &indent);
+        self.content.insert_str(line_start, &indent);
+        let caret = cursor + indent.len();
+        self.selected_range = caret..caret;
+        self.selection_reversed = false;
+        self.goal_x = None;
+        self.remap_diagnostics(&range, indent.len());
+        cx.emit(EditorEvent::Changed);
+        cx.notify();
+    }
+
+    /// Shift+Tab: outdent the caret's line — remove up to `tab_indent` leading
+    /// spaces (or one leading tab) from the line start. No-op if there's none.
+    fn outdent(&mut self, _: &Outdent, _: &mut Window, cx: &mut Context<Self>) {
+        let cursor = self.cursor_offset();
+        let line_start = self.content[..cursor].rfind('\n').map_or(0, |i| i + 1);
+        let line = &self.content[line_start..];
+        let removed = if line.starts_with('\t') {
+            1
+        } else {
+            line.bytes()
+                .take(self.tab_indent)
+                .take_while(|b| *b == b' ')
+                .count()
+        };
+        if removed == 0 {
+            return;
+        }
+        let range = line_start..line_start + removed;
+        self.record_edit(&range, "");
+        self.content.replace_range(range.clone(), "");
+        let caret = cursor.saturating_sub(removed).max(line_start);
+        self.selected_range = caret..caret;
+        self.selection_reversed = false;
+        self.goal_x = None;
+        self.remap_diagnostics(&range, 0);
+        cx.emit(EditorEvent::Changed);
+        cx.notify();
     }
 
     fn paste(&mut self, _: &Paste, window: &mut Window, cx: &mut Context<Self>) {
@@ -1279,6 +1347,8 @@ impl Render for EditorState {
             .on_action(cx.listener(Self::select_word_right))
             .on_action(cx.listener(Self::select_all))
             .on_action(cx.listener(Self::newline))
+            .on_action(cx.listener(Self::indent))
+            .on_action(cx.listener(Self::outdent))
             .on_action(cx.listener(Self::paste))
             .on_action(cx.listener(Self::copy))
             .on_action(cx.listener(Self::cut))
@@ -1437,6 +1507,32 @@ fn shape_all(
         .unwrap_or_default()
 }
 
+/// The shaped width of `text` at `font_size` — used to inset a gutter line's body
+/// to exactly where its (hidden) source prefix ends, so the rendered + raw views
+/// line up (and tab/space nesting matches the actual whitespace width).
+fn measure_width(window: &mut Window, text: &str, font: &Font, font_size: Pixels) -> Pixels {
+    if text.is_empty() {
+        return px(0.);
+    }
+    let run = TextRun {
+        len: text.len(),
+        font: font.clone(),
+        color: Hsla::default(),
+        background_color: None,
+        underline: None,
+        strikethrough: None,
+    };
+    window
+        .text_system()
+        .shape_line(
+            SharedString::from(text.to_string()),
+            font_size,
+            &[run],
+            None,
+        )
+        .width()
+}
+
 /// Shape `text` with pre-built `runs`, so diagnostics can underline specific
 /// spans. The plain-run [`shape_all`] is used for the placeholder + measurement.
 fn shape_runs(
@@ -1524,18 +1620,22 @@ enum LineMark {
     /// Blockquote: a muted left border; the `>` markers are hidden and the body
     /// text is muted (`SyntaxStyle::quote`).
     Quote(Hsla),
-    /// List item: a painted bullet (`•`) or number (`N.`) at `indent`, muted; the
-    /// source marker is hidden and the body inset past the bullet column.
+    /// List item: a painted bullet (`•`) or number (`N.`) at `bullet_x` (where the
+    /// hidden source marker began), muted; the body sits at `text_inset` — the
+    /// measured width of the whole source prefix, so the rendered + raw views
+    /// line up exactly and tab/space nesting stays in sync.
     List {
-        indent: Pixels,
+        bullet_x: Pixels,
+        text_inset: Pixels,
         ordered: bool,
         num: u32,
         color: Hsla,
     },
-    /// GFM task item: a painted ☐/☑ box at `indent`, muted; the source marker +
-    /// checkbox are hidden and the body inset past the bullet column.
+    /// GFM task item: a painted ☐/☑ box at `bullet_x`, muted; the body sits at
+    /// `text_inset` (measured prefix width) like a list item.
     Check {
-        indent: Pixels,
+        bullet_x: Pixels,
+        text_inset: Pixels,
         checked: bool,
         color: Hsla,
     },
@@ -1546,9 +1646,7 @@ impl LineMark {
     fn inset(self) -> Pixels {
         match self {
             LineMark::Quote(_) => px(QUOTE_INSET),
-            LineMark::List { indent, .. } | LineMark::Check { indent, .. } => {
-                indent + px(BULLET_COL)
-            }
+            LineMark::List { text_inset, .. } | LineMark::Check { text_inset, .. } => text_inset,
         }
     }
 }
@@ -1870,35 +1968,45 @@ fn shape_document(
         // body inset) shows only while the caret is OFF the line; on the line it
         // reads as plain source with the prefix revealed (a line-level reveal — the
         // whole prefix shows wherever the caret sits, unlike inline #5).
-        let gutter: Option<(usize, LineMark)> = md
-            .filter(|_| !is_code && widget.is_none() && table.is_none())
-            .and_then(|st| {
-                let indent_px = |indent: usize| px(indent as f32 * f32::from(fs) * 0.5);
-                if let Some(plen) = markdown_syntax::blockquote_prefix(line) {
-                    Some((plen, LineMark::Quote(st.quote)))
-                } else if let Some((plen, indent, checked)) = markdown_syntax::task_prefix(line) {
-                    Some((
-                        plen,
-                        LineMark::Check {
-                            indent: indent_px(indent),
-                            checked,
-                            color: st.quote,
-                        },
-                    ))
-                } else {
-                    markdown_syntax::list_prefix(line).map(|(plen, indent, ordered, num)| {
-                        (
-                            plen,
-                            LineMark::List {
-                                indent: indent_px(indent),
-                                ordered,
-                                num,
-                                color: st.quote,
-                            },
-                        )
-                    })
-                }
-            });
+        // `bullet_x` = measured width of the leading whitespace (where the bullet
+        // paints); `text_inset` = measured width of the whole source prefix (where
+        // the body sits, matching the raw line so render + edit stay in sync).
+        let gutter: Option<(usize, LineMark)> = if let Some(st) =
+            md.filter(|_| !is_code && widget.is_none() && table.is_none())
+        {
+            if let Some(plen) = markdown_syntax::blockquote_prefix(line) {
+                Some((plen, LineMark::Quote(st.quote)))
+            } else if let Some((plen, indent, checked)) = markdown_syntax::task_prefix(line) {
+                let bullet_x = measure_width(window, &line[..indent], base_font, base_font_size);
+                let text_inset = measure_width(window, &line[..plen], base_font, base_font_size);
+                Some((
+                    plen,
+                    LineMark::Check {
+                        bullet_x,
+                        text_inset,
+                        checked,
+                        color: st.quote,
+                    },
+                ))
+            } else if let Some((plen, indent, ordered, num)) = markdown_syntax::list_prefix(line) {
+                let bullet_x = measure_width(window, &line[..indent], base_font, base_font_size);
+                let text_inset = measure_width(window, &line[..plen], base_font, base_font_size);
+                Some((
+                    plen,
+                    LineMark::List {
+                        bullet_x,
+                        text_inset,
+                        ordered,
+                        num,
+                        color: st.quote,
+                    },
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         let caret_here = caret_col.is_some();
         let mark = gutter
             .filter(|_| !caret_here && !full_source)
@@ -2308,7 +2416,14 @@ impl Element for EditorElement {
                 base_lh * rows as f32
             } else {
                 // Sum of per-line (variable) heights × each line's wrap rows.
-                let caret_row = editor.row_col(editor.cursor_offset()).0;
+                // Reveal-on-caret applies only while focused (matches prepaint).
+                let focused = editor.focus_handle.is_focused(window);
+                let caret_row = focused.then(|| editor.row_col(editor.cursor_offset()).0);
+                let selection = if focused {
+                    (editor.selected_range.start, editor.selected_range.end)
+                } else {
+                    (usize::MAX, usize::MAX)
+                };
                 let sf = window.scale_factor();
                 let (wrapped, heights, _, backgrounds, _, _, _) = shape_document(
                     window,
@@ -2319,12 +2434,12 @@ impl Element for EditorElement {
                     &editor.diagnostics,
                     editor.markdown_style.as_ref(),
                     wrap_width,
-                    Some(caret_row),
+                    caret_row,
                     editor.block_image.as_ref(),
                     editor.block_chip.as_ref(),
                     editor.block_mermaid.as_ref(),
                     sf,
-                    (editor.selected_range.start, editor.selected_range.end),
+                    selection,
                 );
                 wrapped
                     .iter()
@@ -2353,6 +2468,11 @@ impl Element for EditorElement {
         cx: &mut App,
     ) -> PrepaintState {
         let editor = self.editor.read(cx);
+        // Reveal-on-caret (markers, raw-on-caret widgets, per-construct reveal)
+        // applies only while the editor is focused. An unfocused editor — always
+        // shown in WYSIWYG mode but not being edited — renders fully, like a
+        // reading view. `caret_row = None` + a no-match selection do that.
+        let focused = editor.focus_handle.is_focused(window);
         let style = window.text_style();
         let font = style.font();
         let font_size = style.font_size.to_pixels(window.rem_size());
@@ -2362,7 +2482,12 @@ impl Element for EditorElement {
 
         // Placeholder (uniform) when empty; else shape per line so headings get
         // their own taller rows (W2) and image lines render inline (W4).
-        let caret_row = editor.row_col(editor.cursor_offset()).0;
+        let caret_row = focused.then(|| editor.row_col(editor.cursor_offset()).0);
+        let selection = if focused {
+            (editor.selected_range.start, editor.selected_range.end)
+        } else {
+            (usize::MAX, usize::MAX)
+        };
         let sf = window.scale_factor();
         let (wrapped, line_heights, widgets, backgrounds, tables, maps, marks) =
             if editor.content.is_empty() {
@@ -2394,12 +2519,12 @@ impl Element for EditorElement {
                     &editor.diagnostics,
                     editor.markdown_style.as_ref(),
                     wrap_width,
-                    Some(caret_row),
+                    caret_row,
                     editor.block_image.as_ref(),
                     editor.block_chip.as_ref(),
                     editor.block_mermaid.as_ref(),
                     sf,
-                    (editor.selected_range.start, editor.selected_range.end),
+                    selection,
                 )
             };
 
@@ -2565,6 +2690,10 @@ impl Element for EditorElement {
         let text_color = style.color;
         let font_size = style.font_size.to_pixels(window.rem_size());
         let base_lh = font_size * LINE_HEIGHT_RATIO;
+        // Logseq-style list nesting guides: `outline` holds the bullet x of each
+        // active ancestor level, so a faint vertical line can drop from each down
+        // through its descendants. Popped on dedent, reset off the list.
+        let mut outline: Vec<Pixels> = Vec::new();
         for (i, ((line, top), lh)) in prepaint
             .wrapped
             .iter()
@@ -2573,6 +2702,33 @@ impl Element for EditorElement {
             .enumerate()
         {
             let origin = point(bounds.origin.x, bounds.origin.y + *top);
+            // Nesting guides for a list/task row: a thin vertical line at each
+            // ancestor bullet's x, spanning this row (contiguous rows stack into a
+            // continuous guide).
+            match prepaint.marks.get(i).copied().flatten() {
+                Some(LineMark::List {
+                    bullet_x, color, ..
+                })
+                | Some(LineMark::Check {
+                    bullet_x, color, ..
+                }) => {
+                    while outline.last().is_some_and(|&x| x >= bullet_x) {
+                        outline.pop();
+                    }
+                    let guide = Hsla {
+                        a: color.a * 0.5,
+                        ..color
+                    };
+                    for &gx in &outline {
+                        window.paint_quad(fill(
+                            Bounds::new(point(origin.x + gx + px(3.), origin.y), size(px(1.), *lh)),
+                            guide,
+                        ));
+                    }
+                    outline.push(bullet_x);
+                }
+                _ => outline.clear(),
+            }
             // Fenced code block: one rounded, content-fit box (sized to the
             // widest line, like a table). The first line rounds + pads the top, the
             // last rounds + pads the bottom; the pad fills the layout gap reserved
@@ -2599,13 +2755,15 @@ impl Element for EditorElement {
             if let Some(LineMark::Quote(c)) = prepaint.marks.get(i).copied().flatten() {
                 window.paint_quad(fill(Bounds::new(origin, size(px(2.), *lh)), c));
             }
-            // List item: a muted bullet (`•`) or number (`N.`) glyph at the item's
-            // indent; the body is inset past it (the source marker is hidden).
+            // List item: a muted bullet (`•`) or number (`N.`) glyph where the
+            // hidden source marker began (`bullet_x`); the body is inset to the
+            // measured prefix width so it lines up with the raw line.
             if let Some(LineMark::List {
-                indent,
+                bullet_x,
                 ordered,
                 num,
                 color,
+                ..
             }) = prepaint.marks.get(i).copied().flatten()
             {
                 let glyph: SharedString = if ordered {
@@ -2625,7 +2783,7 @@ impl Element for EditorElement {
                     .text_system()
                     .shape_line(glyph, font_size, &[run], None);
                 let _ = shaped.paint(
-                    point(origin.x + indent, origin.y),
+                    point(origin.x + bullet_x, origin.y),
                     *lh,
                     gpui::TextAlign::Left,
                     None,
@@ -2636,13 +2794,14 @@ impl Element for EditorElement {
             // Task item: a crisp cap-height box (custom-drawn, not a font glyph so
             // it reads at the text's size) with a checkmark when done.
             if let Some(LineMark::Check {
-                indent,
+                bullet_x,
                 checked,
                 color,
+                ..
             }) = prepaint.marks.get(i).copied().flatten()
             {
                 let sz = font_size * 0.78; // ~cap height
-                let bx = origin.x + indent;
+                let bx = origin.x + bullet_x;
                 let by = origin.y + (*lh - sz) / 2.; // vertically centered on the line
                 window.paint_quad(PaintQuad {
                     bounds: Bounds::new(point(bx, by), size(sz, sz)),

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -187,6 +187,10 @@ pub struct EditorState {
     /// cursor/IME positioning.
     wrapped: Vec<WrappedLine>,
     line_tops: Vec<Pixels>,
+    /// Per-logical-line wrap-row height. Variable so a heading (bigger font) gets
+    /// a taller row (W2); `line_height` is the base/fallback for the empty doc
+    /// and any row without a recorded height.
+    line_heights: Vec<Pixels>,
     last_bounds: Option<Bounds<Pixels>>,
     line_height: Pixels,
     is_selecting: bool,
@@ -221,6 +225,7 @@ impl EditorState {
             marked_range: None,
             wrapped: Vec::new(),
             line_tops: Vec::new(),
+            line_heights: Vec::new(),
             last_bounds: None,
             line_height: px(20.),
             is_selecting: false,
@@ -317,18 +322,28 @@ impl EditorState {
         self.move_to(offset, cx);
     }
 
+    /// The wrap-row height of logical line `row` (a heading is taller). Falls
+    /// back to the base `line_height` for unrecorded rows / the empty document.
+    fn line_h(&self, row: usize) -> Pixels {
+        self.line_heights
+            .get(row)
+            .copied()
+            .unwrap_or(self.line_height)
+    }
+
     /// Window-space bounds of the caret at `offset`, from the last paint's
     /// layout — for anchoring a popup (e.g. a slash menu) at a document offset.
     /// `None` before the first paint or if `offset`'s row isn't laid out.
     pub fn bounds_for_offset(&self, offset: usize) -> Option<Bounds<Pixels>> {
         let bounds = self.last_bounds?;
         let (row, col) = self.row_col(offset);
+        let lh = self.line_h(row);
         let line = self.wrapped.get(row)?;
-        let p = line.position_for_index(col, self.line_height)?;
+        let p = line.position_for_index(col, lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
         Some(Bounds::from_corners(
             point(bounds.left() + p.x, top),
-            point(bounds.left() + p.x, top + self.line_height),
+            point(bounds.left() + p.x, top + lh),
         ))
     }
 
@@ -754,41 +769,52 @@ impl EditorState {
     /// (x) across the run. Falls back to logical-line movement before the first
     /// paint (when no wrapped layout is cached yet).
     fn move_vertical(&mut self, dir: i32) -> usize {
-        let lh = self.line_height;
-        if self.wrapped.is_empty() || lh <= px(0.) {
+        if self.wrapped.is_empty() {
             return self.vertical_offset(dir);
         }
         let (row, col) = self.row_col(self.cursor_offset());
+        let cur_lh = self.line_h(row);
+        if cur_lh <= px(0.) {
+            return self.vertical_offset(dir);
+        }
         let Some(cur) = self
             .wrapped
             .get(row)
-            .and_then(|l| l.position_for_index(col, lh))
+            .and_then(|l| l.position_for_index(col, cur_lh))
         else {
             return self.vertical_offset(dir);
         };
         let global_y = self.line_tops[row] + cur.y;
         let goal = self.goal_x.unwrap_or(cur.x);
         self.goal_x = Some(goal);
-        let target_y = global_y + lh * dir as f32;
+        // Step to the adjacent visual row. Down: to the bottom of the current
+        // row (= the top of the next one). Up: just above the current row's top
+        // — robust to the row above having a different height (e.g. a heading),
+        // since it doesn't depend on the current row's height.
+        let target_y = if dir >= 0 {
+            global_y + cur_lh
+        } else {
+            global_y - px(1.)
+        };
         if target_y < px(0.) {
             return 0;
         }
         let last = self.wrapped.len() - 1;
-        let total =
-            self.line_tops[last] + lh * (self.wrapped[last].wrap_boundaries().len() + 1) as f32;
+        let total = self.line_tops[last]
+            + self.line_h(last) * (self.wrapped[last].wrap_boundaries().len() + 1) as f32;
         if target_y >= total {
             return self.content.len();
         }
         let mut trow = last;
         for i in 0..self.wrapped.len() {
-            let h = lh * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
+            let h = self.line_h(i) * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
             if target_y < self.line_tops[i] + h {
                 trow = i;
                 break;
             }
         }
         let rel = point(goal, target_y - self.line_tops[trow]);
-        let col = match self.wrapped[trow].closest_index_for_position(rel, lh) {
+        let col = match self.wrapped[trow].closest_index_for_position(rel, self.line_h(trow)) {
             Ok(i) | Err(i) => i,
         };
         self.line_starts()[trow] + col
@@ -852,19 +878,18 @@ impl EditorState {
         let Some(bounds) = self.last_bounds.as_ref() else {
             return 0;
         };
-        let lh = self.line_height;
         let rel = point(position.x - bounds.left(), position.y - bounds.top());
-        // Which logical line, by the vertical band each occupies.
+        // Which logical line, by the vertical band each occupies (variable height).
         let mut row = self.wrapped.len() - 1;
         for i in 0..self.wrapped.len() {
-            let height = lh * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
+            let height = self.line_h(i) * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
             if rel.y < self.line_tops[i] + height {
                 row = i;
                 break;
             }
         }
         let line_rel = point(rel.x, rel.y - self.line_tops[row]);
-        let col = match self.wrapped[row].closest_index_for_position(line_rel, lh) {
+        let col = match self.wrapped[row].closest_index_for_position(line_rel, self.line_h(row)) {
             Ok(i) | Err(i) => i,
         };
         self.line_starts()[row] + col
@@ -1021,12 +1046,13 @@ impl EntityInputHandler for EditorState {
     ) -> Option<Bounds<Pixels>> {
         let range = self.range_from_utf16(&range_utf16);
         let (row, col) = self.row_col(range.start);
+        let lh = self.line_h(row);
         let line = self.wrapped.get(row)?;
-        let p = line.position_for_index(col, self.line_height)?;
+        let p = line.position_for_index(col, lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
         Some(Bounds::from_corners(
             point(bounds.left() + p.x, top),
-            point(bounds.left() + p.x, top + self.line_height),
+            point(bounds.left() + p.x, top + lh),
         ))
     }
 
@@ -1247,6 +1273,58 @@ fn shape_runs(
         .unwrap_or_default()
 }
 
+/// Shape `content` line-by-line so each logical line can use its own font size
+/// (headings are larger — W2). Returns one [`WrappedLine`] per logical line and
+/// each line's wrap-row height. `md` drives the per-line size and inline styling
+/// (`None` keeps every line at the base size); `diagnostics` are clipped and
+/// shifted to each line. A single line (no newline) always shapes to exactly one
+/// wrapped line, including an empty line, so the count matches the logical lines
+/// and blank rows stay positionable.
+#[allow(clippy::too_many_arguments)]
+fn shape_document(
+    window: &mut Window,
+    content: &str,
+    base_font: &Font,
+    base_color: Hsla,
+    base_font_size: Pixels,
+    diagnostics: &[Diagnostic],
+    md: Option<&SyntaxStyle>,
+    wrap_width: Option<Pixels>,
+) -> (Vec<WrappedLine>, Vec<Pixels>) {
+    let mut wrapped = Vec::new();
+    let mut heights = Vec::new();
+    let mut line_start = 0;
+    for line in content.split('\n') {
+        let line_end = line_start + line.len();
+        let fs = base_font_size * md.map_or(1.0, |_| markdown_syntax::line_scale(line));
+        // Diagnostics overlapping this line, shifted to line-relative ranges.
+        let line_diags: Vec<Diagnostic> = diagnostics
+            .iter()
+            .filter_map(|d| {
+                let s = d.range.start.max(line_start);
+                let e = d.range.end.min(line_end);
+                (s < e).then(|| Diagnostic {
+                    range: (s - line_start)..(e - line_start),
+                })
+            })
+            .collect();
+        let runs = markdown_syntax::styled_runs(line, base_font, base_color, &line_diags, md);
+        let shaped = shape_runs(
+            window,
+            &SharedString::from(line.to_string()),
+            fs,
+            &runs,
+            wrap_width,
+        );
+        if let Some(wl) = shaped.into_iter().next() {
+            wrapped.push(wl);
+            heights.push(fs * LINE_HEIGHT_RATIO);
+        }
+        line_start = line_end + 1; // skip the '\n'
+    }
+    (wrapped, heights)
+}
+
 /// The custom element that lays out + paints the editor's wrapped lines, cursor,
 /// and selection, and wires the input handler. Height is content-driven via a
 /// measured layout (it depends on the resolved width once soft-wrap is applied).
@@ -1258,6 +1336,8 @@ struct PrepaintState {
     wrapped: Vec<WrappedLine>,
     /// Top offset of each logical line relative to the editor's top.
     line_tops: Vec<Pixels>,
+    /// Per-logical-line wrap-row height (variable for headings).
+    line_heights: Vec<Pixels>,
     cursor: Option<PaintQuad>,
     selections: Vec<PaintQuad>,
 }
@@ -1294,28 +1374,50 @@ impl Element for EditorElement {
         let mut style = Style::default();
         style.size.width = relative(1.).into();
         let id = window.request_measured_layout(style, move |known, available, window, cx| {
-            let content: SharedString = editor.read(cx).content.clone().into();
+            let editor = editor.read(cx);
             let text_style = window.text_style();
             let font_size = text_style.font_size.to_pixels(window.rem_size());
-            let lh = font_size * LINE_HEIGHT_RATIO;
+            let base_lh = font_size * LINE_HEIGHT_RATIO;
             let wrap_width = match available.width {
                 AvailableSpace::Definite(w) => Some(w),
                 _ => known.width,
             };
-            let rows = shape_all(
-                window,
-                &content,
-                font_size,
-                text_style.font(),
-                text_style.color,
-                wrap_width,
-            )
-            .iter()
-            .map(|line| line.wrap_boundaries().len() + 1)
-            .sum::<usize>()
-            .max(1);
+            let height = if editor.content.is_empty() {
+                // Placeholder rows at the base size.
+                let rows = shape_all(
+                    window,
+                    &editor.placeholder,
+                    font_size,
+                    text_style.font(),
+                    text_style.color,
+                    wrap_width,
+                )
+                .iter()
+                .map(|line| line.wrap_boundaries().len() + 1)
+                .sum::<usize>()
+                .max(1);
+                base_lh * rows as f32
+            } else {
+                // Sum of per-line (variable) heights × each line's wrap rows.
+                let (wrapped, heights) = shape_document(
+                    window,
+                    &editor.content,
+                    &text_style.font(),
+                    text_style.color,
+                    font_size,
+                    &editor.diagnostics,
+                    editor.markdown_style.as_ref(),
+                    wrap_width,
+                );
+                wrapped
+                    .iter()
+                    .zip(&heights)
+                    .map(|(line, h)| *h * (line.wrap_boundaries().len() + 1) as f32)
+                    .fold(px(0.), |a, b| a + b)
+                    .max(base_lh)
+            };
             let width = wrap_width.or(known.width).unwrap_or(px(0.));
-            size(width, lh * rows as f32)
+            size(width, height)
         });
         (id, ())
     }
@@ -1331,39 +1433,44 @@ impl Element for EditorElement {
     ) -> PrepaintState {
         let editor = self.editor.read(cx);
         let style = window.text_style();
+        let font = style.font();
         let font_size = style.font_size.to_pixels(window.rem_size());
-        let lh = font_size * LINE_HEIGHT_RATIO;
+        let base_lh = font_size * LINE_HEIGHT_RATIO;
         let wrap_width = Some(bounds.size.width);
         let text_color = style.color;
 
-        // Shape the content (or placeholder, when empty) at the resolved width.
-        let wrapped = if editor.content.is_empty() {
-            shape_all(
+        // Placeholder (uniform) when empty; else shape per line so headings get
+        // their own taller rows (variable line heights — W2).
+        let (wrapped, line_heights) = if editor.content.is_empty() {
+            let w = shape_all(
                 window,
                 &editor.placeholder,
                 font_size,
-                style.font(),
+                font.clone(),
                 hsla(0., 0., 0.5, 0.5),
                 wrap_width,
-            )
+            );
+            let h = vec![base_lh; w.len()];
+            (w, h)
         } else {
-            let content: SharedString = editor.content.clone().into();
-            let runs = markdown_syntax::styled_runs(
-                &content,
-                &style.font(),
+            shape_document(
+                window,
+                &editor.content,
+                &font,
                 text_color,
+                font_size,
                 &editor.diagnostics,
                 editor.markdown_style.as_ref(),
-            );
-            shape_runs(window, &content, font_size, &runs, wrap_width)
+                wrap_width,
+            )
         };
 
-        // Top offset of each logical line (running sum of wrapped heights).
+        // Top offset of each logical line (running sum of variable wrap heights).
         let mut line_tops = Vec::with_capacity(wrapped.len());
         let mut y = px(0.);
-        for line in &wrapped {
+        for (line, lh) in wrapped.iter().zip(line_heights.iter()) {
             line_tops.push(y);
-            y += lh * (line.wrap_boundaries().len() + 1) as f32;
+            y += *lh * (line.wrap_boundaries().len() + 1) as f32;
         }
 
         // Map a (line-relative) point to a screen point. Captures `bounds` (Copy)
@@ -1373,12 +1480,13 @@ impl Element for EditorElement {
 
         let (cursor, selections) = if editor.content.is_empty() {
             let c = fill(
-                Bounds::new(point(bounds.left(), bounds.top()), size(px(2.), lh)),
+                Bounds::new(point(bounds.left(), bounds.top()), size(px(2.), base_lh)),
                 text_color,
             );
             (Some(c), Vec::new())
         } else if editor.selected_range.is_empty() {
             let (row, col) = editor.row_col(editor.cursor_offset());
+            let lh = line_heights.get(row).copied().unwrap_or(base_lh);
             let p = wrapped
                 .get(row)
                 .and_then(|l| l.position_for_index(col, lh))
@@ -1398,6 +1506,7 @@ impl Element for EditorElement {
                 let Some(line) = wrapped.get(row) else {
                     continue;
                 };
+                let lh = line_heights.get(row).copied().unwrap_or(base_lh);
                 let top = line_tops[row];
                 let line_start = starts[row];
                 let a = s.max(line_start) - line_start;
@@ -1449,6 +1558,7 @@ impl Element for EditorElement {
         PrepaintState {
             wrapped,
             line_tops,
+            line_heights,
             cursor,
             selections,
         }
@@ -1475,11 +1585,16 @@ impl Element for EditorElement {
             window.paint_quad(sel);
         }
 
-        let font_size = window.text_style().font_size.to_pixels(window.rem_size());
-        let lh = font_size * LINE_HEIGHT_RATIO;
-        for (line, top) in prepaint.wrapped.iter().zip(prepaint.line_tops.iter()) {
+        let base_lh =
+            window.text_style().font_size.to_pixels(window.rem_size()) * LINE_HEIGHT_RATIO;
+        for ((line, top), lh) in prepaint
+            .wrapped
+            .iter()
+            .zip(prepaint.line_tops.iter())
+            .zip(prepaint.line_heights.iter())
+        {
             let origin = point(bounds.origin.x, bounds.origin.y + *top);
-            let _ = line.paint(origin, lh, gpui::TextAlign::Left, None, window, cx);
+            let _ = line.paint(origin, *lh, gpui::TextAlign::Left, None, window, cx);
         }
 
         if focus.is_focused(window)
@@ -1490,11 +1605,13 @@ impl Element for EditorElement {
 
         let wrapped = std::mem::take(&mut prepaint.wrapped);
         let line_tops = std::mem::take(&mut prepaint.line_tops);
+        let line_heights = std::mem::take(&mut prepaint.line_heights);
         self.editor.update(cx, |editor, _| {
             editor.wrapped = wrapped;
             editor.line_tops = line_tops;
+            editor.line_heights = line_heights;
             editor.last_bounds = Some(bounds);
-            editor.line_height = lh;
+            editor.line_height = base_lh;
         });
     }
 }

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -118,6 +118,11 @@ const UNDO_LIMIT: usize = 256;
 /// editor text). 1.25 matches the spacing the editor replaced.
 const LINE_HEIGHT_RATIO: f32 = 1.25;
 
+/// Horizontal inset (px) of fenced-code-block text from the box's left edge, so
+/// code sits inside the padded box rather than flush against it. Mirrors the old
+/// renderer's `px(12)` left padding.
+const CODE_INSET: f32 = 12.;
+
 /// A restorable editor state, for undo/redo. Stores the caret offset (not a
 /// selection), so undo/redo place the caret rather than re-selecting text.
 #[derive(Clone)]
@@ -205,6 +210,10 @@ pub struct EditorState {
     /// Per-logical-line display→source byte map for rows with hidden markers
     /// (W6); `None` when the painted text equals the source. From the last paint.
     offset_maps: Vec<Option<Vec<usize>>>,
+    /// Per-logical-line flag: this row is inside a fenced code block, so its text
+    /// (and the caret/selection/hit-test on it) is inset by [`CODE_INSET`] to sit
+    /// inside the block's padded box. From the last paint.
+    code_rows: Vec<bool>,
     last_bounds: Option<Bounds<Pixels>>,
     line_height: Pixels,
     is_selecting: bool,
@@ -245,6 +254,7 @@ impl EditorState {
             line_heights: Vec::new(),
             widget_rows: Vec::new(),
             offset_maps: Vec::new(),
+            code_rows: Vec::new(),
             last_bounds: None,
             line_height: px(20.),
             is_selecting: false,
@@ -362,6 +372,17 @@ impl EditorState {
             .unwrap_or(self.line_height)
     }
 
+    /// Horizontal text inset for logical line `row`: [`CODE_INSET`] for a fenced
+    /// code-block row (text sits inside the padded box), else zero. Applied to the
+    /// caret, selection, hit-test, and text paint so they all stay aligned.
+    fn code_inset(&self, row: usize) -> Pixels {
+        if self.code_rows.get(row).copied().unwrap_or(false) {
+            px(CODE_INSET)
+        } else {
+            px(0.)
+        }
+    }
+
     /// Window-space bounds of the caret at `offset`, from the last paint's
     /// layout — for anchoring a popup (e.g. a slash menu) at a document offset.
     /// `None` before the first paint or if `offset`'s row isn't laid out.
@@ -372,10 +393,8 @@ impl EditorState {
         let line = self.wrapped.get(row)?;
         let p = line.position_for_index(col, lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
-        Some(Bounds::from_corners(
-            point(bounds.left() + p.x, top),
-            point(bounds.left() + p.x, top + lh),
-        ))
+        let x = bounds.left() + p.x + self.code_inset(row);
+        Some(Bounds::from_corners(point(x, top), point(x, top + lh)))
     }
 
     /// The document text as an owned [`SharedString`]; use [`Self::text`] for a
@@ -924,7 +943,8 @@ impl EditorState {
         if self.widget_rows.get(row).copied().unwrap_or(false) {
             return self.line_starts()[row];
         }
-        let line_rel = point(rel.x, rel.y - self.line_tops[row]);
+        let x = (rel.x - self.code_inset(row)).max(px(0.));
+        let line_rel = point(x, rel.y - self.line_tops[row]);
         let col = match self.wrapped[row].closest_index_for_position(line_rel, self.line_h(row)) {
             Ok(i) | Err(i) => i,
         };
@@ -1096,10 +1116,8 @@ impl EntityInputHandler for EditorState {
         let line = self.wrapped.get(row)?;
         let p = line.position_for_index(col, lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
-        Some(Bounds::from_corners(
-            point(bounds.left() + p.x, top),
-            point(bounds.left() + p.x, top + lh),
-        ))
+        let x = bounds.left() + p.x + self.code_inset(row);
+        Some(Bounds::from_corners(point(x, top), point(x, top + lh)))
     }
 
     fn character_index_for_point(
@@ -1328,6 +1346,19 @@ struct BlockImg {
     height: Pixels,
 }
 
+/// A fenced-code-block line's background (W4b/refinement): the block reads as one
+/// rounded, content-fit box (sized to its widest line, like a table — not the
+/// full editor width). Each line carries the block color, the shared box width
+/// (back-patched once the block's extent is known), and whether it's the
+/// first/last visible line (to round the box's top/bottom corners).
+#[derive(Clone, Copy)]
+struct CodeBg {
+    color: Hsla,
+    width: Pixels,
+    top: bool,
+    bottom: bool,
+}
+
 /// A table row rendered as a grid (W4c): its cells, per-column alignment, the
 /// content-fit per-column widths (shared across the table), header/separator/
 /// last-row flags, and the border color. Built only when the caret is outside
@@ -1351,7 +1382,7 @@ type ShapedLines = (
     Vec<WrappedLine>,
     Vec<Pixels>,
     Vec<Option<BlockImg>>,
-    Vec<Option<(Hsla, Pixels)>>,
+    Vec<Option<CodeBg>>,
     Vec<Option<TableRow>>,
     // Per-line display→source byte map for lines with markers hidden (W6); `None`
     // when the displayed text equals the source (revealed / code / widget lines).
@@ -1410,7 +1441,7 @@ fn shape_document(
     let mut wrapped = Vec::new();
     let mut heights = Vec::new();
     let mut widgets = Vec::new();
-    let mut backgrounds = Vec::new();
+    let mut backgrounds: Vec<Option<CodeBg>> = Vec::new();
     let mut tables = Vec::new();
     let mut maps = Vec::new();
     let lines: Vec<&str> = content.split('\n').collect();
@@ -1437,9 +1468,9 @@ fn shape_document(
     }
     let table_row_h = base_font_size * LINE_HEIGHT_RATIO + px(12.);
     let table_sep_h = px(8.);
-    // Fenced-code-block tracking: collect a block's background indices + its
-    // widest line, then back-patch every line's bg width so the block is a
-    // content-fit box (W4c refinement) rather than a full-width band.
+    // Fenced-code-block tracking: collect a block's line indices (so its box can
+    // be sized to its widest line + the first/last line marked for rounding) and
+    // the running max line width.
     let mut code_block: Vec<usize> = Vec::new();
     let mut code_w = px(0.);
     let mut line_start = 0;
@@ -1464,12 +1495,17 @@ fn shape_document(
                 .iter()
                 .any(|r| r.contains(&idx) && caret_row.is_some_and(|cr| r.contains(&cr)));
 
-        // Leaving a code block: back-patch its lines to the block's box width.
+        // Leaving a code block: size the box to its widest line (+ the inset on
+        // each side, like a table) and mark its last line so the box rounds + pads
+        // its bottom edge. The vertical padding is grown into the painted quad, so
+        // line geometry — and the caret — stay untouched.
         if !is_code && !code_block.is_empty() {
-            let box_w = (code_w + px(12.)).min(wrap_width.unwrap_or(code_w + px(12.)));
+            let bw = code_w + px(2. * CODE_INSET);
+            let last = *code_block.last().unwrap();
             for &bi in &code_block {
-                if let Some((_, w)) = &mut backgrounds[bi] {
-                    *w = box_w;
+                if let Some(cb) = &mut backgrounds[bi] {
+                    cb.width = bw;
+                    cb.bottom = bi == last;
                 }
             }
             code_block.clear();
@@ -1520,6 +1556,19 @@ fn shape_document(
         // A line keeps full source while the selection touches it (or styling is
         // off); otherwise its markers are hidden (W6, reveal-on-caret).
         let revealed = selection.0 <= line_end && selection.1 >= line_start;
+        // This line's diagnostics, clipped + shifted to line-local byte offsets —
+        // used as spell-check squiggles whether the line shows source or hides its
+        // markers.
+        let line_diags: Vec<Diagnostic> = diagnostics
+            .iter()
+            .filter_map(|d| {
+                let s = d.range.start.max(line_start);
+                let e = d.range.end.min(line_end);
+                (s < e).then(|| Diagnostic {
+                    range: (s - line_start)..(e - line_start),
+                })
+            })
+            .collect();
         let (shaped_text, runs, bg, map) = if collapse_fence {
             // Hidden ``` fence line: nothing painted, zero height.
             (String::new(), Vec::new(), None, None)
@@ -1538,23 +1587,26 @@ fn shape_document(
             } else {
                 vec![run]
             };
-            (line.to_string(), runs, Some((st.code_bg, px(0.))), None)
+            // First visible code line of the block rounds the box's top corners.
+            let top = code_block.is_empty();
+            (
+                line.to_string(),
+                runs,
+                Some(CodeBg {
+                    color: st.code_bg,
+                    width: px(0.), // back-patched to the block's widest line
+                    top,
+                    bottom: false,
+                }),
+                None,
+            )
         } else if let Some(st) = md.filter(|_| widget.is_none() && table.is_none() && !revealed) {
             // Markers hidden: shape the display string + keep a map back to source.
-            let (disp, runs, m) = markdown_syntax::hidden_runs(line, base_font, base_color, st);
+            let (disp, runs, m) =
+                markdown_syntax::hidden_runs(line, base_font, base_color, &line_diags, st);
             (disp, runs, None, Some(m))
         } else {
             // Full source with diagnostics (the caret/selected line, or md off).
-            let line_diags: Vec<Diagnostic> = diagnostics
-                .iter()
-                .filter_map(|d| {
-                    let s = d.range.start.max(line_start);
-                    let e = d.range.end.min(line_end);
-                    (s < e).then(|| Diagnostic {
-                        range: (s - line_start)..(e - line_start),
-                    })
-                })
-                .collect();
             (
                 line.to_string(),
                 markdown_syntax::styled_runs(line, base_font, base_color, &line_diags, md),
@@ -1563,12 +1615,19 @@ fn shape_document(
             )
         };
 
+        // Code lines are painted inset by CODE_INSET on each side, so they wrap at
+        // a correspondingly narrower width to stay inside the box.
+        let line_wrap = if is_code {
+            wrap_width.map(|w| (w - px(2. * CODE_INSET)).max(px(0.)))
+        } else {
+            wrap_width
+        };
         let shaped = shape_runs(
             window,
             &SharedString::from(shaped_text),
             fs,
             &runs,
-            wrap_width,
+            line_wrap,
         );
         if let Some(wl) = shaped.into_iter().next() {
             let h = if collapse_fence {
@@ -1587,7 +1646,8 @@ fn shape_document(
             backgrounds.push(bg);
             tables.push(table);
             maps.push(map);
-            // Accumulate a (visible) code line into the current block for box sizing.
+            // Track a (visible) code line + its width so the block's box can be
+            // sized to its widest line and its last line marked.
             if is_code && !collapse_fence {
                 code_block.push(backgrounds.len() - 1);
                 code_w = code_w.max(line_w);
@@ -1595,12 +1655,15 @@ fn shape_document(
         }
         line_start = line_end + 1; // skip the '\n'
     }
-    // Back-patch a code block that runs to the end of the document.
+    // A code block running to the end of the document: size its box + mark its
+    // last line (round the box bottom + pad).
     if !code_block.is_empty() {
-        let box_w = (code_w + px(12.)).min(wrap_width.unwrap_or(code_w + px(12.)));
+        let bw = code_w + px(2. * CODE_INSET);
+        let last = *code_block.last().unwrap();
         for &bi in &code_block {
-            if let Some((_, w)) = &mut backgrounds[bi] {
-                *w = box_w;
+            if let Some(cb) = &mut backgrounds[bi] {
+                cb.width = bw;
+                cb.bottom = bi == last;
             }
         }
     }
@@ -1771,8 +1834,8 @@ struct PrepaintState {
     line_heights: Vec<Pixels>,
     /// `Some` for a line painted as an inline image instead of its source text.
     widgets: Vec<Option<BlockImg>>,
-    /// Background behind a line + its width (a content-fit fenced code block).
-    backgrounds: Vec<Option<(Hsla, Pixels)>>,
+    /// Per-line fenced-code-block background (rounded full-width box).
+    backgrounds: Vec<Option<CodeBg>>,
     /// `Some` for a line painted as a table-grid row instead of source.
     tables: Vec<Option<TableRow>>,
     /// Per-line display→source byte map for marker-hidden rows (W6).
@@ -1951,7 +2014,11 @@ impl Element for EditorElement {
                 .and_then(|l| l.position_for_index(col, lh))
                 .unwrap_or_default();
             let top = line_tops.get(row).copied().unwrap_or(px(0.));
-            let c = fill(Bounds::new(to_screen(top, p), size(px(2.), lh)), text_color);
+            let inset = editor.code_inset(row);
+            let c = fill(
+                Bounds::new(to_screen(top, point(p.x + inset, p.y)), size(px(2.), lh)),
+                text_color,
+            );
             (Some(c), Vec::new())
         } else {
             let (s, e) = (editor.selected_range.start, editor.selected_range.end);
@@ -1967,11 +2034,14 @@ impl Element for EditorElement {
                 };
                 let lh = line_heights.get(row).copied().unwrap_or(base_lh);
                 let top = line_tops[row];
+                let inset = editor.code_inset(row);
                 let line_start = starts[row];
                 let a = s.max(line_start) - line_start;
                 let b = e.min(editor.line_end(row)) - line_start;
                 let pa = line.position_for_index(a, lh).unwrap_or_default();
                 let pb = line.position_for_index(b, lh).unwrap_or_default();
+                let pa = point(pa.x + inset, pa.y);
+                let pb = point(pb.x + inset, pb.y);
                 if pa.y == pb.y {
                     sels.push(fill(
                         Bounds::from_corners(
@@ -2061,9 +2131,27 @@ impl Element for EditorElement {
             .enumerate()
         {
             let origin = point(bounds.origin.x, bounds.origin.y + *top);
-            // Content-fit background behind the line (a fenced code block — W4b/c).
-            if let Some((c, w)) = prepaint.backgrounds.get(i).copied().flatten() {
-                window.paint_quad(fill(Bounds::new(origin, size(w, *lh)), c));
+            // Fenced code block: one rounded, content-fit box (sized to the
+            // widest line, like a table). The first line rounds + pads the top,
+            // the last rounds + pads the bottom. Padding is grown into the quad
+            // (not the line height), so the caret/hit-test geometry is unchanged.
+            if let Some(cb) = prepaint.backgrounds.get(i).copied().flatten() {
+                let r = px(6.);
+                let z = px(0.);
+                let pad = px(8.);
+                let top_pad = if cb.top { pad } else { z };
+                let bot_pad = if cb.bottom { pad } else { z };
+                let corners = Corners {
+                    top_left: if cb.top { r } else { z },
+                    top_right: if cb.top { r } else { z },
+                    bottom_left: if cb.bottom { r } else { z },
+                    bottom_right: if cb.bottom { r } else { z },
+                };
+                let box_origin = point(origin.x, origin.y - top_pad);
+                let box_size = size(cb.width, *lh + top_pad + bot_pad);
+                window.paint_quad(
+                    fill(Bounds::new(box_origin, box_size), cb.color).corner_radii(corners),
+                );
             }
             if let Some(t) = prepaint.tables.get(i).and_then(Option::as_ref) {
                 // Table grid row (W4c): cells + borders instead of source.
@@ -2075,7 +2163,24 @@ impl Element for EditorElement {
                 let img_bounds = Bounds::new(origin, size(w.width, w.height));
                 let _ = window.paint_image(img_bounds, Corners::default(), w.img.clone(), 0, false);
             } else {
-                let _ = line.paint(origin, *lh, gpui::TextAlign::Left, None, window, cx);
+                // Code lines inset their text to sit inside the block's padded box
+                // (kept in sync with `EditorState::code_inset`).
+                let text_origin = if prepaint.backgrounds.get(i).copied().flatten().is_some() {
+                    point(origin.x + px(CODE_INSET), origin.y)
+                } else {
+                    origin
+                };
+                // Run backgrounds (the inline-code highlight) paint separately from
+                // the glyphs — `paint` alone wouldn't show them.
+                let _ = line.paint_background(
+                    text_origin,
+                    *lh,
+                    gpui::TextAlign::Left,
+                    None,
+                    window,
+                    cx,
+                );
+                let _ = line.paint(text_origin, *lh, gpui::TextAlign::Left, None, window, cx);
             }
         }
 
@@ -2095,12 +2200,14 @@ impl Element for EditorElement {
             .enumerate()
             .map(|(i, w)| w.is_some() || prepaint.tables.get(i).is_some_and(Option::is_some))
             .collect();
+        let code_rows: Vec<bool> = prepaint.backgrounds.iter().map(Option::is_some).collect();
         self.editor.update(cx, |editor, _| {
             editor.wrapped = wrapped;
             editor.line_tops = line_tops;
             editor.line_heights = line_heights;
             editor.widget_rows = widget_rows;
             editor.offset_maps = offset_maps;
+            editor.code_rows = code_rows;
             editor.last_bounds = Some(bounds);
             editor.line_height = base_lh;
         });

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -202,6 +202,9 @@ pub struct EditorState {
     /// click on it places the caret at the line start instead of hit-testing
     /// source text. From the last paint.
     widget_rows: Vec<bool>,
+    /// Per-logical-line display→source byte map for rows with hidden markers
+    /// (W6); `None` when the painted text equals the source. From the last paint.
+    offset_maps: Vec<Option<Vec<usize>>>,
     last_bounds: Option<Bounds<Pixels>>,
     line_height: Pixels,
     is_selecting: bool,
@@ -241,6 +244,7 @@ impl EditorState {
             line_tops: Vec::new(),
             line_heights: Vec::new(),
             widget_rows: Vec::new(),
+            offset_maps: Vec::new(),
             last_bounds: None,
             line_height: px(20.),
             is_selecting: false,
@@ -844,7 +848,7 @@ impl EditorState {
         let col = match self.wrapped[trow].closest_index_for_position(rel, self.line_h(trow)) {
             Ok(i) | Err(i) => i,
         };
-        self.line_starts()[trow] + col
+        self.line_starts()[trow] + self.source_col(trow, col)
     }
 
     /// The end of the next word at/after `offset` (⌥→ on macOS).
@@ -924,7 +928,17 @@ impl EditorState {
         let col = match self.wrapped[row].closest_index_for_position(line_rel, self.line_h(row)) {
             Ok(i) | Err(i) => i,
         };
-        self.line_starts()[row] + col
+        self.line_starts()[row] + self.source_col(row, col)
+    }
+
+    /// Map a display byte column on `row` back to its source column. Identity
+    /// unless the row's markers are hidden (W6), where the painted text is
+    /// shorter than the source.
+    fn source_col(&self, row: usize, display_col: usize) -> usize {
+        match self.offset_maps.get(row).and_then(Option::as_ref) {
+            Some(map) => map.get(display_col).copied().unwrap_or(display_col),
+            None => display_col,
+        }
     }
 
     // --- UTF-16 + grapheme boundaries (IME / cursor movement) ----------------
@@ -1339,6 +1353,9 @@ type ShapedLines = (
     Vec<Option<BlockImg>>,
     Vec<Option<(Hsla, Pixels)>>,
     Vec<Option<TableRow>>,
+    // Per-line display→source byte map for lines with markers hidden (W6); `None`
+    // when the displayed text equals the source (revealed / code / widget lines).
+    Vec<Option<Vec<usize>>>,
 );
 
 /// Fit-to-width display size for an inline image from its natural (device) size:
@@ -1386,13 +1403,22 @@ fn shape_document(
     caret_row: Option<usize>,
     block_image: Option<&BlockImageFn>,
     scale_factor: f32,
+    // The selected byte range; a line it touches keeps full source (markers
+    // shown), the rest hide their markers (W6, reveal-on-caret).
+    selection: (usize, usize),
 ) -> ShapedLines {
     let mut wrapped = Vec::new();
     let mut heights = Vec::new();
     let mut widgets = Vec::new();
     let mut backgrounds = Vec::new();
     let mut tables = Vec::new();
+    let mut maps = Vec::new();
     let lines: Vec<&str> = content.split('\n').collect();
+    // Fenced-code-block regions; a block's ``` fence lines collapse (W6) unless
+    // the caret is inside that block (then they show, so they stay editable).
+    let code_regions = md
+        .map(|_| markdown_syntax::code_regions(content))
+        .unwrap_or_default();
     // Table regions (W4c); content-fit column widths shared by each region's rows.
     let regions = md
         .map(|_| markdown_syntax::table_regions(content))
@@ -1430,6 +1456,13 @@ fn shape_document(
         if is_fence {
             in_fence = !in_fence;
         }
+        // A ``` fence line collapses (height 0, no text) unless the caret is in
+        // its block — so a code block reads as just its boxed body (W6), with the
+        // fences re-appearing while you edit inside it.
+        let collapse_fence = is_fence
+            && !code_regions
+                .iter()
+                .any(|r| r.contains(&idx) && caret_row.is_some_and(|cr| r.contains(&cr)));
 
         // Leaving a code block: back-patch its lines to the block's box width.
         if !is_code && !code_block.is_empty() {
@@ -1484,7 +1517,13 @@ fn shape_document(
                 }
             });
 
-        let (runs, bg) = if let Some(st) = md.filter(|_| is_code) {
+        // A line keeps full source while the selection touches it (or styling is
+        // off); otherwise its markers are hidden (W6, reveal-on-caret).
+        let revealed = selection.0 <= line_end && selection.1 >= line_start;
+        let (shaped_text, runs, bg, map) = if collapse_fence {
+            // Hidden ``` fence line: nothing painted, zero height.
+            (String::new(), Vec::new(), None, None)
+        } else if let Some(st) = md.filter(|_| is_code) {
             // One monospace run for the whole line; ``` delimiters dimmed.
             let run = TextRun {
                 len: line.len(),
@@ -1499,9 +1538,13 @@ fn shape_document(
             } else {
                 vec![run]
             };
-            (runs, Some((st.code_bg, px(0.))))
+            (line.to_string(), runs, Some((st.code_bg, px(0.))), None)
+        } else if let Some(st) = md.filter(|_| widget.is_none() && table.is_none() && !revealed) {
+            // Markers hidden: shape the display string + keep a map back to source.
+            let (disp, runs, m) = markdown_syntax::hidden_runs(line, base_font, base_color, st);
+            (disp, runs, None, Some(m))
         } else {
-            // Diagnostics overlapping this line, shifted to line-relative ranges.
+            // Full source with diagnostics (the caret/selected line, or md off).
             let line_diags: Vec<Diagnostic> = diagnostics
                 .iter()
                 .filter_map(|d| {
@@ -1513,23 +1556,29 @@ fn shape_document(
                 })
                 .collect();
             (
+                line.to_string(),
                 markdown_syntax::styled_runs(line, base_font, base_color, &line_diags, md),
+                None,
                 None,
             )
         };
 
         let shaped = shape_runs(
             window,
-            &SharedString::from(line.to_string()),
+            &SharedString::from(shaped_text),
             fs,
             &runs,
             wrap_width,
         );
         if let Some(wl) = shaped.into_iter().next() {
-            let h = match &table {
-                Some(t) if t.is_separator => table_sep_h,
-                Some(_) => table_row_h,
-                None => widget.as_ref().map_or(fs * LINE_HEIGHT_RATIO, |w| w.height),
+            let h = if collapse_fence {
+                px(0.)
+            } else {
+                match &table {
+                    Some(t) if t.is_separator => table_sep_h,
+                    Some(_) => table_row_h,
+                    None => widget.as_ref().map_or(fs * LINE_HEIGHT_RATIO, |w| w.height),
+                }
             };
             let line_w = wl.width();
             wrapped.push(wl);
@@ -1537,8 +1586,9 @@ fn shape_document(
             widgets.push(widget);
             backgrounds.push(bg);
             tables.push(table);
-            // Accumulate this code line into the current block for box sizing.
-            if is_code {
+            maps.push(map);
+            // Accumulate a (visible) code line into the current block for box sizing.
+            if is_code && !collapse_fence {
                 code_block.push(backgrounds.len() - 1);
                 code_w = code_w.max(line_w);
             }
@@ -1554,7 +1604,7 @@ fn shape_document(
             }
         }
     }
-    (wrapped, heights, widgets, backgrounds, tables)
+    (wrapped, heights, widgets, backgrounds, tables, maps)
 }
 
 /// Content-fit column widths for a table region (W4c): each column sized to its
@@ -1725,6 +1775,8 @@ struct PrepaintState {
     backgrounds: Vec<Option<(Hsla, Pixels)>>,
     /// `Some` for a line painted as a table-grid row instead of source.
     tables: Vec<Option<TableRow>>,
+    /// Per-line display→source byte map for marker-hidden rows (W6).
+    maps: Vec<Option<Vec<usize>>>,
     cursor: Option<PaintQuad>,
     selections: Vec<PaintQuad>,
 }
@@ -1788,7 +1840,7 @@ impl Element for EditorElement {
                 // Sum of per-line (variable) heights × each line's wrap rows.
                 let caret_row = editor.row_col(editor.cursor_offset()).0;
                 let sf = window.scale_factor();
-                let (wrapped, heights, _, _, _) = shape_document(
+                let (wrapped, heights, _, _, _, _) = shape_document(
                     window,
                     &editor.content,
                     &text_style.font(),
@@ -1800,6 +1852,7 @@ impl Element for EditorElement {
                     Some(caret_row),
                     editor.block_image.as_ref(),
                     sf,
+                    (editor.selected_range.start, editor.selected_range.end),
                 );
                 wrapped
                     .iter()
@@ -1835,38 +1888,41 @@ impl Element for EditorElement {
         // their own taller rows (W2) and image lines render inline (W4).
         let caret_row = editor.row_col(editor.cursor_offset()).0;
         let sf = window.scale_factor();
-        let (wrapped, line_heights, widgets, backgrounds, tables) = if editor.content.is_empty() {
-            let w = shape_all(
-                window,
-                &editor.placeholder,
-                font_size,
-                font.clone(),
-                hsla(0., 0., 0.5, 0.5),
-                wrap_width,
-            );
-            let n = w.len();
-            (
-                w,
-                vec![base_lh; n],
-                vec![None; n],
-                vec![None; n],
-                vec![None; n],
-            )
-        } else {
-            shape_document(
-                window,
-                &editor.content,
-                &font,
-                text_color,
-                font_size,
-                &editor.diagnostics,
-                editor.markdown_style.as_ref(),
-                wrap_width,
-                Some(caret_row),
-                editor.block_image.as_ref(),
-                sf,
-            )
-        };
+        let (wrapped, line_heights, widgets, backgrounds, tables, maps) =
+            if editor.content.is_empty() {
+                let w = shape_all(
+                    window,
+                    &editor.placeholder,
+                    font_size,
+                    font.clone(),
+                    hsla(0., 0., 0.5, 0.5),
+                    wrap_width,
+                );
+                let n = w.len();
+                (
+                    w,
+                    vec![base_lh; n],
+                    vec![None; n],
+                    vec![None; n],
+                    vec![None; n],
+                    vec![None; n],
+                )
+            } else {
+                shape_document(
+                    window,
+                    &editor.content,
+                    &font,
+                    text_color,
+                    font_size,
+                    &editor.diagnostics,
+                    editor.markdown_style.as_ref(),
+                    wrap_width,
+                    Some(caret_row),
+                    editor.block_image.as_ref(),
+                    sf,
+                    (editor.selected_range.start, editor.selected_range.end),
+                )
+            };
 
         // Top offset of each logical line (running sum of variable wrap heights).
         let mut line_tops = Vec::with_capacity(wrapped.len());
@@ -1965,6 +2021,7 @@ impl Element for EditorElement {
             widgets,
             backgrounds,
             tables,
+            maps,
             cursor,
             selections,
         }
@@ -2031,6 +2088,7 @@ impl Element for EditorElement {
         let wrapped = std::mem::take(&mut prepaint.wrapped);
         let line_tops = std::mem::take(&mut prepaint.line_tops);
         let line_heights = std::mem::take(&mut prepaint.line_heights);
+        let offset_maps = std::mem::take(&mut prepaint.maps);
         let widget_rows: Vec<bool> = prepaint
             .widgets
             .iter()
@@ -2042,6 +2100,7 @@ impl Element for EditorElement {
             editor.line_tops = line_tops;
             editor.line_heights = line_heights;
             editor.widget_rows = widget_rows;
+            editor.offset_maps = offset_maps;
             editor.last_bounds = Some(bounds);
             editor.line_height = base_lh;
         });

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -123,6 +123,11 @@ const LINE_HEIGHT_RATIO: f32 = 1.25;
 /// renderer's `px(12)` left padding.
 const CODE_INSET: f32 = 12.;
 
+/// Vertical padding (px) above the first / below the last line of a fenced code
+/// block. Reserved as layout space (a gap in the line tops + total height) so the
+/// box doesn't overlap adjacent lines, with no blank line required.
+const CODE_PAD: f32 = 8.;
+
 /// A restorable editor state, for undo/redo. Stores the caret offset (not a
 /// selection), so undo/redo place the caret rather than re-selecting text.
 #[derive(Clone)]
@@ -391,7 +396,7 @@ impl EditorState {
         let (row, col) = self.row_col(offset);
         let lh = self.line_h(row);
         let line = self.wrapped.get(row)?;
-        let p = line.position_for_index(col, lh)?;
+        let p = line.position_for_index(self.display_col(row, col), lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
         let x = bounds.left() + p.x + self.code_inset(row);
         Some(Bounds::from_corners(point(x, top), point(x, top + lh)))
@@ -830,7 +835,7 @@ impl EditorState {
         let Some(cur) = self
             .wrapped
             .get(row)
-            .and_then(|l| l.position_for_index(col, cur_lh))
+            .and_then(|l| l.position_for_index(self.display_col(row, col), cur_lh))
         else {
             return self.vertical_offset(dir);
         };
@@ -959,6 +964,17 @@ impl EditorState {
             Some(map) => map.get(display_col).copied().unwrap_or(display_col),
             None => display_col,
         }
+    }
+
+    /// Map a source byte column on `row` to its display column — the inverse of
+    /// [`Self::source_col`], for positioning the caret/selection on a row whose
+    /// markers are hidden (W6/#5). Uses the last painted map; in-paint code that
+    /// has this frame's fresh map should call [`display_col_in`] directly.
+    fn display_col(&self, row: usize, source_col: usize) -> usize {
+        display_col_in(
+            self.offset_maps.get(row).and_then(Option::as_ref),
+            source_col,
+        )
     }
 
     // --- UTF-16 + grapheme boundaries (IME / cursor movement) ----------------
@@ -1114,7 +1130,7 @@ impl EntityInputHandler for EditorState {
         let (row, col) = self.row_col(range.start);
         let lh = self.line_h(row);
         let line = self.wrapped.get(row)?;
-        let p = line.position_for_index(col, lh)?;
+        let p = line.position_for_index(self.display_col(row, col), lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
         let x = bounds.left() + p.x + self.code_inset(row);
         Some(Bounds::from_corners(point(x, top), point(x, top + lh)))
@@ -1412,6 +1428,35 @@ fn block_img(
     })
 }
 
+/// Invert a display→source offset map: the display column for `source_col`. The
+/// map is ascending, so a source column that is hidden (a collapsed marker)
+/// snaps to the next visible display column. `None` map → identity (a row shown
+/// as full source). The prepaint cursor/selection pass this frame's fresh map
+/// (the committed `EditorState::offset_maps` lags a frame); event handlers go
+/// through [`EditorState::display_col`], which uses the committed map.
+fn display_col_in(map: Option<&Vec<usize>>, source_col: usize) -> usize {
+    match map {
+        Some(m) => match m.binary_search(&source_col) {
+            Ok(d) | Err(d) => d,
+        },
+        None => source_col,
+    }
+}
+
+/// The reserved vertical gap above (`.0`) and below (`.1`) a row, from its
+/// code-block background: [`CODE_PAD`] above the block's first line and below its
+/// last. Added to the line tops + total height so the padded box has real layout
+/// space and never overlaps adjacent lines.
+fn code_pads(bg: Option<CodeBg>) -> (Pixels, Pixels) {
+    match bg {
+        Some(cb) => (
+            if cb.top { px(CODE_PAD) } else { px(0.) },
+            if cb.bottom { px(CODE_PAD) } else { px(0.) },
+        ),
+        None => (px(0.), px(0.)),
+    }
+}
+
 /// Shape `content` line-by-line so each logical line can use its own font size
 /// (headings are larger — W2) and a standalone image line can render as the image
 /// (W4). Returns, per logical line: the shaped source [`WrappedLine`], its row
@@ -1553,9 +1598,15 @@ fn shape_document(
                 }
             });
 
-        // A line keeps full source while the selection touches it (or styling is
-        // off); otherwise its markers are hidden (W6, reveal-on-caret).
-        let revealed = selection.0 <= line_end && selection.1 >= line_start;
+        // A line shows full source while a non-empty selection touches it (so the
+        // markers are visible to select) or styling is off. Otherwise its markers
+        // are hidden — except, on the caret's own line, the single construct the
+        // caret sits in is revealed (per-construct reveal, #5: finer than the old
+        // whole-line reveal, so the rest of the line stays rendered).
+        let sel_empty = selection.0 == selection.1;
+        let full_source = !sel_empty && selection.0 <= line_end && selection.1 >= line_start;
+        let caret_col = (sel_empty && selection.0 >= line_start && selection.0 <= line_end)
+            .then(|| selection.0 - line_start);
         // This line's diagnostics, clipped + shifted to line-local byte offsets —
         // used as spell-check squiggles whether the line shows source or hides its
         // markers.
@@ -1600,10 +1651,18 @@ fn shape_document(
                 }),
                 None,
             )
-        } else if let Some(st) = md.filter(|_| widget.is_none() && table.is_none() && !revealed) {
-            // Markers hidden: shape the display string + keep a map back to source.
-            let (disp, runs, m) =
-                markdown_syntax::hidden_runs(line, base_font, base_color, &line_diags, st);
+        } else if let Some(st) = md.filter(|_| widget.is_none() && table.is_none() && !full_source)
+        {
+            // Markers hidden (except the caret's construct): shape the display
+            // string + keep a map back to source.
+            let (disp, runs, m) = markdown_syntax::hidden_runs(
+                line,
+                base_font,
+                base_color,
+                &line_diags,
+                caret_col,
+                st,
+            );
             (disp, runs, None, Some(m))
         } else {
             // Full source with diagnostics (the caret/selected line, or md off).
@@ -1903,7 +1962,7 @@ impl Element for EditorElement {
                 // Sum of per-line (variable) heights × each line's wrap rows.
                 let caret_row = editor.row_col(editor.cursor_offset()).0;
                 let sf = window.scale_factor();
-                let (wrapped, heights, _, _, _, _) = shape_document(
+                let (wrapped, heights, _, backgrounds, _, _) = shape_document(
                     window,
                     &editor.content,
                     &text_style.font(),
@@ -1920,7 +1979,11 @@ impl Element for EditorElement {
                 wrapped
                     .iter()
                     .zip(&heights)
-                    .map(|(line, h)| *h * (line.wrap_boundaries().len() + 1) as f32)
+                    .zip(&backgrounds)
+                    .map(|((line, h), bg)| {
+                        let (top, bot) = code_pads(*bg);
+                        *h * (line.wrap_boundaries().len() + 1) as f32 + top + bot
+                    })
                     .fold(px(0.), |a, b| a + b)
                     .max(base_lh)
             };
@@ -1987,18 +2050,40 @@ impl Element for EditorElement {
                 )
             };
 
-        // Top offset of each logical line (running sum of variable wrap heights).
+        // Top offset of each logical line (running sum of variable wrap heights),
+        // reserving a gap above/below each code block so its padded box has its
+        // own space (no overlap with the adjacent line, no blank line required).
         let mut line_tops = Vec::with_capacity(wrapped.len());
         let mut y = px(0.);
-        for (line, lh) in wrapped.iter().zip(line_heights.iter()) {
+        for ((line, lh), bg) in wrapped
+            .iter()
+            .zip(line_heights.iter())
+            .zip(backgrounds.iter())
+        {
+            let (top_pad, bot_pad) = code_pads(*bg);
+            y += top_pad;
             line_tops.push(y);
-            y += *lh * (line.wrap_boundaries().len() + 1) as f32;
+            y += *lh * (line.wrap_boundaries().len() + 1) as f32 + bot_pad;
         }
 
         // Map a (line-relative) point to a screen point. Captures `bounds` (Copy)
         // only, so `line_tops` stays free to move into the prepaint state.
         let to_screen =
             |top: Pixels, p: Point<Pixels>| point(bounds.left() + p.x, bounds.top() + top + p.y);
+
+        // Caret/selection positioning must use THIS frame's fresh per-row data —
+        // `editor.offset_maps`/`code_rows` aren't committed until paint, so the
+        // method forms would lag a frame (a one-frame caret jump after an edit
+        // that hides/reveals markers).
+        let disp_col =
+            |row: usize, sc: usize| display_col_in(maps.get(row).and_then(Option::as_ref), sc);
+        let code_inset = |row: usize| {
+            if backgrounds.get(row).is_some_and(Option::is_some) {
+                px(CODE_INSET)
+            } else {
+                px(0.)
+            }
+        };
 
         let (cursor, selections) = if editor.content.is_empty() {
             let c = fill(
@@ -2011,10 +2096,10 @@ impl Element for EditorElement {
             let lh = line_heights.get(row).copied().unwrap_or(base_lh);
             let p = wrapped
                 .get(row)
-                .and_then(|l| l.position_for_index(col, lh))
+                .and_then(|l| l.position_for_index(disp_col(row, col), lh))
                 .unwrap_or_default();
             let top = line_tops.get(row).copied().unwrap_or(px(0.));
-            let inset = editor.code_inset(row);
+            let inset = code_inset(row);
             let c = fill(
                 Bounds::new(to_screen(top, point(p.x + inset, p.y)), size(px(2.), lh)),
                 text_color,
@@ -2034,12 +2119,16 @@ impl Element for EditorElement {
                 };
                 let lh = line_heights.get(row).copied().unwrap_or(base_lh);
                 let top = line_tops[row];
-                let inset = editor.code_inset(row);
+                let inset = code_inset(row);
                 let line_start = starts[row];
                 let a = s.max(line_start) - line_start;
                 let b = e.min(editor.line_end(row)) - line_start;
-                let pa = line.position_for_index(a, lh).unwrap_or_default();
-                let pb = line.position_for_index(b, lh).unwrap_or_default();
+                let pa = line
+                    .position_for_index(disp_col(row, a), lh)
+                    .unwrap_or_default();
+                let pb = line
+                    .position_for_index(disp_col(row, b), lh)
+                    .unwrap_or_default();
                 let pa = point(pa.x + inset, pa.y);
                 let pb = point(pb.x + inset, pb.y);
                 if pa.y == pb.y {
@@ -2132,15 +2221,14 @@ impl Element for EditorElement {
         {
             let origin = point(bounds.origin.x, bounds.origin.y + *top);
             // Fenced code block: one rounded, content-fit box (sized to the
-            // widest line, like a table). The first line rounds + pads the top,
-            // the last rounds + pads the bottom. Padding is grown into the quad
-            // (not the line height), so the caret/hit-test geometry is unchanged.
+            // widest line, like a table). The first line rounds + pads the top, the
+            // last rounds + pads the bottom; the pad fills the layout gap reserved
+            // for it (see `code_pads`), so the caret geometry stays text-height and
+            // the box never overlaps an adjacent line.
             if let Some(cb) = prepaint.backgrounds.get(i).copied().flatten() {
                 let r = px(6.);
                 let z = px(0.);
-                let pad = px(8.);
-                let top_pad = if cb.top { pad } else { z };
-                let bot_pad = if cb.bottom { pad } else { z };
+                let (top_pad, bot_pad) = code_pads(Some(cb));
                 let corners = Corners {
                     top_left: if cb.top { r } else { z },
                     top_right: if cb.top { r } else { z },

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1803,7 +1803,6 @@ fn shape_document(
         ));
     }
     let table_row_h = base_font_size * LINE_HEIGHT_RATIO + px(12.);
-    let table_sep_h = px(8.);
     // Fenced-code-block tracking: collect a block's line indices (so its box can
     // be sized to its widest line + the first/last line marked for rounding) and
     // the running max line width.
@@ -2094,7 +2093,10 @@ fn shape_document(
                 px(0.)
             } else {
                 match &table {
-                    Some(t) if t.is_separator => table_sep_h,
+                    // The `|---|` separator collapses in grid mode — the old
+                    // renderer doesn't show it; the first body row's top divider
+                    // becomes the header/body border.
+                    Some(t) if t.is_separator => px(0.),
                     Some(_) => table_row_h,
                     None => widget
                         .as_ref()
@@ -2267,37 +2269,32 @@ fn paint_table_row(
     cx: &mut App,
 ) {
     let thick = px(1.);
-    let table_w = t.col_widths.iter().fold(px(0.), |a, &w| a + w);
+    // The collapsed `|---|` separator draws nothing — the outer box + the next
+    // row's top divider form the header/body border.
     if t.is_separator {
-        let y = origin.y + (row_h - thick) / 2.;
-        window.paint_quad(fill(
-            Bounds::new(point(origin.x, y), size(table_w, thick)),
-            t.border,
-        ));
         return;
     }
-    // Horizontal borders: top on every row; bottom only on the last.
-    window.paint_quad(fill(Bounds::new(origin, size(table_w, thick)), t.border));
-    if t.is_last {
-        window.paint_quad(fill(
-            Bounds::new(
-                point(origin.x, origin.y + row_h - thick),
-                size(table_w, thick),
-            ),
-            t.border,
-        ));
+    let table_w = t.col_widths.iter().fold(px(0.), |a, &w| a + w);
+    // Inter-row divider at the top of every row except the header (the outer box's
+    // top border covers that one).
+    if !t.is_header {
+        window.paint_quad(fill(Bounds::new(origin, size(table_w, thick)), t.border));
     }
-    let pad = px(8.);
+    let pad = px(10.);
     let mut cell_font = font.clone();
     if t.is_header {
         cell_font.weight = gpui::FontWeight::BOLD;
     }
     let mut x = origin.x;
     for (c, &cw) in t.col_widths.iter().enumerate() {
-        window.paint_quad(fill(
-            Bounds::new(point(x, origin.y), size(thick, row_h)),
-            t.border,
-        ));
+        // Inner cell separator at the left of every cell except the first (the box
+        // provides the outer-left border).
+        if c > 0 {
+            window.paint_quad(fill(
+                Bounds::new(point(x, origin.y), size(thick, row_h)),
+                t.border,
+            ));
+        }
         if let Some(cell) = t.cells.get(c).filter(|s| !s.is_empty()) {
             let run = TextRun {
                 len: cell.len(),
@@ -2326,10 +2323,6 @@ fn paint_table_row(
         }
         x += cw;
     }
-    window.paint_quad(fill(
-        Bounds::new(point(x, origin.y), size(thick, row_h)),
-        t.border,
-    ));
 }
 
 /// The custom element that lays out + paints the editor's wrapped lines, cursor,
@@ -2823,7 +2816,32 @@ impl Element for EditorElement {
                 }
             }
             if let Some(t) = prepaint.tables.get(i).and_then(Option::as_ref) {
-                // Table grid row (W4c): cells + borders instead of source.
+                // The header row paints the whole table's rounded outer border
+                // (one box around all its rows, matching the reading view); each
+                // row then paints its inner dividers + cell text.
+                if t.is_header {
+                    let mut total_h = px(0.);
+                    for j in i..prepaint.tables.len() {
+                        match prepaint.tables[j].as_ref() {
+                            Some(tr) => {
+                                total_h += prepaint.line_heights[j];
+                                if tr.is_last {
+                                    break;
+                                }
+                            }
+                            None => break,
+                        }
+                    }
+                    let table_w = t.col_widths.iter().fold(px(0.), |a, &w| a + w);
+                    window.paint_quad(PaintQuad {
+                        bounds: Bounds::new(origin, size(table_w, total_h)),
+                        corner_radii: Corners::all(px(6.)),
+                        background: hsla(0., 0., 0., 0.).into(),
+                        border_widths: Edges::all(px(1.)),
+                        border_color: t.border,
+                        border_style: BorderStyle::Solid,
+                    });
+                }
                 paint_table_row(
                     t, origin, *lh, &font, font_size, base_lh, text_color, window, cx,
                 );

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -208,6 +208,21 @@ type BlockImageFn = Box<dyn Fn(&str) -> Option<Arc<RenderImage>>>;
 /// clickable chip (left-click emits [`EditorEvent::OpenLink`]).
 type BlockChipFn = Box<dyn Fn(&str) -> Option<SharedString>>;
 
+/// Resolves a ` ```mermaid ` block's source to a rendered diagram bitmap, so the
+/// editor can render the block as the diagram (caret outside) instead of code.
+/// Set via [`EditorState::set_block_mermaid_provider`]; the host renders +
+/// caches off-thread (see [`EditorState::mermaid_sources`] to pre-render).
+type BlockMermaidFn = Box<dyn Fn(&str) -> Option<Arc<RenderImage>>>;
+
+/// The diagram sources of every ` ```mermaid ` block in `content`, so a host can
+/// pre-render them (the editor's mermaid provider then finds the ready bitmap).
+pub fn mermaid_sources(content: &str) -> Vec<SharedString> {
+    markdown_syntax::mermaid_blocks(content)
+        .into_iter()
+        .map(|(_, source)| source.into())
+        .collect()
+}
+
 /// The editor: text + cursor/selection state, an undo/redo history, plus a
 /// cached layout (the wrapped lines from the last paint) for hit-testing + IME.
 pub struct EditorState {
@@ -267,6 +282,9 @@ pub struct EditorState {
     /// Classifies an `![](src)` as a file chip (e.g. a PDF) + its label; set by
     /// the host via [`Self::set_block_chip_provider`].
     block_chip: Option<BlockChipFn>,
+    /// Resolves a ` ```mermaid ` block's source to a rendered diagram; set by the
+    /// host via [`Self::set_block_mermaid_provider`].
+    block_mermaid: Option<BlockMermaidFn>,
     /// Per-logical-line `src` for rows painted as a file chip (from the last
     /// paint), so a left-click can open it and a right-click can edit it.
     chip_rows: Vec<Option<SharedString>>,
@@ -300,6 +318,7 @@ impl EditorState {
             suggest: None,
             block_image: None,
             block_chip: None,
+            block_mermaid: None,
             chip_rows: Vec::new(),
         }
     }
@@ -388,6 +407,17 @@ impl EditorState {
         provider: impl Fn(&str) -> Option<SharedString> + 'static,
     ) {
         self.block_chip = Some(Box::new(provider));
+    }
+
+    /// Install the provider that resolves a ` ```mermaid ` block's source to a
+    /// rendered diagram. With it, such a block renders as the diagram when the
+    /// caret is elsewhere; with the caret inside (or while it renders) it shows
+    /// the raw fenced source. Pre-render with [`mermaid_sources`].
+    pub fn set_block_mermaid_provider(
+        &mut self,
+        provider: impl Fn(&str) -> Option<Arc<RenderImage>> + 'static,
+    ) {
+        self.block_mermaid = Some(Box::new(provider));
     }
 
     /// The caret's byte offset into [`Self::text`] (the moving end of any
@@ -1624,6 +1654,7 @@ fn shape_document(
     caret_row: Option<usize>,
     block_image: Option<&BlockImageFn>,
     block_chip: Option<&BlockChipFn>,
+    block_mermaid: Option<&BlockMermaidFn>,
     scale_factor: f32,
     // The selected byte range; a line it touches keeps full source (markers
     // shown), the rest hide their markers (W6, reveal-on-caret).
@@ -1642,6 +1673,21 @@ fn shape_document(
     let code_regions = md
         .map(|_| markdown_syntax::code_regions(content))
         .unwrap_or_default();
+    // ```mermaid blocks ready to render as a diagram: the caret is outside the
+    // block and the host has a rendered bitmap. The diagram paints on the block's
+    // first line; the rest collapse. Caret inside / still rendering → raw code.
+    let mermaid: Vec<(Range<usize>, BlockImg)> = match block_mermaid.filter(|_| md.is_some()) {
+        Some(f) => markdown_syntax::mermaid_blocks(content)
+            .into_iter()
+            .filter(|(range, _)| caret_row.is_none_or(|cr| !range.contains(&cr)))
+            .filter_map(|(range, source)| {
+                let img = f(&source)?;
+                let bi = block_img(img, None, wrap_width, scale_factor)?;
+                Some((range, bi))
+            })
+            .collect(),
+        None => Vec::new(),
+    };
     // Table regions (W4c); content-fit column widths shared by each region's rows.
     let regions = md
         .map(|_| markdown_syntax::table_regions(content))
@@ -1669,6 +1715,39 @@ fn shape_document(
     let mut in_fence = false;
     for (idx, &line) in lines.iter().enumerate() {
         let line_end = line_start + line.len();
+
+        // A ready mermaid block renders as its diagram (on the first line) with the
+        // rest of the block collapsed — bypassing the normal per-line handling. Its
+        // ``` fences still toggle `in_fence` so later code blocks track correctly.
+        if let Some((range, bi)) = mermaid.iter().find(|(r, _)| r.contains(&idx)) {
+            if line.trim_start().starts_with("```") {
+                in_fence = !in_fence;
+            }
+            let (h, widget) = if idx == range.start {
+                (bi.height, Some(Block::Image(bi.clone())))
+            } else {
+                (px(0.), None)
+            };
+            let wl = shape_runs(
+                window,
+                &SharedString::default(),
+                base_font_size,
+                &[],
+                wrap_width,
+            )
+            .into_iter()
+            .next()
+            .expect("a line always shapes to one wrapped line");
+            wrapped.push(wl);
+            heights.push(h);
+            widgets.push(widget);
+            backgrounds.push(None);
+            tables.push(None);
+            maps.push(None);
+            marks.push(None);
+            line_start = line_end + 1;
+            continue;
+        }
 
         // Fenced code block (W4b): a ``` line toggles the fence; the delimiter
         // lines + the lines between render as monospace code over a content-fit
@@ -2243,6 +2322,7 @@ impl Element for EditorElement {
                     Some(caret_row),
                     editor.block_image.as_ref(),
                     editor.block_chip.as_ref(),
+                    editor.block_mermaid.as_ref(),
                     sf,
                     (editor.selected_range.start, editor.selected_range.end),
                 );
@@ -2317,6 +2397,7 @@ impl Element for EditorElement {
                     Some(caret_row),
                     editor.block_image.as_ref(),
                     editor.block_chip.as_ref(),
+                    editor.block_mermaid.as_ref(),
                     sf,
                     (editor.selected_range.start, editor.selected_range.end),
                 )

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1784,6 +1784,9 @@ enum LineMark {
         checked: bool,
         color: Hsla,
     },
+    /// Thematic break (`---`): a full-width muted divider painted in place of the
+    /// source; the line has no body text (reveal-on-caret shows the raw `---`).
+    Rule(Hsla),
 }
 
 impl LineMark {
@@ -1792,6 +1795,7 @@ impl LineMark {
         match self {
             LineMark::Quote(_) => px(QUOTE_INSET),
             LineMark::List { text_inset, .. } | LineMark::Check { text_inset, .. } => text_inset,
+            LineMark::Rule(_) => px(0.),
         }
     }
 }
@@ -2155,18 +2159,42 @@ fn shape_document(
             None
         };
         let caret_here = caret_col.is_some();
-        let mark = gutter
-            .filter(|_| !caret_here && !full_source)
-            .map(|(_, m)| m);
+        // A thematic break (`---`) renders as a full-width divider, but only while
+        // the caret is off it; on the line it reads as the raw `---` (editable).
+        let is_rule = !is_code
+            && widget.is_none()
+            && table.is_none()
+            && !caret_here
+            && !full_source
+            && md.is_some()
+            && markdown_syntax::thematic_break(line);
+        let mark = if is_rule {
+            md.map(|st| LineMark::Rule(st.quote))
+        } else {
+            gutter
+                .filter(|_| !caret_here && !full_source)
+                .map(|(_, m)| m)
+        };
         let reveal_prefix = gutter.filter(|_| caret_here).map_or(0, |(plen, _)| plen);
+        // Footnote definitions (`[^1]: …`) and raw-HTML lines render muted, the way
+        // the reading view shows them — a whole-line color, no hidden markers.
+        let muted_line = md
+            .filter(|_| !is_code && widget.is_none() && table.is_none())
+            .filter(|_| {
+                markdown_syntax::footnote_def(line).is_some() || markdown_syntax::html_block(line)
+            })
+            .map(|st| st.quote);
         // A blockquote's body is muted; a list keeps the normal body color (only
         // its bullet is muted).
         let line_base = match mark {
             Some(LineMark::Quote(c)) => c,
-            _ => base_color,
+            _ => muted_line.unwrap_or(base_color),
         };
         let (shaped_text, runs, bg, map) = if collapse_fence {
             // Hidden ``` fence line: nothing painted, zero height.
+            (String::new(), Vec::new(), None, None)
+        } else if is_rule {
+            // Thematic break: the divider is painted from the mark; no body text.
             (String::new(), Vec::new(), None, None)
         } else if let Some(st) = md.filter(|_| is_code) {
             // One monospace run for the whole line; ``` delimiters dimmed.
@@ -2283,10 +2311,10 @@ fn shape_document(
     (wrapped, heights, widgets, backgrounds, tables, maps, marks)
 }
 
-/// Paint a file chip — a rounded, bordered button with a 📄 icon + `label` —
-/// filling the row (sized in `shape_document` to include vertical padding), its
-/// width fit to the label. Left-click opens it, right-click edits (handled by the
-/// mouse handlers via `chip_rows`).
+/// Paint a file chip — a rounded, bordered button with a flat document icon +
+/// `label` — filling the row (sized in `shape_document` to include vertical
+/// padding), its width fit to the label. Left-click opens it, right-click edits
+/// (handled by the mouse handlers via `chip_rows`).
 #[allow(clippy::too_many_arguments)]
 fn paint_chip(
     label: &str,
@@ -2300,7 +2328,7 @@ fn paint_chip(
     window: &mut Window,
     cx: &mut App,
 ) {
-    let text = SharedString::from(format!("📄  {label}"));
+    let text = SharedString::from(label.to_string());
     let run = TextRun {
         len: text.len(),
         font: font.clone(),
@@ -2313,7 +2341,10 @@ fn paint_chip(
         .text_system()
         .shape_line(text, font_size, &[run], None);
     let pad_x = px(10.);
-    let box_w = shaped.width() + pad_x * 2.;
+    let icon_h = font_size * 0.92;
+    let icon_w = icon_h * 0.74;
+    let gap = px(7.); // between the icon and the label
+    let box_w = pad_x * 2. + icon_w + gap + shaped.width();
     window.paint_quad(PaintQuad {
         bounds: Bounds::new(origin, size(box_w, row_h)),
         corner_radii: Corners::all(px(6.)),
@@ -2322,15 +2353,59 @@ fn paint_chip(
         border_color: border,
         border_style: BorderStyle::Solid,
     });
+    let ix = origin.x + pad_x;
+    paint_doc_icon(
+        ix,
+        origin.y + (row_h - icon_h) / 2.,
+        icon_w,
+        icon_h,
+        link,
+        window,
+    );
     let line_h = font_size * LINE_HEIGHT_RATIO;
     let _ = shaped.paint(
-        point(origin.x + pad_x, origin.y + (row_h - line_h) / 2.),
+        point(ix + icon_w + gap, origin.y + (row_h - line_h) / 2.),
         line_h,
         gpui::TextAlign::Left,
         None,
         window,
         cx,
     );
+}
+
+/// Paint a flat, line-art document glyph (a page with a folded top-right corner +
+/// two text lines) in `color`, the chip's file icon. Drawn with strokes — not a
+/// font emoji — so it reads flat and on-theme at the text's size.
+fn paint_doc_icon(x: Pixels, y: Pixels, w: Pixels, h: Pixels, color: Hsla, window: &mut Window) {
+    let f = w * 0.33; // folded-corner size
+    // Page silhouette, with the top-right corner cut away for the fold.
+    let mut outline = PathBuilder::stroke(px(1.3));
+    outline.move_to(point(x, y));
+    outline.line_to(point(x + w - f, y));
+    outline.line_to(point(x + w, y + f));
+    outline.line_to(point(x + w, y + h));
+    outline.line_to(point(x, y + h));
+    outline.line_to(point(x, y));
+    if let Ok(p) = outline.build() {
+        window.paint_path(p, color);
+    }
+    // The folded corner (dog-ear).
+    let mut fold = PathBuilder::stroke(px(1.3));
+    fold.move_to(point(x + w - f, y));
+    fold.line_to(point(x + w - f, y + f));
+    fold.line_to(point(x + w, y + f));
+    if let Ok(p) = fold.build() {
+        window.paint_path(p, color);
+    }
+    // Two short text lines below the fold.
+    for fy in [0.6_f32, 0.78] {
+        let mut ln = PathBuilder::stroke(px(1.));
+        ln.move_to(point(x + w * 0.26, y + h * fy));
+        ln.line_to(point(x + w * 0.74, y + h * fy));
+        if let Ok(p) = ln.build() {
+            window.paint_path(p, color);
+        }
+    }
 }
 
 /// Content-fit column widths for a table region (W4c): each column sized to its
@@ -3049,6 +3124,12 @@ impl Element for EditorElement {
             // past it by QUOTE_INSET).
             if let Some(LineMark::Quote(c)) = prepaint.marks.get(i).copied().flatten() {
                 window.paint_quad(fill(Bounds::new(origin, size(px(2.), *lh)), c));
+            }
+            // Thematic break: a 1px full-width divider centered in the row.
+            if let Some(LineMark::Rule(c)) = prepaint.marks.get(i).copied().flatten() {
+                let y = origin.y + (*lh - px(1.)) / 2.;
+                let w = bounds.size.width;
+                window.paint_quad(fill(Bounds::new(point(origin.x, y), size(w, px(1.))), c));
             }
             // List item: a muted bullet (`•`) or number (`N.`) glyph where the
             // hidden source marker began (`bullet_x`); the body is inset to the

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -132,6 +132,10 @@ const CODE_PAD: f32 = 8.;
 /// room for the left border (2px) + a gap, matching the reading view's `pl(12)`.
 const QUOTE_INSET: f32 = 14.;
 
+/// Width (px) of a list item's bullet/number column — the body text is inset this
+/// far past the item's indent, leaving room for the painted `•` / `N.` + a gap.
+const BULLET_COL: f32 = 22.;
+
 /// A restorable editor state, for undo/redo. Stores the caret offset (not a
 /// selection), so undo/redo place the caret rather than re-selecting text.
 #[derive(Clone)]
@@ -1398,6 +1402,14 @@ enum LineMark {
     /// Blockquote: a muted left border; the `>` markers are hidden and the body
     /// text is muted (`SyntaxStyle::quote`).
     Quote(Hsla),
+    /// List item: a painted bullet (`•`) or number (`N.`) at `indent`, muted; the
+    /// source marker is hidden and the body inset past the bullet column.
+    List {
+        indent: Pixels,
+        ordered: bool,
+        num: u32,
+        color: Hsla,
+    },
 }
 
 impl LineMark {
@@ -1405,6 +1417,7 @@ impl LineMark {
     fn inset(self) -> Pixels {
         match self {
             LineMark::Quote(_) => px(QUOTE_INSET),
+            LineMark::List { indent, .. } => indent + px(BULLET_COL),
         }
     }
 }
@@ -1652,23 +1665,41 @@ fn shape_document(
                 })
             })
             .collect();
-        // Gutter decoration (blockquote for now): a non-code/widget/table line
-        // beginning with `>`. The decoration (muted text + left border, `>`
-        // hidden) shows only while the caret is OFF the line; on the line it reads
-        // as plain source with the `>` revealed (a line-level reveal — the whole
-        // prefix shows wherever the caret sits on the line, unlike inline #5).
-        let quote_prefix = md
+        // Gutter decoration (blockquote / list): a non-code/widget/table line with
+        // a `>` or list marker. The decoration (border / bullet, marker hidden,
+        // body inset) shows only while the caret is OFF the line; on the line it
+        // reads as plain source with the prefix revealed (a line-level reveal — the
+        // whole prefix shows wherever the caret sits, unlike inline #5).
+        let gutter: Option<(usize, LineMark)> = md
             .filter(|_| !is_code && widget.is_none() && table.is_none())
-            .and_then(|_| markdown_syntax::blockquote_prefix(line));
+            .and_then(|st| {
+                if let Some(plen) = markdown_syntax::blockquote_prefix(line) {
+                    Some((plen, LineMark::Quote(st.quote)))
+                } else {
+                    markdown_syntax::list_prefix(line).map(|(plen, indent, ordered, num)| {
+                        let indent_px = px(indent as f32 * f32::from(fs) * 0.5);
+                        (
+                            plen,
+                            LineMark::List {
+                                indent: indent_px,
+                                ordered,
+                                num,
+                                color: st.quote,
+                            },
+                        )
+                    })
+                }
+            });
         let caret_here = caret_col.is_some();
-        let mark = quote_prefix
+        let mark = gutter
             .filter(|_| !caret_here && !full_source)
-            .and(md)
-            .map(|st| LineMark::Quote(st.quote));
-        let reveal_prefix = quote_prefix.filter(|_| caret_here).unwrap_or(0);
+            .map(|(_, m)| m);
+        let reveal_prefix = gutter.filter(|_| caret_here).map_or(0, |(plen, _)| plen);
+        // A blockquote's body is muted; a list keeps the normal body color (only
+        // its bullet is muted).
         let line_base = match mark {
             Some(LineMark::Quote(c)) => c,
-            None => base_color,
+            _ => base_color,
         };
         let (shaped_text, runs, bg, map) = if collapse_fence {
             // Hidden ``` fence line: nothing painted, zero height.
@@ -2302,6 +2333,40 @@ impl Element for EditorElement {
             // past it by QUOTE_INSET).
             if let Some(LineMark::Quote(c)) = prepaint.marks.get(i).copied().flatten() {
                 window.paint_quad(fill(Bounds::new(origin, size(px(2.), *lh)), c));
+            }
+            // List item: a muted bullet (`•`) or number (`N.`) at the item's
+            // indent; the body is inset past it (the source marker is hidden).
+            if let Some(LineMark::List {
+                indent,
+                ordered,
+                num,
+                color,
+            }) = prepaint.marks.get(i).copied().flatten()
+            {
+                let glyph: SharedString = if ordered {
+                    format!("{num}.").into()
+                } else {
+                    "•".into()
+                };
+                let run = TextRun {
+                    len: glyph.len(),
+                    font: font.clone(),
+                    color,
+                    background_color: None,
+                    underline: None,
+                    strikethrough: None,
+                };
+                let shaped = window
+                    .text_system()
+                    .shape_line(glyph, font_size, &[run], None);
+                let _ = shaped.paint(
+                    point(origin.x + indent, origin.y),
+                    *lh,
+                    gpui::TextAlign::Left,
+                    None,
+                    window,
+                    cx,
+                );
             }
             if let Some(t) = prepaint.tables.get(i).and_then(Option::as_ref) {
                 // Table grid row (W4c): cells + borders instead of source.

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -18,15 +18,16 @@
 //! once at startup so the editing actions resolve while it's focused.
 
 use std::ops::Range;
+use std::sync::Arc;
 
 use gpui::{
-    App, AvailableSpace, Bounds, ClipboardItem, Context, CursorStyle, Element, ElementId,
+    App, AvailableSpace, Bounds, ClipboardItem, Context, Corners, CursorStyle, Element, ElementId,
     ElementInputHandler, Entity, EntityInputHandler, EventEmitter, FocusHandle, Focusable, Font,
     GlobalElementId, Hsla, InspectorElementId, InteractiveElement, IntoElement, KeyBinding,
     LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, ParentElement,
-    Pixels, Point, Render, ScrollHandle, SharedString, StatefulInteractiveElement, Style, Styled,
-    TextRun, UTF16Selection, Window, WrappedLine, actions, div, fill, hsla, point, px, relative,
-    rgb, rgba, size,
+    Pixels, Point, Render, RenderImage, ScrollHandle, SharedString, StatefulInteractiveElement,
+    Style, Styled, TextRun, UTF16Selection, Window, WrappedLine, actions, div, fill, hsla, point,
+    px, relative, rgb, rgba, size,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -170,6 +171,12 @@ pub enum EditorEvent {
 /// host via [`EditorState::on_suggest`] and consulted on right-click.
 type SuggestFn = Box<dyn Fn(&str) -> Vec<String>>;
 
+/// Resolves a standalone image line's `src` to a decoded image so the editor can
+/// render it inline (W4). Set by the host via
+/// [`EditorState::set_block_image_provider`]; the host owns loading + caching and
+/// returns `None` while still decoding / on failure (the line shows raw source).
+type BlockImageFn = Box<dyn Fn(&str) -> Option<Arc<RenderImage>>>;
+
 /// The editor: text + cursor/selection state, an undo/redo history, plus a
 /// cached layout (the wrapped lines from the last paint) for hit-testing + IME.
 pub struct EditorState {
@@ -191,6 +198,10 @@ pub struct EditorState {
     /// a taller row (W2); `line_height` is the base/fallback for the empty doc
     /// and any row without a recorded height.
     line_heights: Vec<Pixels>,
+    /// Per-logical-line flag: this row is painted as an inline image (W4), so a
+    /// click on it places the caret at the line start instead of hit-testing
+    /// source text. From the last paint.
+    widget_rows: Vec<bool>,
     last_bounds: Option<Bounds<Pixels>>,
     line_height: Pixels,
     is_selecting: bool,
@@ -212,6 +223,9 @@ pub struct EditorState {
     /// the user right-clicks it. Set by the host via [`Self::on_suggest`];
     /// without it, the right-click menu has nothing to offer.
     suggest: Option<SuggestFn>,
+    /// Resolves a standalone image line's `src` to a decoded image for inline
+    /// rendering (W4); set by the host via [`Self::set_block_image_provider`].
+    block_image: Option<BlockImageFn>,
 }
 
 impl EditorState {
@@ -226,6 +240,7 @@ impl EditorState {
             wrapped: Vec::new(),
             line_tops: Vec::new(),
             line_heights: Vec::new(),
+            widget_rows: Vec::new(),
             last_bounds: None,
             line_height: px(20.),
             is_selecting: false,
@@ -237,6 +252,7 @@ impl EditorState {
             markdown_style: None,
             menu: None,
             suggest: None,
+            block_image: None,
         }
     }
 
@@ -302,6 +318,17 @@ impl EditorState {
     /// on right-click, never in the per-edit detection pass.
     pub fn on_suggest(&mut self, provider: impl Fn(&str) -> Vec<String> + 'static) {
         self.suggest = Some(Box::new(provider));
+    }
+
+    /// Install the provider that resolves a standalone image line's `src` to a
+    /// decoded image; with it, such lines render inline (W4) when the caret is
+    /// elsewhere. Without it (or while an image is still loading), the line shows
+    /// its raw `![](src)` source.
+    pub fn set_block_image_provider(
+        &mut self,
+        provider: impl Fn(&str) -> Option<Arc<RenderImage>> + 'static,
+    ) {
+        self.block_image = Some(Box::new(provider));
     }
 
     /// The caret's byte offset into [`Self::text`] (the moving end of any
@@ -888,6 +915,11 @@ impl EditorState {
                 break;
             }
         }
+        // An inline-image row: clicking it puts the caret at the line start (the
+        // line then shows its source — "raw on caret"), not a text column.
+        if self.widget_rows.get(row).copied().unwrap_or(false) {
+            return self.line_starts()[row];
+        }
         let line_rel = point(rel.x, rel.y - self.line_tops[row]);
         let col = match self.wrapped[row].closest_index_for_position(line_rel, self.line_h(row)) {
             Ok(i) | Err(i) => i,
@@ -1273,13 +1305,47 @@ fn shape_runs(
         .unwrap_or_default()
 }
 
+/// A line currently rendered as an inline image (W4) instead of its source text:
+/// the decoded image plus its fit-to-width display size (logical px).
+#[derive(Clone)]
+struct BlockImg {
+    img: Arc<RenderImage>,
+    width: Pixels,
+    height: Pixels,
+}
+
+/// Fit-to-width display size for an inline image from its natural (device) size:
+/// cap to the content width (or an explicit `{width=N}`), preserving aspect.
+fn block_img(
+    img: Arc<RenderImage>,
+    width_attr: Option<f32>,
+    wrap_width: Option<Pixels>,
+    scale_factor: f32,
+) -> Option<BlockImg> {
+    let dev = img.size(0);
+    let (dw, dh) = (dev.width.0 as f32, dev.height.0 as f32);
+    if dw <= 0. || dh <= 0. || scale_factor <= 0. {
+        return None;
+    }
+    let natural_w = dw / scale_factor;
+    let avail = wrap_width.map_or(natural_w, f32::from);
+    let target_w = width_attr.unwrap_or(natural_w).min(avail).max(1.);
+    Some(BlockImg {
+        img,
+        width: px(target_w),
+        height: px(target_w * dh / dw),
+    })
+}
+
 /// Shape `content` line-by-line so each logical line can use its own font size
-/// (headings are larger — W2). Returns one [`WrappedLine`] per logical line and
-/// each line's wrap-row height. `md` drives the per-line size and inline styling
-/// (`None` keeps every line at the base size); `diagnostics` are clipped and
-/// shifted to each line. A single line (no newline) always shapes to exactly one
-/// wrapped line, including an empty line, so the count matches the logical lines
-/// and blank rows stay positionable.
+/// (headings are larger — W2) and a standalone image line can render as the image
+/// (W4). Returns, per logical line: the shaped source [`WrappedLine`], its row
+/// height, and `Some(BlockImg)` when it paints as an image. `md` drives the
+/// per-line size + inline styling (`None` keeps the base size, no images);
+/// `diagnostics` are clipped + shifted to each line. The caret's line
+/// (`caret_row`) always shows source, so an image stays editable ("raw on
+/// caret"). A single line always shapes to one wrapped line (incl. empty), so the
+/// counts match the logical lines and blank rows stay positionable.
 #[allow(clippy::too_many_arguments)]
 fn shape_document(
     window: &mut Window,
@@ -1290,13 +1356,30 @@ fn shape_document(
     diagnostics: &[Diagnostic],
     md: Option<&SyntaxStyle>,
     wrap_width: Option<Pixels>,
-) -> (Vec<WrappedLine>, Vec<Pixels>) {
+    caret_row: Option<usize>,
+    block_image: Option<&BlockImageFn>,
+    scale_factor: f32,
+) -> (Vec<WrappedLine>, Vec<Pixels>, Vec<Option<BlockImg>>) {
     let mut wrapped = Vec::new();
     let mut heights = Vec::new();
+    let mut widgets = Vec::new();
     let mut line_start = 0;
-    for line in content.split('\n') {
+    for (idx, line) in content.split('\n').enumerate() {
         let line_end = line_start + line.len();
         let fs = base_font_size * md.map_or(1.0, |_| markdown_syntax::line_scale(line));
+
+        // Inline image: a standalone image line that isn't the caret's line and
+        // has a decoded image renders as that image, fit to the content width.
+        let widget = if md.is_some()
+            && Some(idx) != caret_row
+            && let Some((src, w_attr)) = markdown_syntax::image_line(line)
+            && let Some(img) = block_image.and_then(|f| f(src))
+        {
+            block_img(img, w_attr, wrap_width, scale_factor)
+        } else {
+            None
+        };
+
         // Diagnostics overlapping this line, shifted to line-relative ranges.
         let line_diags: Vec<Diagnostic> = diagnostics
             .iter()
@@ -1317,12 +1400,14 @@ fn shape_document(
             wrap_width,
         );
         if let Some(wl) = shaped.into_iter().next() {
+            let h = widget.as_ref().map_or(fs * LINE_HEIGHT_RATIO, |w| w.height);
             wrapped.push(wl);
-            heights.push(fs * LINE_HEIGHT_RATIO);
+            heights.push(h);
+            widgets.push(widget);
         }
         line_start = line_end + 1; // skip the '\n'
     }
-    (wrapped, heights)
+    (wrapped, heights, widgets)
 }
 
 /// The custom element that lays out + paints the editor's wrapped lines, cursor,
@@ -1336,8 +1421,10 @@ struct PrepaintState {
     wrapped: Vec<WrappedLine>,
     /// Top offset of each logical line relative to the editor's top.
     line_tops: Vec<Pixels>,
-    /// Per-logical-line wrap-row height (variable for headings).
+    /// Per-logical-line wrap-row height (variable for headings + images).
     line_heights: Vec<Pixels>,
+    /// `Some` for a line painted as an inline image instead of its source text.
+    widgets: Vec<Option<BlockImg>>,
     cursor: Option<PaintQuad>,
     selections: Vec<PaintQuad>,
 }
@@ -1399,7 +1486,9 @@ impl Element for EditorElement {
                 base_lh * rows as f32
             } else {
                 // Sum of per-line (variable) heights × each line's wrap rows.
-                let (wrapped, heights) = shape_document(
+                let caret_row = editor.row_col(editor.cursor_offset()).0;
+                let sf = window.scale_factor();
+                let (wrapped, heights, _) = shape_document(
                     window,
                     &editor.content,
                     &text_style.font(),
@@ -1408,6 +1497,9 @@ impl Element for EditorElement {
                     &editor.diagnostics,
                     editor.markdown_style.as_ref(),
                     wrap_width,
+                    Some(caret_row),
+                    editor.block_image.as_ref(),
+                    sf,
                 );
                 wrapped
                     .iter()
@@ -1440,8 +1532,10 @@ impl Element for EditorElement {
         let text_color = style.color;
 
         // Placeholder (uniform) when empty; else shape per line so headings get
-        // their own taller rows (variable line heights — W2).
-        let (wrapped, line_heights) = if editor.content.is_empty() {
+        // their own taller rows (W2) and image lines render inline (W4).
+        let caret_row = editor.row_col(editor.cursor_offset()).0;
+        let sf = window.scale_factor();
+        let (wrapped, line_heights, widgets) = if editor.content.is_empty() {
             let w = shape_all(
                 window,
                 &editor.placeholder,
@@ -1451,7 +1545,8 @@ impl Element for EditorElement {
                 wrap_width,
             );
             let h = vec![base_lh; w.len()];
-            (w, h)
+            let g = vec![None; w.len()];
+            (w, h, g)
         } else {
             shape_document(
                 window,
@@ -1462,6 +1557,9 @@ impl Element for EditorElement {
                 &editor.diagnostics,
                 editor.markdown_style.as_ref(),
                 wrap_width,
+                Some(caret_row),
+                editor.block_image.as_ref(),
+                sf,
             )
         };
 
@@ -1559,6 +1657,7 @@ impl Element for EditorElement {
             wrapped,
             line_tops,
             line_heights,
+            widgets,
             cursor,
             selections,
         }
@@ -1587,14 +1686,21 @@ impl Element for EditorElement {
 
         let base_lh =
             window.text_style().font_size.to_pixels(window.rem_size()) * LINE_HEIGHT_RATIO;
-        for ((line, top), lh) in prepaint
+        for (((line, top), lh), widget) in prepaint
             .wrapped
             .iter()
             .zip(prepaint.line_tops.iter())
             .zip(prepaint.line_heights.iter())
+            .zip(prepaint.widgets.iter())
         {
             let origin = point(bounds.origin.x, bounds.origin.y + *top);
-            let _ = line.paint(origin, *lh, gpui::TextAlign::Left, None, window, cx);
+            if let Some(w) = widget {
+                // Inline image (W4): paint the decoded image instead of source.
+                let img_bounds = Bounds::new(origin, size(w.width, w.height));
+                let _ = window.paint_image(img_bounds, Corners::default(), w.img.clone(), 0, false);
+            } else {
+                let _ = line.paint(origin, *lh, gpui::TextAlign::Left, None, window, cx);
+            }
         }
 
         if focus.is_focused(window)
@@ -1606,10 +1712,12 @@ impl Element for EditorElement {
         let wrapped = std::mem::take(&mut prepaint.wrapped);
         let line_tops = std::mem::take(&mut prepaint.line_tops);
         let line_heights = std::mem::take(&mut prepaint.line_heights);
+        let widget_rows: Vec<bool> = prepaint.widgets.iter().map(Option::is_some).collect();
         self.editor.update(cx, |editor, _| {
             editor.wrapped = wrapped;
             editor.line_tops = line_tops;
             editor.line_heights = line_heights;
+            editor.widget_rows = widget_rows;
             editor.last_bounds = Some(bounds);
             editor.line_height = base_lh;
         });

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -184,6 +184,46 @@ struct DiagMenu {
     scroll: ScrollHandle,
 }
 
+/// A column edit applied to every row of a table (insert/delete a cell at index).
+#[derive(Clone, Copy)]
+enum ColEdit {
+    Insert(usize),
+    Delete(usize),
+}
+
+/// An item in the table right-click menu (Word-style table editing).
+#[derive(Clone, Copy)]
+enum TableMenuAction {
+    InsertRowAbove,
+    InsertRowBelow,
+    InsertColLeft,
+    InsertColRight,
+    DeleteRow,
+    DeleteColumn,
+}
+
+impl TableMenuAction {
+    const ITEMS: &'static [(&'static str, TableMenuAction)] = &[
+        ("Insert row above", TableMenuAction::InsertRowAbove),
+        ("Insert row below", TableMenuAction::InsertRowBelow),
+        ("Insert column left", TableMenuAction::InsertColLeft),
+        ("Insert column right", TableMenuAction::InsertColRight),
+        ("Delete row", TableMenuAction::DeleteRow),
+        ("Delete column", TableMenuAction::DeleteColumn),
+    ];
+
+    fn apply(self, editor: &mut EditorState, cx: &mut Context<EditorState>) {
+        match self {
+            TableMenuAction::InsertRowAbove => editor.insert_table_row(false, cx),
+            TableMenuAction::InsertRowBelow => editor.insert_table_row(true, cx),
+            TableMenuAction::InsertColLeft => editor.insert_table_column(false, cx),
+            TableMenuAction::InsertColRight => editor.insert_table_column(true, cx),
+            TableMenuAction::DeleteRow => editor.delete_table_row(cx),
+            TableMenuAction::DeleteColumn => editor.delete_table_column(cx),
+        }
+    }
+}
+
 /// Events the editor emits so a host can react. Subscribe with
 /// `cx.subscribe(&editor, …)` — e.g. to re-run spell-check after an edit.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -280,6 +320,10 @@ pub struct EditorState {
     undo_stack: Vec<Snapshot>,
     redo_stack: Vec<Snapshot>,
     last_edit: EditKind,
+    /// Whether the last content edit was a single typed grapheme or a single-char
+    /// backspace — the only edits auto-pairing should react to, so programmatic /
+    /// structural edits (table ops, etc.) don't trip it.
+    last_edit_keystroke: bool,
     /// Spaces inserted per Tab / one list-nesting level (`Indent`/`Outdent`); set
     /// by the host via [`Self::set_tab_indent`] to match its list-indent setting.
     tab_indent: usize,
@@ -294,6 +338,9 @@ pub struct EditorState {
     markdown_style: Option<SyntaxStyle>,
     /// The open right-click suggestions menu, if any.
     menu: Option<DiagMenu>,
+    /// The open table right-click menu's anchor (relative to the editor's
+    /// top-left), if any. Its actions operate on the caret's table cell.
+    table_menu: Option<Point<Pixels>>,
     /// Supplies replacement suggestions for a flagged word, fetched lazily when
     /// the user right-clicks it. Set by the host via [`Self::on_suggest`];
     /// without it, the right-click menu has nothing to offer.
@@ -334,11 +381,13 @@ impl EditorState {
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
             last_edit: EditKind::Other,
+            last_edit_keystroke: false,
             tab_indent: 4,
             goal_x: None,
             diagnostics: Vec::new(),
             markdown_style: None,
             menu: None,
+            table_menu: None,
             suggest: None,
             block_image: None,
             block_chip: None,
@@ -454,6 +503,13 @@ impl EditorState {
     /// selection). For hosts that drive a menu/completion off the caret position.
     pub fn cursor(&self) -> usize {
         self.cursor_offset()
+    }
+
+    /// Whether the last content change was a single typed character or single-char
+    /// backspace (vs a programmatic / multi-char edit). Hosts gate auto-pairing on
+    /// this so structural edits (table row/column ops, paste, …) don't trip it.
+    pub fn last_edit_was_keystroke(&self) -> bool {
+        self.last_edit_keystroke
     }
 
     /// Place the caret at `offset` (a byte offset into the document), collapsing
@@ -817,6 +873,11 @@ impl EditorState {
             self.redo_stack.clear();
         }
         self.last_edit = kind;
+        // A keystroke is one typed grapheme (incl. typed over a selection — that's
+        // an auto-pair "wrap") or a single-char backspace. Multi-char edits (paste,
+        // table ops, …) are not, so auto-pairing skips them.
+        self.last_edit_keystroke = (new_text != "\n" && new_text.graphemes(true).count() == 1)
+            || (new_text.is_empty() && self.content[range.clone()].graphemes(true).count() == 1);
     }
 
     // --- Mouse ---------------------------------------------------------------
@@ -839,6 +900,7 @@ impl EditorState {
             .table_offset_at(event.position, window)
             .unwrap_or_else(|| self.index_for_mouse_position(event.position));
         self.menu = None;
+        self.table_menu = None;
         self.goal_x = None;
         self.last_edit = EditKind::Other;
         match event.click_count {
@@ -906,6 +968,21 @@ impl EditorState {
             self.move_to(offset, cx);
             return;
         }
+        // Right-click in a table cell: place the caret there + open the table menu
+        // (insert/delete rows + columns), instead of the spell menu.
+        if let Some(offset) = self.table_offset_at(event.position, window) {
+            self.menu = None;
+            self.focus(window, cx);
+            self.move_to(offset, cx);
+            self.table_menu = Some(
+                self.last_bounds
+                    .as_ref()
+                    .map(|b| point(event.position.x - b.left(), event.position.y - b.top()))
+                    .unwrap_or_default(),
+            );
+            cx.notify();
+            return;
+        }
         let offset = self.index_for_mouse_position(event.position);
         let anchor = self
             .last_bounds
@@ -935,7 +1012,7 @@ impl EditorState {
 
     /// Close the suggestions menu (Escape, or a click elsewhere).
     fn dismiss(&mut self, _: &Dismiss, _: &mut Window, cx: &mut Context<Self>) {
-        if self.menu.take().is_some() {
+        if self.menu.take().is_some() || self.table_menu.take().is_some() {
             cx.notify();
         }
     }
@@ -1347,6 +1424,207 @@ impl EditorState {
         cx.notify();
     }
 
+    /// The caret's table block as `(header_line, separator_line, end_exclusive,
+    /// columns)`, or `None` outside a table.
+    fn caret_table_block(&self) -> Option<(usize, usize, usize, usize)> {
+        let (row, _) = self.row_col(self.cursor_offset());
+        let region = markdown_syntax::table_regions(&self.content)
+            .into_iter()
+            .find(|r| r.lines.contains(&row))?;
+        Some((
+            region.lines.start,
+            region.lines.start + 1,
+            region.lines.end,
+            region.aligns.len().max(1),
+        ))
+    }
+
+    /// Insert an empty row above/below the caret's row (Word-style); the caret
+    /// moves into the new row's first cell. No-op outside a table.
+    pub fn insert_table_row(&mut self, below: bool, cx: &mut Context<Self>) {
+        let (row, _) = self.row_col(self.cursor_offset());
+        let Some((header, sep, _end, cols)) = self.caret_table_block() else {
+            return;
+        };
+        // From the header a new row always lands below the separator (the first
+        // body row); above/below a body row is literal.
+        let after = if row == header {
+            sep
+        } else if below {
+            row
+        } else {
+            (row - 1).max(sep)
+        };
+        let new_row = format!("\n|{}", "  |".repeat(cols));
+        let pos = self.line_end(after);
+        let range = pos..pos;
+        self.record_edit(&range, &new_row);
+        self.content = self.content[..pos].to_owned() + &new_row + &self.content[pos..];
+        self.remap_diagnostics(&range, new_row.len());
+        self.selected_range = (pos + 3)..(pos + 3); // first cell, after "\n| "
+        self.table_menu = None;
+        cx.emit(EditorEvent::Changed);
+        cx.notify();
+    }
+
+    /// Delete the caret's table row (body rows only — the header + separator stay).
+    /// The caret keeps its cell + in-cell offset, landing on the row that takes the
+    /// deleted row's place. No-op outside a table.
+    pub fn delete_table_row(&mut self, cx: &mut Context<Self>) {
+        let Some((row, cell, in_cell)) = self.caret_table_cell_pos() else {
+            return;
+        };
+        let Some((header, sep, end, _cols)) = self.caret_table_block() else {
+            return;
+        };
+        if row == header || row == sep {
+            return;
+        }
+        let start = self.line_starts()[row];
+        let line_end = self.line_end(row);
+        // Remove the line + its trailing newline; for the last line, eat the
+        // preceding newline instead so no blank line is left behind.
+        let (del_start, del_end) = if line_end < self.content.len() {
+            (start, line_end + 1)
+        } else {
+            (start.saturating_sub(1), line_end)
+        };
+        let range = del_start..del_end;
+        self.record_edit(&range, "");
+        self.content = self.content[..del_start].to_owned() + &self.content[del_end..];
+        self.remap_diagnostics(&range, 0);
+        // Stay at the same cell/offset, on the row now at this position (shifted
+        // up), or the header if no body rows remain.
+        let target = if end <= sep + 2 {
+            header
+        } else {
+            row.min(end - 2)
+        };
+        let caret = self.caret_pos_for_cell(target, cell, in_cell);
+        self.selected_range = caret..caret;
+        self.table_menu = None;
+        cx.emit(EditorEvent::Changed);
+        cx.notify();
+    }
+
+    /// The caret's table position as `(row, cell_index, offset_within_cell)`, or
+    /// `None` outside a table. Lets structural edits keep the caret put.
+    fn caret_table_cell_pos(&self) -> Option<(usize, usize, usize)> {
+        let (row, _) = self.row_col(self.cursor_offset());
+        self.caret_table_block()?;
+        let starts = self.line_starts();
+        let row_start = starts[row];
+        let line = &self.content[row_start..self.line_end(row)];
+        let line_col = self.cursor_offset() - row_start;
+        let ranges = markdown_syntax::table_cell_ranges(line);
+        let cell = ranges
+            .iter()
+            .position(|r| line_col <= r.end)
+            .unwrap_or(ranges.len().saturating_sub(1));
+        let in_cell = ranges
+            .get(cell)
+            .map_or(0, |r| line_col.saturating_sub(r.start).min(r.len()));
+        Some((row, cell, in_cell))
+    }
+
+    /// Byte offset of `(row, cell, offset_within_cell)` in the current content,
+    /// clamping the cell + offset to what that row actually has.
+    fn caret_pos_for_cell(&self, row: usize, cell: usize, in_cell: usize) -> usize {
+        let starts = self.line_starts();
+        let Some(&row_start) = starts.get(row) else {
+            return self.content.len();
+        };
+        let line = &self.content[row_start..self.line_end(row)];
+        let ranges = markdown_syntax::table_cell_ranges(line);
+        if ranges.is_empty() {
+            return row_start;
+        }
+        let r = &ranges[cell.min(ranges.len() - 1)];
+        // Keep the caret strictly inside the cell, before its closing pipe — an
+        // empty cell's trimmed range collapses onto that pipe (the line end for the
+        // last cell), which would drop the caret out of the rendered table.
+        let bytes = line.as_bytes();
+        let close = (r.end..bytes.len())
+            .find(|&i| bytes[i] == b'|')
+            .unwrap_or(bytes.len());
+        row_start + (r.start + in_cell).min(close.saturating_sub(1))
+    }
+
+    /// Insert an empty column left/right of the caret's column (a cell added to
+    /// every row; the separator gets a default-left marker). The caret stays in its
+    /// cell. No-op outside a table.
+    pub fn insert_table_column(&mut self, right: bool, cx: &mut Context<Self>) {
+        let Some((row, cell, in_cell)) = self.caret_table_cell_pos() else {
+            return;
+        };
+        let at = if right { cell + 1 } else { cell };
+        if self.rewrite_table_columns(ColEdit::Insert(at)) {
+            // Inserting to the left shifts the caret's cell one column right.
+            let new_cell = if right { cell } else { cell + 1 };
+            let caret = self.caret_pos_for_cell(row, new_cell, in_cell);
+            self.selected_range = caret..caret;
+            self.table_menu = None;
+            cx.emit(EditorEvent::Changed);
+            cx.notify();
+        }
+    }
+
+    /// Delete the caret's column from every row; the caret stays near where the
+    /// column was. No-op outside a table, or on the last remaining column.
+    pub fn delete_table_column(&mut self, cx: &mut Context<Self>) {
+        let Some((row, cell, in_cell)) = self.caret_table_cell_pos() else {
+            return;
+        };
+        if self.rewrite_table_columns(ColEdit::Delete(cell)) {
+            let caret = self.caret_pos_for_cell(row, cell, in_cell);
+            self.selected_range = caret..caret;
+            self.table_menu = None;
+            cx.emit(EditorEvent::Changed);
+            cx.notify();
+        }
+    }
+
+    /// Rewrite every row of the caret's table to insert/delete a cell, normalizing
+    /// cell spacing. Returns `false` (no edit) outside a table or when a delete
+    /// would remove the last column; the caller restores the caret.
+    fn rewrite_table_columns(&mut self, edit: ColEdit) -> bool {
+        let Some((header, sep, end, _cols)) = self.caret_table_block() else {
+            return false;
+        };
+        let lines: Vec<&str> = self.content.split('\n').collect();
+        let mut new_rows: Vec<String> = Vec::with_capacity(end - header);
+        for (i, &line) in lines[header..end].iter().enumerate() {
+            let is_sep = header + i == sep;
+            let mut cells: Vec<String> = markdown_syntax::table_cells(line)
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect();
+            match edit {
+                ColEdit::Insert(at) => cells.insert(
+                    at.min(cells.len()),
+                    if is_sep { "---".into() } else { String::new() },
+                ),
+                ColEdit::Delete(c) => {
+                    if cells.len() <= 1 || c >= cells.len() {
+                        return false; // never delete the last column
+                    }
+                    cells.remove(c);
+                }
+            }
+            new_rows.push(format!("| {} |", cells.join(" | ")));
+        }
+        let starts = self.line_starts();
+        let block_start = starts[header];
+        let block_end = self.line_end(end - 1);
+        let new_block = new_rows.join("\n");
+        let range = block_start..block_end;
+        self.record_edit(&range, &new_block);
+        self.content =
+            self.content[..block_start].to_owned() + &new_block + &self.content[block_end..];
+        self.remap_diagnostics(&range, new_block.len());
+        true
+    }
+
     fn index_for_mouse_position(&self, position: Point<Pixels>) -> usize {
         if self.content.is_empty() || self.wrapped.is_empty() {
             return 0;
@@ -1725,6 +2003,49 @@ impl Render for EditorState {
                             .children(rows),
                     )
                     .children(thumb)
+            }))
+            // The table right-click menu (Word-style row/column editing), anchored
+            // at the click; each row runs its action on the caret's table cell.
+            .children(self.table_menu.map(|anchor| {
+                let rows: Vec<_> = TableMenuAction::ITEMS
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &(label, action))| {
+                        div()
+                            .id(("table-menu-row", i))
+                            .flex_shrink_0()
+                            .px(px(12.))
+                            .py(px(5.))
+                            .hover(|s| s.bg(rgb(0x2f6fd6)))
+                            .child(SharedString::from(label))
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |editor, _: &MouseDownEvent, _, cx| {
+                                    cx.stop_propagation();
+                                    action.apply(editor, cx);
+                                }),
+                            )
+                    })
+                    .collect();
+                div()
+                    .absolute()
+                    .left(anchor.x)
+                    .top(anchor.y)
+                    .min_w(px(170.))
+                    .cursor(CursorStyle::Arrow)
+                    .bg(rgb(0x26262b))
+                    .border_1()
+                    .border_color(rgb(0x45454c))
+                    .rounded(px(6.))
+                    .overflow_hidden()
+                    .text_color(rgb(0xe6e6e6))
+                    .text_size(px(14.))
+                    .py(px(4.))
+                    .on_mouse_down_out(cx.listener(|editor, _: &MouseDownEvent, _, cx| {
+                        editor.table_menu = None;
+                        cx.notify();
+                    }))
+                    .children(rows)
             }))
     }
 }

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -614,6 +614,24 @@ impl EditorState {
     }
 
     fn newline(&mut self, _: &Newline, window: &mut Window, cx: &mut Context<Self>) {
+        // Inside a table, the caret sits at a source offset *within a cell*, so a
+        // raw newline would split the row's `| … |` markup. Instead, exit the
+        // table: drop the caret onto a fresh line just below it.
+        if self.caret_in_table() {
+            let (row, _) = self.row_col(self.cursor_offset());
+            let mut last = row;
+            while self
+                .table_rows
+                .get(last + 1)
+                .and_then(Option::as_ref)
+                .is_some()
+            {
+                last += 1;
+            }
+            let starts = self.line_starts();
+            let end = starts.get(last + 1).map_or(self.content.len(), |&s| s - 1);
+            self.selected_range = end..end;
+        }
         self.replace_text_in_range(None, "\n", window, cx);
     }
 
@@ -1754,7 +1772,14 @@ struct TableRow {
     is_header: bool,
     is_separator: bool,
     is_last: bool,
+    /// 0-based position among the body rows (`None` for header/separator) — drives
+    /// striping (shade odd indices) + the rule-under-header (index 0).
+    body_index: Option<usize>,
+    /// The table's visual style (from its `<!-- table:STYLE -->` marker).
+    style: markdown_syntax::TableStyle,
     border: Hsla,
+    /// Row-shade color for striped / header-shaded styles (a faint tint).
+    shade: Hsla,
 }
 
 /// A per-line "gutter" decoration: a left-margin treatment that hides its source
@@ -2011,6 +2036,10 @@ fn shape_document(
             && !code_regions
                 .iter()
                 .any(|r| r.contains(&idx) && caret_row.is_some_and(|cr| r.contains(&cr)));
+        // A `<!-- table:STYLE -->` marker line collapses (hidden) too, unless the
+        // caret lands on it — so the style stays out of the way but is editable.
+        let collapse_marker =
+            caret_row != Some(idx) && regions.iter().any(|r| r.marker_line == Some(idx));
 
         // Leaving a code block: size the box to its widest line (+ the inset on
         // each side, like a table) and mark its last line so the box rounds + pads
@@ -2083,7 +2112,11 @@ fn shape_document(
                     is_header: idx == r.lines.start,
                     is_separator: idx == r.lines.start + 1,
                     is_last: idx + 1 == r.lines.end,
+                    // 0 for the first body row; None for the header/separator.
+                    body_index: idx.checked_sub(r.lines.start + 2),
+                    style: r.style,
                     border: md.map_or(base_color, |m| m.marker),
+                    shade: md.map_or(hsla(0., 0., 0., 0.), |m| m.code_bg),
                 }
             });
 
@@ -2190,8 +2223,8 @@ fn shape_document(
             Some(LineMark::Quote(c)) => c,
             _ => muted_line.unwrap_or(base_color),
         };
-        let (shaped_text, runs, bg, map) = if collapse_fence {
-            // Hidden ``` fence line: nothing painted, zero height.
+        let (shaped_text, runs, bg, map) = if collapse_fence || collapse_marker {
+            // Hidden ``` fence line or table-style marker: nothing, zero height.
             (String::new(), Vec::new(), None, None)
         } else if is_rule {
             // Thematic break: the divider is painted from the mark; no body text.
@@ -2265,7 +2298,7 @@ fn shape_document(
             line_wrap,
         );
         if let Some(wl) = shaped.into_iter().next() {
-            let h = if collapse_fence {
+            let h = if collapse_fence || collapse_marker {
                 px(0.)
             } else {
                 match &table {
@@ -2606,16 +2639,38 @@ fn paint_table_row(
     window: &mut Window,
     cx: &mut App,
 ) {
+    use markdown_syntax::TableStyle;
     let thick = px(1.);
     // The collapsed `|---|` separator draws nothing — the outer box + the next
     // row's top divider form the header/body border.
     if t.is_separator {
         return;
     }
+    let style = t.style;
+    let vlines = matches!(style, TableStyle::Grid);
+    // A single rule under the header (Striped/Minimal) vs a divider under every
+    // row (Grid) vs none (Header).
+    let header_rule = matches!(style, TableStyle::Striped | TableStyle::Minimal);
     let table_w = t.col_widths.iter().fold(px(0.), |a, &w| a + w);
-    // Inter-row divider at the top of every row except the header (the outer box's
-    // top border covers that one).
-    if !t.is_header {
+    // Row shading (painted first, behind everything): the header for the Header
+    // style; alternate body rows for Striped.
+    let shaded = match style {
+        TableStyle::Header => t.is_header,
+        TableStyle::Striped => t.body_index.is_some_and(|b| b % 2 == 1),
+        _ => false,
+    };
+    if shaded {
+        window.paint_quad(fill(Bounds::new(origin, size(table_w, row_h)), t.shade));
+    }
+    // Horizontal divider at the row's top: under every row (Grid, header excepted —
+    // the box covers it), or just under the header (Striped/Minimal: the first body
+    // row's top), or never (Header).
+    let top_divider = if matches!(style, TableStyle::Grid) {
+        !t.is_header
+    } else {
+        header_rule && t.body_index == Some(0)
+    };
+    if top_divider {
         window.paint_quad(fill(Bounds::new(origin, size(table_w, thick)), t.border));
     }
     let pad = px(TABLE_CELL_PAD);
@@ -2625,9 +2680,9 @@ fn paint_table_row(
     }
     let mut x = origin.x;
     for (c, &cw) in t.col_widths.iter().enumerate() {
-        // Inner cell separator at the left of every cell except the first (the box
-        // provides the outer-left border).
-        if c > 0 {
+        // Inner cell separator at the left of every cell except the first (Grid
+        // only; the other styles drop vertical lines).
+        if vlines && c > 0 {
             window.paint_quad(fill(
                 Bounds::new(point(x, origin.y), size(thick, row_h)),
                 t.border,
@@ -3200,9 +3255,10 @@ impl Element for EditorElement {
             }
             if let Some(t) = prepaint.tables.get(i).and_then(Option::as_ref) {
                 // The header row paints the whole table's rounded outer border
-                // (one box around all its rows, matching the reading view); each
-                // row then paints its inner dividers + cell text.
-                if t.is_header {
+                // (one box around all its rows, matching the reading view) — for the
+                // Grid style only; the others are box-less. Each row then paints its
+                // shading, dividers, + cell text.
+                if t.is_header && matches!(t.style, markdown_syntax::TableStyle::Grid) {
                     let mut total_h = px(0.);
                     for j in i..prepaint.tables.len() {
                         match prepaint.tables[j].as_ref() {

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -136,6 +136,10 @@ const QUOTE_INSET: f32 = 14.;
 /// far past the item's indent, leaving room for the painted `•` / `N.` + a gap.
 const BULLET_COL: f32 = 22.;
 
+/// Vertical padding (px) inside a file chip (e.g. a PDF embed), above + below its
+/// label, so the chip box reads as a button rather than a bare line of text.
+const CHIP_PAD: f32 = 5.;
+
 /// A restorable editor state, for undo/redo. Stores the caret offset (not a
 /// selection), so undo/redo place the caret rather than re-selecting text.
 #[derive(Clone)]
@@ -178,11 +182,14 @@ struct DiagMenu {
 
 /// Events the editor emits so a host can react. Subscribe with
 /// `cx.subscribe(&editor, …)` — e.g. to re-run spell-check after an edit.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EditorEvent {
     /// The document text changed via a user edit (typing, delete, paste, IME,
     /// applying a suggestion). Not emitted for programmatic `set_text`.
     Changed,
+    /// A file chip (e.g. a PDF embed) was left-clicked — the host opens its
+    /// `src`. The chip itself stays in the document; this is a navigation hint.
+    OpenLink(SharedString),
 }
 
 /// Provides replacement suggestions for a flagged word (best first); set by the
@@ -194,6 +201,12 @@ type SuggestFn = Box<dyn Fn(&str) -> Vec<String>>;
 /// [`EditorState::set_block_image_provider`]; the host owns loading + caching and
 /// returns `None` while still decoding / on failure (the line shows raw source).
 type BlockImageFn = Box<dyn Fn(&str) -> Option<Arc<RenderImage>>>;
+
+/// Classifies an `![](src)` reference as a file chip (e.g. a PDF) rather than an
+/// image, returning its display label. Set via
+/// [`EditorState::set_block_chip_provider`]; the editor renders such a line as a
+/// clickable chip (left-click emits [`EditorEvent::OpenLink`]).
+type BlockChipFn = Box<dyn Fn(&str) -> Option<SharedString>>;
 
 /// The editor: text + cursor/selection state, an undo/redo history, plus a
 /// cached layout (the wrapped lines from the last paint) for hit-testing + IME.
@@ -251,6 +264,12 @@ pub struct EditorState {
     /// Resolves a standalone image line's `src` to a decoded image for inline
     /// rendering (W4); set by the host via [`Self::set_block_image_provider`].
     block_image: Option<BlockImageFn>,
+    /// Classifies an `![](src)` as a file chip (e.g. a PDF) + its label; set by
+    /// the host via [`Self::set_block_chip_provider`].
+    block_chip: Option<BlockChipFn>,
+    /// Per-logical-line `src` for rows painted as a file chip (from the last
+    /// paint), so a left-click can open it and a right-click can edit it.
+    chip_rows: Vec<Option<SharedString>>,
 }
 
 impl EditorState {
@@ -280,6 +299,8 @@ impl EditorState {
             menu: None,
             suggest: None,
             block_image: None,
+            block_chip: None,
+            chip_rows: Vec::new(),
         }
     }
 
@@ -356,6 +377,17 @@ impl EditorState {
         provider: impl Fn(&str) -> Option<Arc<RenderImage>> + 'static,
     ) {
         self.block_image = Some(Box::new(provider));
+    }
+
+    /// Install the provider that classifies an `![](src)` reference as a file chip
+    /// (e.g. a PDF) and supplies its label. With it, such lines render as a
+    /// clickable chip when the caret is elsewhere; a left-click emits
+    /// [`EditorEvent::OpenLink`] and a right-click places the caret to edit.
+    pub fn set_block_chip_provider(
+        &mut self,
+        provider: impl Fn(&str) -> Option<SharedString> + 'static,
+    ) {
+        self.block_chip = Some(Box::new(provider));
     }
 
     /// The caret's byte offset into [`Self::text`] (the moving end of any
@@ -638,6 +670,12 @@ impl EditorState {
     // --- Mouse ---------------------------------------------------------------
 
     fn on_mouse_down(&mut self, event: &MouseDownEvent, _: &mut Window, cx: &mut Context<Self>) {
+        // Left-click a file chip (e.g. a PDF embed) opens it rather than editing —
+        // the host handles the link. Right-click edits (see on_right_mouse_down).
+        if let Some(src) = self.chip_at(event.position) {
+            cx.emit(EditorEvent::OpenLink(src));
+            return;
+        }
         let offset = self.index_for_mouse_position(event.position);
         self.menu = None;
         self.goal_x = None;
@@ -687,9 +725,18 @@ impl EditorState {
     fn on_right_mouse_down(
         &mut self,
         event: &MouseDownEvent,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Right-click a file chip places the caret to edit its source (the line
+        // then reveals raw `![](src)`), instead of opening the spell menu.
+        if self.chip_at(event.position).is_some() {
+            self.menu = None;
+            self.focus(window, cx);
+            let offset = self.index_for_mouse_position(event.position);
+            self.move_to(offset, cx);
+            return;
+        }
         let offset = self.index_for_mouse_position(event.position);
         let anchor = self
             .last_bounds
@@ -928,6 +975,25 @@ impl EditorState {
     fn select_word_right(&mut self, _: &SelectWordRight, _: &mut Window, cx: &mut Context<Self>) {
         self.goal_x = None;
         self.select_to(self.next_word(self.cursor_offset()), cx);
+    }
+
+    /// The `src` of a file chip on the row at window `position`, if that row is a
+    /// chip (from the last paint) — left-click opens it, right-click edits.
+    fn chip_at(&self, position: Point<Pixels>) -> Option<SharedString> {
+        if self.wrapped.is_empty() || self.chip_rows.iter().all(Option::is_none) {
+            return None;
+        }
+        let bounds = self.last_bounds.as_ref()?;
+        let rel_y = position.y - bounds.top();
+        let mut row = self.wrapped.len() - 1;
+        for i in 0..self.wrapped.len() {
+            let h = self.line_h(i) * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
+            if rel_y < self.line_tops[i] + h {
+                row = i;
+                break;
+            }
+        }
+        self.chip_rows.get(row).and_then(Option::clone)
     }
 
     fn index_for_mouse_position(&self, position: Point<Pixels>) -> usize {
@@ -1366,6 +1432,32 @@ struct BlockImg {
     height: Pixels,
 }
 
+/// A line rendered as a block widget instead of its source text: a standalone
+/// image, or a clickable file chip (e.g. a PDF — left-click opens it, right-click
+/// edits). Shown only while the caret is off the line ("raw on caret").
+#[derive(Clone)]
+enum Block {
+    Image(BlockImg),
+    Chip {
+        src: SharedString,
+        label: SharedString,
+        /// Label color (accent, signalling clickable), box fill, box border.
+        link: Hsla,
+        bg: Hsla,
+        border: Hsla,
+        height: Pixels,
+    },
+}
+
+impl Block {
+    fn height(&self) -> Pixels {
+        match self {
+            Block::Image(i) => i.height,
+            Block::Chip { height, .. } => *height,
+        }
+    }
+}
+
 /// A fenced-code-block line's background (W4b/refinement): the block reads as one
 /// rounded, content-fit box (sized to its widest line, like a table — not the
 /// full editor width). Each line carries the block color, the shared box width
@@ -1438,7 +1530,7 @@ impl LineMark {
 type ShapedLines = (
     Vec<WrappedLine>,
     Vec<Pixels>,
-    Vec<Option<BlockImg>>,
+    Vec<Option<Block>>,
     Vec<Option<CodeBg>>,
     Vec<Option<TableRow>>,
     // Per-line display→source byte map for lines with markers hidden (W6); `None`
@@ -1531,6 +1623,7 @@ fn shape_document(
     wrap_width: Option<Pixels>,
     caret_row: Option<usize>,
     block_image: Option<&BlockImageFn>,
+    block_chip: Option<&BlockChipFn>,
     scale_factor: f32,
     // The selected byte range; a line it touches keeps full source (markers
     // shown), the rest hide their markers (W6, reveal-on-caret).
@@ -1617,15 +1710,29 @@ fn shape_document(
             base_font_size * md.map_or(1.0, |_| markdown_syntax::line_scale(line))
         };
 
-        // Inline image (non-code): a standalone image line that isn't the caret's
-        // line and has a decoded image renders as that image, fit to width.
-        let widget = if !is_code
-            && md.is_some()
+        // Block widget (non-code): a standalone `![](src)` line that isn't the
+        // caret's renders as a file chip (if the host classifies `src` as one,
+        // e.g. a PDF) or else its decoded image, fit to width.
+        let widget: Option<Block> = if !is_code
             && Some(idx) != caret_row
+            && let Some(st) = md
             && let Some((src, w_attr)) = markdown_syntax::image_line(line)
-            && let Some(img) = block_image.and_then(|f| f(src))
         {
-            block_img(img, w_attr, wrap_width, scale_factor)
+            if let Some(label) = block_chip.and_then(|f| f(src)) {
+                Some(Block::Chip {
+                    src: src.into(),
+                    label,
+                    link: st.link,
+                    bg: st.code_bg,
+                    border: st.marker,
+                    height: fs * LINE_HEIGHT_RATIO + px(CHIP_PAD * 2.),
+                })
+            } else {
+                block_image
+                    .and_then(|f| f(src))
+                    .and_then(|img| block_img(img, w_attr, wrap_width, scale_factor))
+                    .map(Block::Image)
+            }
         } else {
             None
         };
@@ -1658,9 +1765,14 @@ fn shape_document(
         // caret sits in is revealed (per-construct reveal, #5: finer than the old
         // whole-line reveal, so the rest of the line stays rendered).
         let sel_empty = selection.0 == selection.1;
-        let full_source = !sel_empty && selection.0 <= line_end && selection.1 >= line_start;
         let caret_col = (sel_empty && selection.0 >= line_start && selection.0 <= line_end)
             .then(|| selection.0 - line_start);
+        // An `![](src)` line (image/chip candidate) shows full raw source while the
+        // caret is on it, so editing reveals the whole `![](src)` rather than the
+        // per-construct view (where the caret at the `!` would hide the link).
+        let widget_line = md.is_some() && markdown_syntax::image_line(line).is_some();
+        let full_source = (!sel_empty && selection.0 <= line_end && selection.1 >= line_start)
+            || (caret_col.is_some() && widget_line);
         // This line's diagnostics, clipped + shifted to line-local byte offsets —
         // used as spell-check squiggles whether the line shows source or hides its
         // markers.
@@ -1797,7 +1909,9 @@ fn shape_document(
                 match &table {
                     Some(t) if t.is_separator => table_sep_h,
                     Some(_) => table_row_h,
-                    None => widget.as_ref().map_or(fs * LINE_HEIGHT_RATIO, |w| w.height),
+                    None => widget
+                        .as_ref()
+                        .map_or(fs * LINE_HEIGHT_RATIO, Block::height),
                 }
             };
             let line_w = wl.width();
@@ -1830,6 +1944,56 @@ fn shape_document(
         }
     }
     (wrapped, heights, widgets, backgrounds, tables, maps, marks)
+}
+
+/// Paint a file chip — a rounded, bordered button with a 📄 icon + `label` —
+/// filling the row (sized in `shape_document` to include vertical padding), its
+/// width fit to the label. Left-click opens it, right-click edits (handled by the
+/// mouse handlers via `chip_rows`).
+#[allow(clippy::too_many_arguments)]
+fn paint_chip(
+    label: &str,
+    link: Hsla,
+    bg: Hsla,
+    border: Hsla,
+    origin: Point<Pixels>,
+    row_h: Pixels,
+    font: &Font,
+    font_size: Pixels,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let text = SharedString::from(format!("📄  {label}"));
+    let run = TextRun {
+        len: text.len(),
+        font: font.clone(),
+        color: link,
+        background_color: None,
+        underline: None,
+        strikethrough: None,
+    };
+    let shaped = window
+        .text_system()
+        .shape_line(text, font_size, &[run], None);
+    let pad_x = px(10.);
+    let box_w = shaped.width() + pad_x * 2.;
+    window.paint_quad(PaintQuad {
+        bounds: Bounds::new(origin, size(box_w, row_h)),
+        corner_radii: Corners::all(px(6.)),
+        background: bg.into(),
+        border_widths: Edges::all(px(1.)),
+        border_color: border,
+        border_style: BorderStyle::Solid,
+    });
+    let line_h = font_size * LINE_HEIGHT_RATIO;
+    let _ = shaped.paint(
+        point(origin.x + pad_x, origin.y + (row_h - line_h) / 2.),
+        line_h,
+        gpui::TextAlign::Left,
+        None,
+        window,
+        cx,
+    );
 }
 
 /// Content-fit column widths for a table region (W4c): each column sized to its
@@ -1995,7 +2159,7 @@ struct PrepaintState {
     /// Per-logical-line wrap-row height (variable for headings + images).
     line_heights: Vec<Pixels>,
     /// `Some` for a line painted as an inline image instead of its source text.
-    widgets: Vec<Option<BlockImg>>,
+    widgets: Vec<Option<Block>>,
     /// Per-line fenced-code-block background (rounded full-width box).
     backgrounds: Vec<Option<CodeBg>>,
     /// `Some` for a line painted as a table-grid row instead of source.
@@ -2078,6 +2242,7 @@ impl Element for EditorElement {
                     wrap_width,
                     Some(caret_row),
                     editor.block_image.as_ref(),
+                    editor.block_chip.as_ref(),
                     sf,
                     (editor.selected_range.start, editor.selected_range.end),
                 );
@@ -2151,6 +2316,7 @@ impl Element for EditorElement {
                     wrap_width,
                     Some(caret_row),
                     editor.block_image.as_ref(),
+                    editor.block_chip.as_ref(),
                     sf,
                     (editor.selected_range.start, editor.selected_range.end),
                 )
@@ -2421,10 +2587,22 @@ impl Element for EditorElement {
                 paint_table_row(
                     t, origin, *lh, &font, font_size, base_lh, text_color, window, cx,
                 );
-            } else if let Some(w) = prepaint.widgets.get(i).and_then(Option::as_ref) {
+            } else if let Some(Block::Image(w)) = prepaint.widgets.get(i).and_then(Option::as_ref) {
                 // Inline image (W4a): paint the decoded image instead of source.
                 let img_bounds = Bounds::new(origin, size(w.width, w.height));
                 let _ = window.paint_image(img_bounds, Corners::default(), w.img.clone(), 0, false);
+            } else if let Some(Block::Chip {
+                label,
+                link,
+                bg,
+                border,
+                ..
+            }) = prepaint.widgets.get(i).and_then(Option::as_ref)
+            {
+                // File chip (e.g. a PDF embed): a rounded button with the label.
+                paint_chip(
+                    label, *link, *bg, *border, origin, *lh, &font, font_size, window, cx,
+                );
             } else {
                 // Code blocks + gutter marks inset their text (kept in sync with
                 // `EditorState::line_inset` / the fresh prepaint inset).
@@ -2469,12 +2647,21 @@ impl Element for EditorElement {
             .zip(prepaint.marks.iter())
             .map(|(bg, mark)| row_inset(*bg, *mark))
             .collect();
+        let chip_rows: Vec<Option<SharedString>> = prepaint
+            .widgets
+            .iter()
+            .map(|w| match w {
+                Some(Block::Chip { src, .. }) => Some(src.clone()),
+                _ => None,
+            })
+            .collect();
         self.editor.update(cx, |editor, _| {
             editor.wrapped = wrapped;
             editor.line_tops = line_tops;
             editor.line_heights = line_heights;
             editor.widget_rows = widget_rows;
             editor.offset_maps = offset_maps;
+            editor.chip_rows = chip_rows;
             editor.line_insets = line_insets;
             editor.last_bounds = Some(bounds);
             editor.line_height = base_lh;

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -344,6 +344,33 @@ pub(crate) fn heading_level(line: &str) -> Option<u8> {
     ((1..=6).contains(&n) && (n == b.len() || b[n] == b' ')).then_some(n as u8)
 }
 
+/// If `line` is a standalone image — `![alt](src)`, optionally followed by a
+/// `{width=N}` / `{width=Npx}` attribute, with only whitespace around it —
+/// return `(src, explicit_width)`. The editor renders such a line as the image
+/// (W4) when the caret is elsewhere; a line with any other trailing text stays
+/// plain source.
+pub(crate) fn image_line(line: &str) -> Option<(&str, Option<f32>)> {
+    let rest = line.trim().strip_prefix("![")?;
+    let close_alt = rest.find("](")?;
+    let after_alt = &rest[close_alt + 2..];
+    let close_src = after_alt.find(')')?;
+    let src = after_alt[..close_src].trim();
+    let tail = after_alt[close_src + 1..].trim();
+    let width = if tail.is_empty() {
+        None
+    } else {
+        let w = tail.strip_prefix("{width=")?.strip_suffix('}')?;
+        Some(
+            w.strip_suffix("px")
+                .unwrap_or(w)
+                .trim()
+                .parse::<f32>()
+                .ok()?,
+        )
+    };
+    (!src.is_empty()).then_some((src, width))
+}
+
 /// Font-size multiplier for a line — larger for headings (matching the reading
 /// view's scale), 1.0 for body text. Drives the editor's variable line heights.
 pub(crate) fn line_scale(line: &str) -> f32 {

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -800,11 +800,57 @@ pub(crate) enum Align {
     Right,
 }
 
+/// Visual style of a GFM table, chosen per-table via a `<!-- table:STYLE -->`
+/// marker comment on the line directly above it. `Grid` is the default (no
+/// marker). The renderers honor it; standard Markdown viewers ignore the comment
+/// and show a plain table.
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub(crate) enum TableStyle {
+    /// Full outer box + all row/column gridlines.
+    #[default]
+    Grid,
+    /// Alternate body rows shaded; no gridlines; a rule under the header.
+    Striped,
+    /// Only the header row shaded; no gridlines.
+    Header,
+    /// No box or gridlines — just a rule under the header.
+    Minimal,
+}
+
+impl TableStyle {
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "grid" => Some(Self::Grid),
+            "striped" => Some(Self::Striped),
+            "header" => Some(Self::Header),
+            "minimal" => Some(Self::Minimal),
+            _ => None,
+        }
+    }
+}
+
+/// Parse a `<!-- table:STYLE -->` marker line into its [`TableStyle`]. `None` if
+/// the line isn't a recognized table-style marker (so an unknown marker stays a
+/// plain HTML comment).
+pub(crate) fn table_style_marker(line: &str) -> Option<TableStyle> {
+    let inner = line
+        .trim()
+        .strip_prefix("<!--")?
+        .strip_suffix("-->")?
+        .trim();
+    TableStyle::from_name(inner.strip_prefix("table:")?.trim())
+}
+
 /// A detected GFM table region: the half-open range of logical line indices it
-/// spans (header, separator, then body rows) and its per-column alignment.
+/// spans (header, separator, then body rows) and its per-column alignment, plus
+/// an optional `<!-- table:STYLE -->` marker line directly above it.
 pub(crate) struct TableRegion {
     pub lines: Range<usize>,
     pub aligns: Vec<Align>,
+    pub style: TableStyle,
+    /// Index of the style-marker comment line above the header, if present — the
+    /// editor hides it (revealed only when the caret lands on it).
+    pub marker_line: Option<usize>,
 }
 
 /// Detect GFM table regions in `content` (W4c). A region is a row line (trimmed
@@ -823,9 +869,20 @@ pub(crate) fn table_regions(content: &str) -> Vec<TableRegion> {
             while end < lines.len() && is_table_row(lines[end]) {
                 end += 1;
             }
+            // A `<!-- table:STYLE -->` comment on the line directly above sets the
+            // table's visual style (and is hidden by the editor).
+            let (style, marker_line) = match start
+                .checked_sub(1)
+                .map(|m| (m, table_style_marker(lines[m])))
+            {
+                Some((m, Some(s))) => (s, Some(m)),
+                _ => (TableStyle::Grid, None),
+            };
             out.push(TableRegion {
                 lines: start..end,
                 aligns,
+                style,
+                marker_line,
             });
             i = end;
         } else {
@@ -951,6 +1008,33 @@ mod tests {
             table_regions("| h |\n| ---: |\n| x |")[0].aligns,
             vec![Align::Right]
         );
+    }
+
+    #[test]
+    fn table_style_marker_and_region() {
+        assert_eq!(
+            table_style_marker("<!-- table:striped -->"),
+            Some(TableStyle::Striped)
+        );
+        assert_eq!(
+            table_style_marker("<!--table:minimal-->"),
+            Some(TableStyle::Minimal)
+        );
+        assert_eq!(table_style_marker("<!-- table:bogus -->"), None);
+        assert_eq!(table_style_marker("<!-- a comment -->"), None);
+        assert_eq!(table_style_marker("| a | b |"), None);
+
+        // The marker above a table sets its style + is recorded (not in `lines`).
+        let r = table_regions("<!-- table:header -->\n| h |\n| --- |\n| x |");
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].style, TableStyle::Header);
+        assert_eq!(r[0].marker_line, Some(0));
+        assert_eq!(r[0].lines, 1..4);
+
+        // No marker → default Grid.
+        let g = table_regions("| h |\n| --- |\n| x |");
+        assert_eq!(g[0].style, TableStyle::Grid);
+        assert_eq!(g[0].marker_line, None);
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -143,6 +143,7 @@ fn run_for(
     base_font: &Font,
     base_color: Hsla,
     md: Option<&SyntaxStyle>,
+    underline: Option<UnderlineStyle>,
 ) -> TextRun {
     let mut font = match style {
         Some(s) if s.mono => md.map_or_else(|| base_font.clone(), |m| m.mono.clone()),
@@ -161,7 +162,7 @@ fn run_for(
         font,
         color: style.and_then(|s| s.color).unwrap_or(base_color),
         background_color: style.and_then(|s| s.bg),
-        underline: None,
+        underline,
         strikethrough: style.filter(|s| s.strike).map(|_| StrikethroughStyle {
             thickness: px(1.5),
             color: None,
@@ -180,40 +181,68 @@ pub(crate) fn hidden_runs(
     line: &str,
     base_font: &Font,
     base_color: Hsla,
+    diagnostics: &[Diagnostic],
     md: &SyntaxStyle,
 ) -> (String, Vec<TextRun>, Vec<usize>) {
     let mut spans = scan(line, md);
     spans.sort_by_key(|s| s.range.start);
-    let mut display = String::with_capacity(line.len());
-    let mut runs: Vec<TextRun> = Vec::new();
-    let mut map: Vec<usize> = Vec::with_capacity(line.len() + 1);
+
+    // The visible segments (markers dropped), each a source byte range + style.
+    // A visible segment is copied verbatim, so source↔display is 1:1 within it —
+    // which lets a diagnostic (source coords) map straight onto the display.
+    let mut segs: Vec<(Range<usize>, Option<&Style>)> = Vec::new();
     let mut pos = 0;
     for span in &spans {
         if span.range.start > pos {
-            let seg = &line[pos..span.range.start];
-            runs.push(run_for(seg.len(), None, base_font, base_color, Some(md)));
-            map.extend(pos..span.range.start);
-            display.push_str(seg);
+            segs.push((pos..span.range.start, None));
         }
         if !span.style.hide {
-            let seg = &line[span.range.clone()];
-            runs.push(run_for(
-                seg.len(),
-                Some(&span.style),
-                base_font,
-                base_color,
-                Some(md),
-            ));
-            map.extend(span.range.clone());
-            display.push_str(seg);
+            segs.push((span.range.clone(), Some(&span.style)));
         }
         pos = span.range.end;
     }
     if pos < line.len() {
-        let seg = &line[pos..];
-        runs.push(run_for(seg.len(), None, base_font, base_color, Some(md)));
-        map.extend(pos..line.len());
-        display.push_str(seg);
+        segs.push((pos..line.len(), None));
+    }
+
+    let squiggle = UnderlineStyle {
+        color: Some(hsla(0., 0.8, 0.55, 1.)),
+        thickness: px(1.5),
+        wavy: true,
+    };
+    let mut display = String::with_capacity(line.len());
+    let mut runs: Vec<TextRun> = Vec::new();
+    let mut map: Vec<usize> = Vec::with_capacity(line.len() + 1);
+    for (src, style) in &segs {
+        display.push_str(&line[src.clone()]);
+        map.extend(src.clone());
+        // Split the segment at any diagnostic edges falling inside it, so the
+        // covered pieces get a spell-check squiggle (W6 lines kept their markers
+        // hidden but were dropping these underlines).
+        let mut edges = vec![src.start, src.end];
+        for d in diagnostics.iter().filter(|d| d.range.start < d.range.end) {
+            for e in [d.range.start, d.range.end] {
+                if e > src.start && e < src.end {
+                    edges.push(e);
+                }
+            }
+        }
+        edges.sort_unstable();
+        edges.dedup();
+        for w in edges.windows(2) {
+            let (a, b) = (w[0], w[1]);
+            let under = diagnostics
+                .iter()
+                .any(|d| d.range.start <= a && a < d.range.end);
+            runs.push(run_for(
+                b - a,
+                *style,
+                base_font,
+                base_color,
+                Some(md),
+                under.then_some(squiggle),
+            ));
+        }
     }
     map.push(line.len());
     (display, runs, map)
@@ -273,8 +302,8 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
     let mut i = start;
     while i < end {
         let c = b[i];
-        // Inline code: `code` — backticks are hideable markers, the body a mono
-        // chip (so it matches the reading view: a highlight, no backticks).
+        // Inline code: `code` — backticks are hideable markers, the body a
+        // highlight (code color on a tint, body font) matching the reading view.
         if c == b'`'
             && let Some(close) = find1(b, i + 1, end, b'`')
         {
@@ -283,7 +312,6 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                 out,
                 i + 1..close,
                 Style {
-                    mono: true,
                     color: Some(st.code),
                     bg: Some(st.code_bg),
                     ..Default::default()
@@ -655,21 +683,46 @@ mod tests {
         let st = test_style();
 
         // "**bold**" → "bold"; display 0 maps to source 2, end (4) to 8.
-        let (disp, _, map) = hidden_runs("**bold**", &font, c, &st);
+        let (disp, _, map) = hidden_runs("**bold**", &font, c, &[], &st);
         assert_eq!(disp, "bold");
         assert_eq!(map.len(), disp.len() + 1);
         assert_eq!(map[0], 2);
         assert_eq!(map[4], 8);
 
         // "## Hi" → "Hi"; the `## ` prefix is gone, display 0 maps to source 3.
-        let (disp, _, map) = hidden_runs("## Hi", &font, c, &st);
+        let (disp, _, map) = hidden_runs("## Hi", &font, c, &[], &st);
         assert_eq!(disp, "Hi");
         assert_eq!(map[0], 3);
         assert_eq!(map[2], 5);
 
         // No markers → unchanged, identity map.
-        let (disp, _, map) = hidden_runs("plain text", &font, c, &st);
+        let (disp, _, map) = hidden_runs("plain text", &font, c, &[], &st);
         assert_eq!(disp, "plain text");
         assert_eq!(map, (0..=10).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn hidden_runs_squiggle_diagnostics() {
+        let font = gpui::font("Helvetica");
+        let c = hsla(0., 0., 0., 1.);
+        let st = test_style();
+
+        // A diagnostic on the bold body ("bold" at source 2..6) underlines the
+        // whole display string — squiggles survive marker hiding (W6).
+        let (disp, runs, _) = hidden_runs("**bold**", &font, c, &[Diagnostic { range: 2..6 }], &st);
+        assert_eq!(disp, "bold");
+        assert_eq!(runs.iter().map(|r| r.len).sum::<usize>(), disp.len());
+        assert!(runs.iter().all(|r| r.underline.is_some()));
+
+        // A partial diagnostic splits the segment: only "text" (6..10) squiggles.
+        let (disp, runs, _) =
+            hidden_runs("plain text", &font, c, &[Diagnostic { range: 6..10 }], &st);
+        assert_eq!(disp, "plain text");
+        let underlined: usize = runs
+            .iter()
+            .filter(|r| r.underline.is_some())
+            .map(|r| r.len)
+            .sum();
+        assert_eq!(underlined, 4); // "text"
     }
 }

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -737,6 +737,31 @@ pub(crate) fn table_cells(line: &str) -> Vec<&str> {
     t.split('|').map(str::trim).collect()
 }
 
+/// The byte range of each cell's *trimmed content* within `line` (line-local), in
+/// the same order as [`table_cells`]. Lets the editor place the caret inside a
+/// rendered cell and hit-test a click back to a source offset. An empty cell is a
+/// zero-width range at its content position.
+pub(crate) fn table_cell_ranges(line: &str) -> Vec<Range<usize>> {
+    let (Some(first), Some(last)) = (line.find('|'), line.rfind('|')) else {
+        return Vec::new();
+    };
+    if last <= first {
+        return Vec::new();
+    }
+    let base = first + 1; // start of the inter-pipe region in `line`
+    let inner = &line[base..last];
+    let mut out = Vec::new();
+    let mut seg = 0; // offset of the current cell within `inner`
+    for piece in inner.split('|') {
+        let lead = piece.len() - piece.trim_start().len();
+        let trail = piece.len() - piece.trim_end().len();
+        let start = base + seg + lead;
+        out.push(start..(base + seg + piece.len() - trail).max(start));
+        seg += piece.len() + 1; // + the `|`
+    }
+    out
+}
+
 /// If `line` is a table separator row (every cell is dashes with optional
 /// alignment colons), return its per-column alignment, else `None`.
 fn separator_aligns(line: &str) -> Option<Vec<Align>> {

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -350,6 +350,11 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         }
         marker(out, start..p, st.marker);
         i = p;
+    } else if let Some((prefix_len, ..)) = list_prefix(&text[start..end]) {
+        // List item: hide the leading whitespace + marker; a bullet/number is
+        // painted in its place and the body keeps inline styling.
+        marker(out, start..start + prefix_len, st.marker);
+        i = start + prefix_len;
     }
     while i < end {
         let c = b[i];
@@ -532,6 +537,35 @@ pub(crate) fn blockquote_prefix(line: &str) -> Option<usize> {
         }
     }
     Some(p)
+}
+
+/// If `line` is a list item, return `(prefix_len, indent, ordered, number)`.
+/// `prefix_len` is the byte length of the leading whitespace plus the marker
+/// (a bullet `-`/`*`/`+`, or digits then `.`/`)`) plus one space; `indent` is the
+/// leading-whitespace length (nesting depth); `ordered`/`number` describe an
+/// ordered item. The editor hides this prefix and paints a bullet/number,
+/// revealing the raw prefix on caret.
+pub(crate) fn list_prefix(line: &str) -> Option<(usize, usize, bool, u32)> {
+    let b = line.as_bytes();
+    let mut i = 0;
+    while i < b.len() && (b[i] == b' ' || b[i] == b'\t') {
+        i += 1;
+    }
+    let indent = i;
+    // Unordered: `-`/`*`/`+` then a space.
+    if i < b.len() && matches!(b[i], b'-' | b'*' | b'+') && b.get(i + 1) == Some(&b' ') {
+        return Some((i + 2, indent, false, 0));
+    }
+    // Ordered: one or more digits, then `.` or `)`, then a space.
+    let ds = i;
+    while i < b.len() && b[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i > ds && matches!(b.get(i), Some(b'.') | Some(b')')) && b.get(i + 1) == Some(&b' ') {
+        let num = line[ds..i].parse::<u32>().unwrap_or(1);
+        return Some((i + 2, indent, true, num));
+    }
+    None
 }
 
 /// If `line` is a standalone image — `![alt](src)`, optionally followed by a
@@ -852,5 +886,27 @@ mod tests {
         // the caret isn't in it; inline markers still hide unless under the caret.
         let (disp, _, _) = hidden_runs("> a **b**", &font, c, &[], Some(3), 2, &st);
         assert_eq!(disp, "> a b");
+    }
+
+    #[test]
+    fn list_prefix_detection() {
+        assert_eq!(list_prefix("- item"), Some((2, 0, false, 0)));
+        assert_eq!(list_prefix("* item"), Some((2, 0, false, 0)));
+        assert_eq!(list_prefix("+ item"), Some((2, 0, false, 0)));
+        assert_eq!(list_prefix("  - nested"), Some((4, 2, false, 0)));
+        assert_eq!(list_prefix("3. third"), Some((3, 0, true, 3)));
+        assert_eq!(list_prefix("  10) tenth"), Some((6, 2, true, 10)));
+        // Not lists: italic, a bare dash, indented prose.
+        assert_eq!(list_prefix("*italic*"), None);
+        assert_eq!(list_prefix("-no space"), None);
+        assert_eq!(list_prefix("  just indented"), None);
+
+        // The marker hides; a nested item maps the body back past the prefix.
+        let font = gpui::font("Helvetica");
+        let c = hsla(0., 0., 0., 1.);
+        let st = test_style();
+        let (disp, _, map) = hidden_runs("  - hi", &font, c, &[], None, 0, &st);
+        assert_eq!(disp, "hi");
+        assert_eq!(map[0], 4); // display 0 ('h') ← source 4
     }
 }

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -350,9 +350,12 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         }
         marker(out, start..p, st.marker);
         i = p;
-    } else if let Some((prefix_len, ..)) = list_prefix(&text[start..end]) {
-        // List item: hide the leading whitespace + marker; a bullet/number is
-        // painted in its place and the body keeps inline styling.
+    } else if let Some(prefix_len) = task_prefix(&text[start..end])
+        .map(|(p, ..)| p)
+        .or_else(|| list_prefix(&text[start..end]).map(|(p, ..)| p))
+    {
+        // List / task item: hide the leading whitespace + marker (+ checkbox); a
+        // bullet/number/box is painted in its place, body keeps inline styling.
         marker(out, start..start + prefix_len, st.marker);
         i = start + prefix_len;
     }
@@ -564,6 +567,24 @@ pub(crate) fn list_prefix(line: &str) -> Option<(usize, usize, bool, u32)> {
     if i > ds && matches!(b.get(i), Some(b'.') | Some(b')')) && b.get(i + 1) == Some(&b' ') {
         let num = line[ds..i].parse::<u32>().unwrap_or(1);
         return Some((i + 2, indent, true, num));
+    }
+    None
+}
+
+/// If `line` is a GFM task item — a list item whose body starts with `[ ]`,
+/// `[x]`, or `[X]` then a space — return `(prefix_len, indent, checked)`, where
+/// `prefix_len` covers the list marker plus the checkbox. The editor hides this
+/// prefix and paints a ☐/☑ box (parity with the reading view).
+pub(crate) fn task_prefix(line: &str) -> Option<(usize, usize, bool)> {
+    let (list_len, indent, ..) = list_prefix(line)?;
+    let rest = &line.as_bytes()[list_len..];
+    if rest.len() >= 4
+        && rest[0] == b'['
+        && rest[2] == b']'
+        && rest[3] == b' '
+        && matches!(rest[1], b' ' | b'x' | b'X')
+    {
+        return Some((list_len + 4, indent, matches!(rest[1], b'x' | b'X')));
     }
     None
 }
@@ -908,5 +929,23 @@ mod tests {
         let (disp, _, map) = hidden_runs("  - hi", &font, c, &[], None, 0, &st);
         assert_eq!(disp, "hi");
         assert_eq!(map[0], 4); // display 0 ('h') ← source 4
+    }
+
+    #[test]
+    fn task_prefix_detection() {
+        assert_eq!(task_prefix("- [ ] todo"), Some((6, 0, false)));
+        assert_eq!(task_prefix("- [x] done"), Some((6, 0, true)));
+        assert_eq!(task_prefix("- [X] done"), Some((6, 0, true)));
+        assert_eq!(task_prefix("  - [ ] nested"), Some((8, 2, false)));
+        // A plain list item is not a task.
+        assert_eq!(task_prefix("- item"), None);
+
+        // The `- [ ] ` prefix hides entirely; body maps back past it.
+        let font = gpui::font("Helvetica");
+        let c = hsla(0., 0., 0., 1.);
+        let st = test_style();
+        let (disp, _, map) = hidden_runs("- [x] go", &font, c, &[], None, 0, &st);
+        assert_eq!(disp, "go");
+        assert_eq!(map[0], 6); // display 0 ('g') ← source 6
     }
 }

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -48,6 +48,9 @@ struct Style {
     mono: bool,
     color: Option<Hsla>,
     bg: Option<Hsla>,
+    /// A syntax marker (`**`, `#`, `[`, …) — dimmed when shown, and removed
+    /// entirely when the line's markers are hidden (W6, reveal-on-caret).
+    hide: bool,
 }
 
 struct Span {
@@ -132,6 +135,90 @@ pub(crate) fn styled_runs(
     runs
 }
 
+/// Build a `TextRun` of byte length `len` from a scanned span's style (or the
+/// base style when `None`). Shared by the hidden-line renderer.
+fn run_for(
+    len: usize,
+    style: Option<&Style>,
+    base_font: &Font,
+    base_color: Hsla,
+    md: Option<&SyntaxStyle>,
+) -> TextRun {
+    let mut font = match style {
+        Some(s) if s.mono => md.map_or_else(|| base_font.clone(), |m| m.mono.clone()),
+        _ => base_font.clone(),
+    };
+    if let Some(s) = style {
+        if s.bold {
+            font.weight = FontWeight::BOLD;
+        }
+        if s.italic {
+            font.style = FontStyle::Italic;
+        }
+    }
+    TextRun {
+        len,
+        font,
+        color: style.and_then(|s| s.color).unwrap_or(base_color),
+        background_color: style.and_then(|s| s.bg),
+        underline: None,
+        strikethrough: style.filter(|s| s.strike).map(|_| StrikethroughStyle {
+            thickness: px(1.5),
+            color: None,
+        }),
+    }
+}
+
+/// Render `line` with its syntax markers HIDDEN (W6): returns the display string
+/// (source minus the marker chars), the styled runs over it, and a per-display-
+/// byte map back to the source byte offset (length `display.len() + 1`, so the
+/// end position maps too). Used for lines the caret/selection don't touch; the
+/// caret's line keeps full source, so its caret/selection math is unchanged.
+/// Spans don't overlap and cover the line in order, so each non-marker segment
+/// contributes one run of its byte length.
+pub(crate) fn hidden_runs(
+    line: &str,
+    base_font: &Font,
+    base_color: Hsla,
+    md: &SyntaxStyle,
+) -> (String, Vec<TextRun>, Vec<usize>) {
+    let mut spans = scan(line, md);
+    spans.sort_by_key(|s| s.range.start);
+    let mut display = String::with_capacity(line.len());
+    let mut runs: Vec<TextRun> = Vec::new();
+    let mut map: Vec<usize> = Vec::with_capacity(line.len() + 1);
+    let mut pos = 0;
+    for span in &spans {
+        if span.range.start > pos {
+            let seg = &line[pos..span.range.start];
+            runs.push(run_for(seg.len(), None, base_font, base_color, Some(md)));
+            map.extend(pos..span.range.start);
+            display.push_str(seg);
+        }
+        if !span.style.hide {
+            let seg = &line[span.range.clone()];
+            runs.push(run_for(
+                seg.len(),
+                Some(&span.style),
+                base_font,
+                base_color,
+                Some(md),
+            ));
+            map.extend(span.range.clone());
+            display.push_str(seg);
+        }
+        pos = span.range.end;
+    }
+    if pos < line.len() {
+        let seg = &line[pos..];
+        runs.push(run_for(seg.len(), None, base_font, base_color, Some(md)));
+        map.extend(pos..line.len());
+        display.push_str(seg);
+    }
+    map.push(line.len());
+    (display, runs, map)
+}
+
 /// Scan the whole document line by line for inline markdown constructs.
 fn scan(text: &str, st: &SyntaxStyle) -> Vec<Span> {
     let mut out = Vec::new();
@@ -151,6 +238,7 @@ fn marker(out: &mut Vec<Span>, range: Range<usize>, color: Hsla) {
         range,
         style: Style {
             color: Some(color),
+            hide: true,
             ..Default::default()
         },
     });
@@ -185,19 +273,23 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
     let mut i = start;
     while i < end {
         let c = b[i];
-        // Inline code: `code` (whole span styled as a mono chip).
+        // Inline code: `code` — backticks are hideable markers, the body a mono
+        // chip (so it matches the reading view: a highlight, no backticks).
         if c == b'`'
             && let Some(close) = find1(b, i + 1, end, b'`')
         {
-            out.push(Span {
-                range: i..close + 1,
-                style: Style {
+            marker(out, i..i + 1, st.marker);
+            push(
+                out,
+                i + 1..close,
+                Style {
                     mono: true,
                     color: Some(st.code),
                     bg: Some(st.code_bg),
                     ..Default::default()
                 },
-            });
+            );
+            marker(out, close..close + 1, st.marker);
             i = close + 1;
             continue;
         }
@@ -384,6 +476,31 @@ pub(crate) fn line_scale(line: &str) -> f32 {
     }
 }
 
+/// Fenced code-block regions (W4b/W6): each ` ``` ` line toggles a block;
+/// returns the line-index range `start..end` covering both fences (and the body
+/// between). An unclosed fence runs to the last line.
+pub(crate) fn code_regions(content: &str) -> Vec<Range<usize>> {
+    let mut out = Vec::new();
+    let mut open: Option<usize> = None;
+    let mut last = 0;
+    for (i, line) in content.split('\n').enumerate() {
+        last = i;
+        if line.trim_start().starts_with("```") {
+            match open {
+                None => open = Some(i),
+                Some(s) => {
+                    out.push(s..i + 1);
+                    open = None;
+                }
+            }
+        }
+    }
+    if let Some(s) = open {
+        out.push(s..last + 1);
+    }
+    out
+}
+
 /// Per-column text alignment of a GFM table.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub(crate) enum Align {
@@ -517,5 +634,42 @@ mod tests {
             Some(("b.png", Some(320.0)))
         );
         assert_eq!(image_line("text ![a](b.png)"), None);
+    }
+
+    fn test_style() -> SyntaxStyle {
+        let c = hsla(0., 0., 0.5, 1.);
+        SyntaxStyle {
+            marker: c,
+            code: c,
+            code_bg: c,
+            link: c,
+            tag: c,
+            mono: gpui::font("monospace"),
+        }
+    }
+
+    #[test]
+    fn hidden_runs_removes_markers_and_maps_back() {
+        let font = gpui::font("Helvetica");
+        let c = hsla(0., 0., 0., 1.);
+        let st = test_style();
+
+        // "**bold**" → "bold"; display 0 maps to source 2, end (4) to 8.
+        let (disp, _, map) = hidden_runs("**bold**", &font, c, &st);
+        assert_eq!(disp, "bold");
+        assert_eq!(map.len(), disp.len() + 1);
+        assert_eq!(map[0], 2);
+        assert_eq!(map[4], 8);
+
+        // "## Hi" → "Hi"; the `## ` prefix is gone, display 0 maps to source 3.
+        let (disp, _, map) = hidden_runs("## Hi", &font, c, &st);
+        assert_eq!(disp, "Hi");
+        assert_eq!(map[0], 3);
+        assert_eq!(map[2], 5);
+
+        // No markers → unchanged, identity map.
+        let (disp, _, map) = hidden_runs("plain text", &font, c, &st);
+        assert_eq!(disp, "plain text");
+        assert_eq!(map, (0..=10).collect::<Vec<_>>());
     }
 }

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -160,6 +160,28 @@ fn marker(out: &mut Vec<Span>, range: Range<usize>, color: Hsla) {
 /// UTF-8-safe (an ASCII byte never appears inside a multi-byte char).
 fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut Vec<Span>) {
     let b = text.as_bytes();
+    // Heading: `#`..`######` + a space. Dim the marker, bold the rest. The
+    // larger heading SIZE is applied per line at layout time (variable line
+    // heights), not here — so the rest of the line isn't scanned for inline
+    // constructs in W2. (W2)
+    if let Some(level) = heading_level(&text[start..end]) {
+        let mut marker_end = start + level as usize;
+        if marker_end < end && b[marker_end] == b' ' {
+            marker_end += 1;
+        }
+        marker(out, start..marker_end, st.marker);
+        if marker_end < end {
+            push(
+                out,
+                marker_end..end,
+                Style {
+                    bold: true,
+                    ..Default::default()
+                },
+            );
+        }
+        return;
+    }
     let mut i = start;
     while i < end {
         let c = b[i];
@@ -309,6 +331,30 @@ fn find1(b: &[u8], from: usize, end: usize, c: u8) -> Option<usize> {
 /// First index of the pair `c1 c2` in `b[from..end]`.
 fn find2(b: &[u8], from: usize, end: usize, c1: u8, c2: u8) -> Option<usize> {
     (from..end.saturating_sub(1)).find(|&k| b[k] == c1 && b[k + 1] == c2)
+}
+
+/// ATX heading depth (1–6) if `line` is a heading: 1–6 leading `#` followed by
+/// a space or end-of-line. `None` otherwise.
+pub(crate) fn heading_level(line: &str) -> Option<u8> {
+    let b = line.as_bytes();
+    let mut n = 0;
+    while n < b.len() && b[n] == b'#' {
+        n += 1;
+    }
+    ((1..=6).contains(&n) && (n == b.len() || b[n] == b' ')).then_some(n as u8)
+}
+
+/// Font-size multiplier for a line — larger for headings (matching the reading
+/// view's scale), 1.0 for body text. Drives the editor's variable line heights.
+pub(crate) fn line_scale(line: &str) -> f32 {
+    match heading_level(line) {
+        Some(1) => 1.8,
+        Some(2) => 1.5,
+        Some(3) => 1.3,
+        Some(4) => 1.15,
+        Some(5) => 1.05,
+        _ => 1.0,
+    }
 }
 
 fn is_word(c: u8) -> bool {

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -170,11 +170,34 @@ fn run_for(
     }
 }
 
+/// The maximal run of adjacent spans (a markdown construct: its markers + body)
+/// containing source byte `c`, or an empty range when `c` is in plain text.
+/// `spans` must be sorted by `range.start` and non-overlapping. Used to reveal
+/// only the construct the caret sits in (#5).
+fn construct_at(spans: &[Span], c: usize) -> Range<usize> {
+    let mut i = 0;
+    while i < spans.len() {
+        let start = spans[i].range.start;
+        let mut end = spans[i].range.end;
+        let mut j = i + 1;
+        while j < spans.len() && spans[j].range.start == end {
+            end = spans[j].range.end;
+            j += 1;
+        }
+        if start <= c && c <= end {
+            return start..end;
+        }
+        i = j;
+    }
+    0..0
+}
+
 /// Render `line` with its syntax markers HIDDEN (W6): returns the display string
 /// (source minus the marker chars), the styled runs over it, and a per-display-
 /// byte map back to the source byte offset (length `display.len() + 1`, so the
-/// end position maps too). Used for lines the caret/selection don't touch; the
-/// caret's line keeps full source, so its caret/selection math is unchanged.
+/// end position maps too). Used for every styled line that isn't fully revealed;
+/// the construct under `caret_col` (if any) keeps its markers (#5). The caller
+/// maps caret/selection columns through the returned map (see `display_col`).
 /// Spans don't overlap and cover the line in order, so each non-marker segment
 /// contributes one run of its byte length.
 pub(crate) fn hidden_runs(
@@ -182,10 +205,16 @@ pub(crate) fn hidden_runs(
     base_font: &Font,
     base_color: Hsla,
     diagnostics: &[Diagnostic],
+    caret_col: Option<usize>,
     md: &SyntaxStyle,
 ) -> (String, Vec<TextRun>, Vec<usize>) {
     let mut spans = scan(line, md);
     spans.sort_by_key(|s| s.range.start);
+
+    // The construct (a maximal run of adjacent spans: its markers + body) the
+    // caret sits in keeps its markers visible — everything else hides them (#5,
+    // per-construct reveal). Empty range when the caret is in plain text / absent.
+    let reveal = caret_col.map_or(0..0, |c| construct_at(&spans, c));
 
     // The visible segments (markers dropped), each a source byte range + style.
     // A visible segment is copied verbatim, so source↔display is 1:1 within it —
@@ -196,7 +225,9 @@ pub(crate) fn hidden_runs(
         if span.range.start > pos {
             segs.push((pos..span.range.start, None));
         }
-        if !span.style.hide {
+        let hidden =
+            span.style.hide && !(reveal.start <= span.range.start && span.range.end <= reveal.end);
+        if !hidden {
             segs.push((span.range.clone(), Some(&span.style)));
         }
         pos = span.range.end;
@@ -683,20 +714,20 @@ mod tests {
         let st = test_style();
 
         // "**bold**" → "bold"; display 0 maps to source 2, end (4) to 8.
-        let (disp, _, map) = hidden_runs("**bold**", &font, c, &[], &st);
+        let (disp, _, map) = hidden_runs("**bold**", &font, c, &[], None, &st);
         assert_eq!(disp, "bold");
         assert_eq!(map.len(), disp.len() + 1);
         assert_eq!(map[0], 2);
         assert_eq!(map[4], 8);
 
         // "## Hi" → "Hi"; the `## ` prefix is gone, display 0 maps to source 3.
-        let (disp, _, map) = hidden_runs("## Hi", &font, c, &[], &st);
+        let (disp, _, map) = hidden_runs("## Hi", &font, c, &[], None, &st);
         assert_eq!(disp, "Hi");
         assert_eq!(map[0], 3);
         assert_eq!(map[2], 5);
 
         // No markers → unchanged, identity map.
-        let (disp, _, map) = hidden_runs("plain text", &font, c, &[], &st);
+        let (disp, _, map) = hidden_runs("plain text", &font, c, &[], None, &st);
         assert_eq!(disp, "plain text");
         assert_eq!(map, (0..=10).collect::<Vec<_>>());
     }
@@ -709,14 +740,27 @@ mod tests {
 
         // A diagnostic on the bold body ("bold" at source 2..6) underlines the
         // whole display string — squiggles survive marker hiding (W6).
-        let (disp, runs, _) = hidden_runs("**bold**", &font, c, &[Diagnostic { range: 2..6 }], &st);
+        let (disp, runs, _) = hidden_runs(
+            "**bold**",
+            &font,
+            c,
+            &[Diagnostic { range: 2..6 }],
+            None,
+            &st,
+        );
         assert_eq!(disp, "bold");
         assert_eq!(runs.iter().map(|r| r.len).sum::<usize>(), disp.len());
         assert!(runs.iter().all(|r| r.underline.is_some()));
 
         // A partial diagnostic splits the segment: only "text" (6..10) squiggles.
-        let (disp, runs, _) =
-            hidden_runs("plain text", &font, c, &[Diagnostic { range: 6..10 }], &st);
+        let (disp, runs, _) = hidden_runs(
+            "plain text",
+            &font,
+            c,
+            &[Diagnostic { range: 6..10 }],
+            None,
+            &st,
+        );
         assert_eq!(disp, "plain text");
         let underlined: usize = runs
             .iter()
@@ -724,5 +768,26 @@ mod tests {
             .map(|r| r.len)
             .sum();
         assert_eq!(underlined, 4); // "text"
+    }
+
+    #[test]
+    fn hidden_runs_reveals_only_caret_construct() {
+        let font = gpui::font("Helvetica");
+        let c = hsla(0., 0., 0., 1.);
+        let st = test_style();
+
+        let line = "**bold** *it*";
+        // Caret in "bold" reveals the bold markers; the italic stays hidden.
+        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(4), &st);
+        assert_eq!(disp, "**bold** it");
+        // Caret in "it" reveals the italic; the bold hides.
+        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(11), &st);
+        assert_eq!(disp, "bold *it*");
+        // Caret in plain text reveals nothing.
+        let (disp, _, _) = hidden_runs("a **b**", &font, c, &[], Some(0), &st);
+        assert_eq!(disp, "a b");
+        // No caret on the line → fully hidden (W6).
+        let (disp, _, _) = hidden_runs(line, &font, c, &[], None, &st);
+        assert_eq!(disp, "bold it");
     }
 }

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -37,6 +37,8 @@ pub struct SyntaxStyle {
     pub tag: Hsla,
     /// Blockquote text + left-border color (a muted tone).
     pub quote: Hsla,
+    /// `<mark>` highlight background.
+    pub mark_bg: Hsla,
     /// Monospace font for inline code.
     pub mono: Font,
 }
@@ -436,6 +438,34 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             i = close + 2;
             continue;
         }
+        // Footnote reference: [^label] — rendered `[label]` in link color (the
+        // `^` hidden), matching the reading view's resolved marker.
+        if c == b'['
+            && i + 1 < end
+            && b[i + 1] == b'^'
+            && let Some(rb) = find1(b, i + 2, end, b']')
+            && rb > i + 2
+        {
+            push(
+                out,
+                i..i + 1,
+                Style {
+                    color: Some(st.link),
+                    ..Default::default()
+                },
+            );
+            marker(out, i + 1..i + 2, st.marker); // hide the `^`
+            push(
+                out,
+                i + 2..rb + 1,
+                Style {
+                    color: Some(st.link),
+                    ..Default::default()
+                },
+            );
+            i = rb + 1;
+            continue;
+        }
         // Wiki-link: [[Page]] (check before single-[ link).
         if c == b'['
             && i + 1 < end
@@ -473,6 +503,48 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             );
             marker(out, rb..rp + 1, st.marker);
             i = rp + 1;
+            continue;
+        }
+        // Reference link: [text][id] — `text` colored, brackets + `[id]` dimmed.
+        // (Inline `[text](url)` is handled just above; this is the `][` form.)
+        if c == b'['
+            && let Some(rb) = find1(b, i + 1, end, b']')
+            && rb + 1 < end
+            && b[rb + 1] == b'['
+            && let Some(rb2) = find1(b, rb + 2, end, b']')
+        {
+            marker(out, i..i + 1, st.marker);
+            push(
+                out,
+                i + 1..rb,
+                Style {
+                    color: Some(st.link),
+                    ..Default::default()
+                },
+            );
+            marker(out, rb..rb2 + 1, st.marker);
+            i = rb2 + 1;
+            continue;
+        }
+        // <mark>…</mark>: a highlight — the one safe inline-HTML tag the reading
+        // view honors. Tags hidden, body gets a highlight background.
+        if c == b'<'
+            && text[i..end].starts_with("<mark>")
+            && let Some(rel) = text[i + 6..end].find("</mark>")
+        {
+            let body = i + 6;
+            let close = body + rel;
+            marker(out, i..body, st.marker);
+            push(
+                out,
+                body..close,
+                Style {
+                    bg: Some(st.mark_bg),
+                    ..Default::default()
+                },
+            );
+            marker(out, close..close + 7, st.marker);
+            i = close + 7;
             continue;
         }
         // Tag: #tag (at a non-word boundary; needs at least one tag char).
@@ -521,6 +593,46 @@ pub(crate) fn heading_level(line: &str) -> Option<u8> {
         n += 1;
     }
     ((1..=6).contains(&n) && (n == b.len() || b[n] == b' ')).then_some(n as u8)
+}
+
+/// True if `line` is a thematic break (horizontal rule): three or more of the
+/// same `-`, `*`, or `_`, separated only by optional spaces — e.g. `---`, `***`,
+/// `- - -`. The editor paints a divider in its place (reveal-on-caret). Matches
+/// CommonMark, ignoring the rare setext-underline ambiguity this app doesn't use.
+pub(crate) fn thematic_break(line: &str) -> bool {
+    let mut chars = line.bytes().filter(|b| !b.is_ascii_whitespace());
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !matches!(first, b'-' | b'*' | b'_') {
+        return false;
+    }
+    let mut count = 1;
+    for b in chars {
+        if b != first {
+            return false;
+        }
+        count += 1;
+    }
+    count >= 3
+}
+
+/// Byte length of the `[^label]:` prefix if `line` is a footnote definition, so
+/// the editor can render the whole line muted (the reading view does the same).
+/// `None` otherwise.
+pub(crate) fn footnote_def(line: &str) -> Option<usize> {
+    let rest = line.strip_prefix("[^")?;
+    let close = rest.find(']')?;
+    // Label must be non-empty and the `]` immediately followed by `:`.
+    (close > 0 && rest[close + 1..].starts_with(':')).then_some(2 + close + 2)
+}
+
+/// True if `line` looks like a block-level raw HTML line — `<tag …>`, `</tag>`,
+/// or `<!-- … -->` at the start (after optional indentation). The editor renders
+/// it muted, matching the reading view (raw HTML is shown literally, never run).
+pub(crate) fn html_block(line: &str) -> bool {
+    let t = line.trim_start().as_bytes();
+    matches!(t, [b'<', rest, ..] if rest.is_ascii_alphabetic() || *rest == b'/' || *rest == b'!')
 }
 
 /// Byte length of a blockquote's leading marker — one or more `>` (GFM nesting),
@@ -862,8 +974,35 @@ mod tests {
             link: c,
             tag: c,
             quote: c,
+            mark_bg: c,
             mono: gpui::font("monospace"),
         }
+    }
+
+    #[test]
+    fn thematic_break_detection() {
+        for s in ["---", "***", "___", "- - -", "  ---  ", "----"] {
+            assert!(thematic_break(s), "{s:?} should be a rule");
+        }
+        for s in ["--", "**", "", "text", "---x", "- -- text", "===", "> ---"] {
+            assert!(!thematic_break(s), "{s:?} should not be a rule");
+        }
+    }
+
+    #[test]
+    fn footnote_def_and_html_block() {
+        assert_eq!(footnote_def("[^1]: a note"), Some(5)); // `[^1]:`
+        assert_eq!(footnote_def("[^note]:x"), Some(8)); // `[^note]:`
+        assert_eq!(footnote_def("[^1] not a def"), None);
+        assert_eq!(footnote_def("[^]: empty label"), None);
+        assert_eq!(footnote_def("plain"), None);
+
+        assert!(html_block("<div>"));
+        assert!(html_block("</section>"));
+        assert!(html_block("<!-- comment -->"));
+        assert!(html_block("  <span>indented"));
+        assert!(!html_block("< 5 items"));
+        assert!(!html_block("text <b>inline</b>"));
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -654,6 +654,32 @@ pub(crate) fn code_regions(content: &str) -> Vec<Range<usize>> {
     out
 }
 
+/// Fenced ` ```mermaid ` blocks: each entry is `(line_range, source)` — the line
+/// range covering both fences (so it can collapse), and the diagram source (the
+/// lines between the fences, joined). Used to render the block as a diagram.
+pub(crate) fn mermaid_blocks(content: &str) -> Vec<(Range<usize>, String)> {
+    let lines: Vec<&str> = content.split('\n').collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let t = lines[i].trim_start();
+        if t.starts_with("```") && t[3..].trim() == "mermaid" {
+            let start = i;
+            let mut j = i + 1;
+            while j < lines.len() && !lines[j].trim_start().starts_with("```") {
+                j += 1;
+            }
+            let source = lines[start + 1..j].join("\n");
+            let end = (j + 1).min(lines.len()); // include the closing fence
+            out.push((start..end, source));
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
 /// Per-column text alignment of a GFM table.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub(crate) enum Align {
@@ -757,6 +783,19 @@ mod tests {
         assert_eq!(regions.len(), 1);
         assert_eq!(regions[0].lines, 2..6); // header, separator, 2 body rows
         assert_eq!(regions[0].aligns, vec![Align::Left, Align::Center]);
+    }
+
+    #[test]
+    fn mermaid_block_extraction() {
+        let md = "intro\n\n```mermaid\ngraph TD\nA --> B\n```\n\nafter";
+        let blocks = mermaid_blocks(md);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].0, 2..6); // ```mermaid(2), graph(3), A-->B(4), ```(5)
+        assert_eq!(blocks[0].1, "graph TD\nA --> B");
+        // A plain ``` block is not mermaid.
+        assert!(mermaid_blocks("```rust\nfn x() {}\n```").is_empty());
+        // Trailing-space lang still matches.
+        assert_eq!(mermaid_blocks("```mermaid \npie\n```").len(), 1);
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -35,6 +35,8 @@ pub struct SyntaxStyle {
     pub link: Hsla,
     /// `#tags`.
     pub tag: Hsla,
+    /// Blockquote text + left-border color (a muted tone).
+    pub quote: Hsla,
     /// Monospace font for inline code.
     pub mono: Font,
 }
@@ -206,6 +208,7 @@ pub(crate) fn hidden_runs(
     base_color: Hsla,
     diagnostics: &[Diagnostic],
     caret_col: Option<usize>,
+    reveal_prefix: usize,
     md: &SyntaxStyle,
 ) -> (String, Vec<TextRun>, Vec<usize>) {
     let mut spans = scan(line, md);
@@ -225,8 +228,12 @@ pub(crate) fn hidden_runs(
         if span.range.start > pos {
             segs.push((pos..span.range.start, None));
         }
-        let hidden =
-            span.style.hide && !(reveal.start <= span.range.start && span.range.end <= reveal.end);
+        // A marker is shown when it's inside the caret's construct OR within the
+        // revealed line-level prefix (e.g. a blockquote's `>` while the caret is
+        // anywhere on the line).
+        let in_construct = reveal.start <= span.range.start && span.range.end <= reveal.end;
+        let in_prefix = span.range.end <= reveal_prefix;
+        let hidden = span.style.hide && !in_construct && !in_prefix;
         if !hidden {
             segs.push((span.range.clone(), Some(&span.style)));
         }
@@ -330,7 +337,20 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         }
         return;
     }
+    // Blockquote: leading `>` (GFM nesting) + optional spaces. Hide the markers;
+    // the body keeps inline styling over a muted base color (set by the caller).
     let mut i = start;
+    if b.get(start) == Some(&b'>') {
+        let mut p = start;
+        while p < end && b[p] == b'>' {
+            p += 1;
+            if p < end && b[p] == b' ' {
+                p += 1;
+            }
+        }
+        marker(out, start..p, st.marker);
+        i = p;
+    }
     while i < end {
         let c = b[i];
         // Inline code: `code` — backticks are hideable markers, the body a
@@ -493,6 +513,25 @@ pub(crate) fn heading_level(line: &str) -> Option<u8> {
         n += 1;
     }
     ((1..=6).contains(&n) && (n == b.len() || b[n] == b' ')).then_some(n as u8)
+}
+
+/// Byte length of a blockquote's leading marker — one or more `>` (GFM nesting),
+/// each with an optional trailing space — if `line` is a blockquote. `None`
+/// otherwise. The editor hides this marker (reveal-on-caret) and renders the line
+/// with a muted color + a left border.
+pub(crate) fn blockquote_prefix(line: &str) -> Option<usize> {
+    let b = line.as_bytes();
+    if b.first() != Some(&b'>') {
+        return None;
+    }
+    let mut p = 0;
+    while p < b.len() && b[p] == b'>' {
+        p += 1;
+        if p < b.len() && b[p] == b' ' {
+            p += 1;
+        }
+    }
+    Some(p)
 }
 
 /// If `line` is a standalone image — `![alt](src)`, optionally followed by a
@@ -703,6 +742,7 @@ mod tests {
             code_bg: c,
             link: c,
             tag: c,
+            quote: c,
             mono: gpui::font("monospace"),
         }
     }
@@ -714,20 +754,20 @@ mod tests {
         let st = test_style();
 
         // "**bold**" → "bold"; display 0 maps to source 2, end (4) to 8.
-        let (disp, _, map) = hidden_runs("**bold**", &font, c, &[], None, &st);
+        let (disp, _, map) = hidden_runs("**bold**", &font, c, &[], None, 0, &st);
         assert_eq!(disp, "bold");
         assert_eq!(map.len(), disp.len() + 1);
         assert_eq!(map[0], 2);
         assert_eq!(map[4], 8);
 
         // "## Hi" → "Hi"; the `## ` prefix is gone, display 0 maps to source 3.
-        let (disp, _, map) = hidden_runs("## Hi", &font, c, &[], None, &st);
+        let (disp, _, map) = hidden_runs("## Hi", &font, c, &[], None, 0, &st);
         assert_eq!(disp, "Hi");
         assert_eq!(map[0], 3);
         assert_eq!(map[2], 5);
 
         // No markers → unchanged, identity map.
-        let (disp, _, map) = hidden_runs("plain text", &font, c, &[], None, &st);
+        let (disp, _, map) = hidden_runs("plain text", &font, c, &[], None, 0, &st);
         assert_eq!(disp, "plain text");
         assert_eq!(map, (0..=10).collect::<Vec<_>>());
     }
@@ -746,6 +786,7 @@ mod tests {
             c,
             &[Diagnostic { range: 2..6 }],
             None,
+            0,
             &st,
         );
         assert_eq!(disp, "bold");
@@ -759,6 +800,7 @@ mod tests {
             c,
             &[Diagnostic { range: 6..10 }],
             None,
+            0,
             &st,
         );
         assert_eq!(disp, "plain text");
@@ -778,16 +820,37 @@ mod tests {
 
         let line = "**bold** *it*";
         // Caret in "bold" reveals the bold markers; the italic stays hidden.
-        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(4), &st);
+        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(4), 0, &st);
         assert_eq!(disp, "**bold** it");
         // Caret in "it" reveals the italic; the bold hides.
-        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(11), &st);
+        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(11), 0, &st);
         assert_eq!(disp, "bold *it*");
         // Caret in plain text reveals nothing.
-        let (disp, _, _) = hidden_runs("a **b**", &font, c, &[], Some(0), &st);
+        let (disp, _, _) = hidden_runs("a **b**", &font, c, &[], Some(0), 0, &st);
         assert_eq!(disp, "a b");
         // No caret on the line → fully hidden (W6).
-        let (disp, _, _) = hidden_runs(line, &font, c, &[], None, &st);
+        let (disp, _, _) = hidden_runs(line, &font, c, &[], None, 0, &st);
         assert_eq!(disp, "bold it");
+    }
+
+    #[test]
+    fn blockquote_prefix_and_hidden() {
+        assert_eq!(blockquote_prefix("> quote"), Some(2));
+        assert_eq!(blockquote_prefix(">no space"), Some(1));
+        assert_eq!(blockquote_prefix(">> nested"), Some(3));
+        assert_eq!(blockquote_prefix("not a quote"), None);
+
+        // The `> ` marker hides; inline styling in the body still applies.
+        let font = gpui::font("Helvetica");
+        let c = hsla(0., 0., 0., 1.);
+        let st = test_style();
+        let (disp, _, map) = hidden_runs("> a **b**", &font, c, &[], None, 0, &st);
+        assert_eq!(disp, "a b"); // "> " + "**" hidden
+        assert_eq!(map[0], 2); // display 0 ('a') ← source 2
+
+        // With the prefix revealed (caret on the line) the `> ` shows even when
+        // the caret isn't in it; inline markers still hide unless under the caret.
+        let (disp, _, _) = hidden_runs("> a **b**", &font, c, &[], Some(3), 2, &st);
+        assert_eq!(disp, "> a b");
     }
 }

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -384,10 +384,138 @@ pub(crate) fn line_scale(line: &str) -> f32 {
     }
 }
 
+/// Per-column text alignment of a GFM table.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub(crate) enum Align {
+    Left,
+    Center,
+    Right,
+}
+
+/// A detected GFM table region: the half-open range of logical line indices it
+/// spans (header, separator, then body rows) and its per-column alignment.
+pub(crate) struct TableRegion {
+    pub lines: Range<usize>,
+    pub aligns: Vec<Align>,
+}
+
+/// Detect GFM table regions in `content` (W4c). A region is a row line (trimmed
+/// text starts with `|`) immediately followed by a separator row
+/// (`| --- | :--: |`), then any further row lines. Returns regions in order.
+pub(crate) fn table_regions(content: &str) -> Vec<TableRegion> {
+    let lines: Vec<&str> = content.split('\n').collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i + 1 < lines.len() {
+        if is_table_row(lines[i])
+            && let Some(aligns) = separator_aligns(lines[i + 1])
+        {
+            let start = i;
+            let mut end = i + 2; // header + separator
+            while end < lines.len() && is_table_row(lines[end]) {
+                end += 1;
+            }
+            out.push(TableRegion {
+                lines: start..end,
+                aligns,
+            });
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// A table row is a line whose trimmed text starts with `|`.
+pub(crate) fn is_table_row(line: &str) -> bool {
+    line.trim_start().starts_with('|')
+}
+
+/// Split a `| a | b |` row into trimmed cell strings (the bounding pipes drop the
+/// empty leading/trailing cells they'd otherwise create).
+pub(crate) fn table_cells(line: &str) -> Vec<&str> {
+    let t = line.trim();
+    let t = t.strip_prefix('|').unwrap_or(t);
+    let t = t.strip_suffix('|').unwrap_or(t);
+    t.split('|').map(str::trim).collect()
+}
+
+/// If `line` is a table separator row (every cell is dashes with optional
+/// alignment colons), return its per-column alignment, else `None`.
+fn separator_aligns(line: &str) -> Option<Vec<Align>> {
+    if !is_table_row(line) {
+        return None;
+    }
+    let cells = table_cells(line);
+    if cells.is_empty() {
+        return None;
+    }
+    cells
+        .iter()
+        .map(|c| {
+            let left = c.starts_with(':');
+            let right = c.ends_with(':');
+            let dashes = c.trim_matches(':');
+            (!dashes.is_empty() && dashes.bytes().all(|b| b == b'-')).then_some(
+                match (left, right) {
+                    (true, true) => Align::Center,
+                    (false, true) => Align::Right,
+                    _ => Align::Left,
+                },
+            )
+        })
+        .collect()
+}
+
 fn is_word(c: u8) -> bool {
     c.is_ascii_alphanumeric() || c == b'_'
 }
 
 fn is_tag(c: u8) -> bool {
     c.is_ascii_alphanumeric() || matches!(c, b'_' | b'-' | b'/')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_a_gfm_table() {
+        let md = "intro\n\n| A | B |\n| --- | :-: |\n| 1 | 2 |\n| 3 | 4 |\n\nafter";
+        let regions = table_regions(md);
+        assert_eq!(regions.len(), 1);
+        assert_eq!(regions[0].lines, 2..6); // header, separator, 2 body rows
+        assert_eq!(regions[0].aligns, vec![Align::Left, Align::Center]);
+    }
+
+    #[test]
+    fn cells_split_and_trim() {
+        assert_eq!(table_cells("| a | b |"), vec!["a", "b"]);
+        assert_eq!(table_cells("|  |  |"), vec!["", ""]);
+    }
+
+    #[test]
+    fn separator_required_and_alignment() {
+        // Pipes in prose without a separator row are not a table.
+        assert!(table_regions("a | b\nc | d").is_empty());
+        assert!(table_regions("| not a table\njust text").is_empty());
+        // Right alignment from `---:`.
+        assert_eq!(
+            table_regions("| h |\n| ---: |\n| x |")[0].aligns,
+            vec![Align::Right]
+        );
+    }
+
+    #[test]
+    fn heading_and_image_line() {
+        assert_eq!(heading_level("## Hi"), Some(2));
+        assert_eq!(heading_level("#notaheading"), None);
+        assert_eq!(image_line("![a](b.png)"), Some(("b.png", None)));
+        assert_eq!(
+            image_line("![a](b.png){width=320}"),
+            Some(("b.png", Some(320.0)))
+        );
+        assert_eq!(image_line("text ![a](b.png)"), None);
+    }
 }

--- a/crates/gpui-markdown/src/lib.rs
+++ b/crates/gpui-markdown/src/lib.rs
@@ -1543,6 +1543,35 @@ pub fn indent_list_line(value: &str, cursor: usize, indent: &str) -> Option<(Str
     Some((new, cursor + indent.len()))
 }
 
+/// Re-indent every space-indented list / quote item in `content` from `old`-space
+/// nesting units to `new`-space units (e.g. when the list-indent setting changes),
+/// so existing nesting matches the new width. Each item's level is its leading
+/// spaces ÷ `old`. Non-list lines, top-level items, and tab-indented lines are
+/// left untouched. `None` when nothing changes.
+pub fn reindent(content: &str, old: usize, new: usize) -> Option<String> {
+    if old == 0 || old == new {
+        return None;
+    }
+    let mut changed = false;
+    let out = content
+        .split('\n')
+        .map(|line| {
+            let ws = line.len() - line.trim_start_matches(' ').len();
+            if ws > 0 && parse_list_marker(&line[ws..]).is_some() {
+                let new_ws = (ws / old) * new;
+                if new_ws != ws {
+                    changed = true;
+                }
+                format!("{}{}", " ".repeat(new_ws), &line[ws..])
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    changed.then_some(out)
+}
+
 /// Outdent the caret's line one level: remove up to `indent`'s width of leading
 /// spaces (or one leading tab). Returns the new text and caret, or `None` if the
 /// line has no leading indent to remove.
@@ -1572,6 +1601,21 @@ mod tests {
 
     fn cont(s: &str) -> Option<ListEdit> {
         list_continuation(s, s.len())
+    }
+
+    #[test]
+    fn reindent_converts_list_widths() {
+        let content = "- a\n    - b\n        - c\nplain\n    not a list";
+        // 4 → 2 spaces/level: nested list items shrink; non-list + top-level stay.
+        assert_eq!(
+            reindent(content, 4, 2).unwrap(),
+            "- a\n  - b\n    - c\nplain\n    not a list"
+        );
+        // 4 → 8: nested items grow.
+        assert_eq!(reindent("    - b", 4, 8).unwrap(), "        - b");
+        // No-op when unchanged or nothing nested.
+        assert!(reindent(content, 4, 4).is_none());
+        assert!(reindent("- a\n- b", 4, 8).is_none());
     }
 
     #[test]

--- a/crates/gpui-markdown/src/lib.rs
+++ b/crates/gpui-markdown/src/lib.rs
@@ -338,7 +338,25 @@ impl RenderOnce for MarkdownView {
                 for node in &root.children {
                     collect_definitions(node, &mut ctx.definitions);
                 }
+                // A `<!-- table:STYLE -->` comment styles the next table and is
+                // itself hidden; everything else renders normally.
+                let mut pending_style = None;
                 for node in &root.children {
+                    if let mdast::Node::Html(h) = node
+                        && let Some(style) = table_style_marker(&h.value)
+                    {
+                        pending_style = Some(style);
+                        continue;
+                    }
+                    if let mdast::Node::Table(t) = node {
+                        col = col.child(render_table(
+                            t,
+                            &mut ctx,
+                            pending_style.take().unwrap_or_default(),
+                        ));
+                        continue;
+                    }
+                    pending_style = None;
                     if let Some(el) = render_block(node, &mut ctx) {
                         col = col.child(el);
                     }
@@ -492,7 +510,9 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx) -> Option<AnyElement> {
                 .bg(ctx.style.rule_color)
                 .into_any_element(),
         ),
-        mdast::Node::Table(t) => Some(render_table(t, ctx)),
+        // Top-level tables get their style from a preceding marker (see the root
+        // loop); a nested/standalone table here renders as the default Grid.
+        mdast::Node::Table(t) => Some(render_table(t, ctx, TableStyle::default())),
         // A footnote definition: `[label] <content>`, rendered muted/smaller
         // where it sits (authors put these at the bottom).
         mdast::Node::FootnoteDefinition(f) => {
@@ -1091,42 +1111,96 @@ fn collect_definitions(node: &mdast::Node, out: &mut HashMap<String, String>) {
 }
 
 /// Render a GFM table as a bordered grid; the first row is the header.
-fn render_table(table: &mdast::Table, ctx: &mut Ctx) -> AnyElement {
+/// Per-table visual style, from a `<!-- table:STYLE -->` marker comment on the
+/// line above the table (mirrors the editor; the style names are the shared
+/// contract). `Grid` is the default (no marker).
+#[derive(Clone, Copy, Default, PartialEq, Debug)]
+enum TableStyle {
+    #[default]
+    Grid,
+    Striped,
+    Header,
+    Minimal,
+}
+
+/// Parse a `<!-- table:STYLE -->` HTML comment's value into a [`TableStyle`].
+/// `None` if it isn't a recognized table-style marker.
+fn table_style_marker(html: &str) -> Option<TableStyle> {
+    let inner = html
+        .trim()
+        .strip_prefix("<!--")?
+        .strip_suffix("-->")?
+        .trim();
+    match inner.strip_prefix("table:")?.trim() {
+        "grid" => Some(TableStyle::Grid),
+        "striped" => Some(TableStyle::Striped),
+        "header" => Some(TableStyle::Header),
+        "minimal" => Some(TableStyle::Minimal),
+        _ => None,
+    }
+}
+
+fn render_table(table: &mdast::Table, ctx: &mut Ctx, style: TableStyle) -> AnyElement {
     let border = ctx.style.muted_color;
-    let mut grid = div()
-        .flex()
-        .flex_col()
-        .border_1()
-        .border_color(border)
-        .rounded(px(6.0))
-        .overflow_hidden();
+    let shade = ctx.style.code_bg;
+    let boxed = matches!(style, TableStyle::Grid);
+    let vlines = matches!(style, TableStyle::Grid);
+    let row_lines = matches!(style, TableStyle::Grid);
+    // A single rule under the header instead of a divider between every row.
+    let header_rule = matches!(style, TableStyle::Striped | TableStyle::Minimal);
+
+    let mut grid = div().flex().flex_col();
+    if boxed {
+        grid = grid
+            .border_1()
+            .border_color(border)
+            .rounded(px(6.0))
+            .overflow_hidden();
+    }
 
     for (ri, row) in table.children.iter().enumerate() {
         let mdast::Node::TableRow(r) = row else {
             continue;
         };
+        let is_header = ri == 0;
+        // The mdast table has no separator child: row 0 is the header, row 1 the
+        // first body row (body_index 0).
+        let body_index = ri.checked_sub(1);
         let mut row_el = div().flex().flex_row();
-        if ri > 0 {
+        // Top divider: under every row (Grid), just under the header
+        // (Striped/Minimal → the first body row's top), or never (Header).
+        let top_divider = if row_lines {
+            !is_header
+        } else {
+            header_rule && body_index == Some(0)
+        };
+        if top_divider {
             row_el = row_el.border_t_1().border_color(border);
+        }
+        // Row shading: the header (Header style) or alternate body rows (Striped).
+        let shaded = match style {
+            TableStyle::Header => is_header,
+            TableStyle::Striped => body_index.is_some_and(|b| b % 2 == 1),
+            _ => false,
+        };
+        if shaded {
+            row_el = row_el.bg(shade);
         }
         for (ci, cell) in r.children.iter().enumerate() {
             let mdast::Node::TableCell(c) = cell else {
                 continue;
             };
-            let mut cell_el = div()
-                .flex_1()
-                .min_w_0()
-                .px(px(10.0))
-                .py(px(6.0))
-                .border_r_1()
-                .border_color(border);
+            let mut cell_el = div().flex_1().min_w_0().px(px(10.0)).py(px(6.0));
+            if vlines {
+                cell_el = cell_el.border_r_1().border_color(border);
+            }
             // Honor the column's GFM alignment (`:---:` / `---:`).
             match table.align.get(ci) {
                 Some(mdast::AlignKind::Center) => cell_el = cell_el.text_center(),
                 Some(mdast::AlignKind::Right) => cell_el = cell_el.text_right(),
                 _ => {}
             }
-            if ri == 0 {
+            if is_header {
                 cell_el = cell_el.font_weight(FontWeight::BOLD);
             }
             row_el = row_el.child(cell_el.child(inline_element(&c.children, ctx)));
@@ -1308,19 +1382,23 @@ pub fn find_matches(source: &str, query: &str) -> Vec<usize> {
 /// returning `Some`). Kept in sync with `render_block` so `find_matches`' block
 /// indices line up with the `track_blocks` handle's `bounds_for_item`.
 fn renders_to_block(node: &mdast::Node) -> bool {
-    matches!(
-        node,
-        mdast::Node::Paragraph(_)
-            | mdast::Node::Heading(_)
-            | mdast::Node::List(_)
-            | mdast::Node::Code(_)
-            | mdast::Node::Blockquote(_)
-            | mdast::Node::ThematicBreak(_)
-            | mdast::Node::Table(_)
-            | mdast::Node::FootnoteDefinition(_)
-            | mdast::Node::Html(_)
-            | mdast::Node::Text(_)
-    )
+    match node {
+        // A `<!-- table:STYLE -->` marker is hidden (folded into the next table),
+        // so it isn't a column child; other HTML renders as a muted block.
+        mdast::Node::Html(h) => table_style_marker(&h.value).is_none(),
+        _ => matches!(
+            node,
+            mdast::Node::Paragraph(_)
+                | mdast::Node::Heading(_)
+                | mdast::Node::List(_)
+                | mdast::Node::Code(_)
+                | mdast::Node::Blockquote(_)
+                | mdast::Node::ThematicBreak(_)
+                | mdast::Node::Table(_)
+                | mdast::Node::FootnoteDefinition(_)
+                | mdast::Node::Text(_)
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -1336,6 +1414,20 @@ mod search_tests {
         assert_eq!(scan_matches("aaaa", "aa"), vec![0..2, 2..4]); // non-overlapping
         assert!(scan_matches("abc", "").is_empty());
         assert!(scan_matches("abc", "xyz").is_empty());
+    }
+
+    #[test]
+    fn table_style_marker_parses() {
+        assert_eq!(
+            table_style_marker("<!-- table:striped -->"),
+            Some(TableStyle::Striped)
+        );
+        assert_eq!(
+            table_style_marker("<!--table:header-->"),
+            Some(TableStyle::Header)
+        );
+        assert_eq!(table_style_marker("<!-- table:nope -->"), None);
+        assert_eq!(table_style_marker("<!-- ordinary -->"), None);
     }
 
     #[test]

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -75,13 +75,14 @@ pub fn bind_keys(cx: &mut App) {
     // indent actions so the menu, Tab, and Esc work there too. `gpui_editor::
     // bind_keys` runs first (see `main`), so these are tried first and the
     // handlers `cx.propagate()` to fall through to the editor when not consumed.
+    // Note: Tab / Shift+Tab are NOT rebound here — gpui-editor owns them as its
+    // own `Indent`/`Outdent` (configurable, list-aware), so they work reliably in
+    // the always-live editor without depending on the app's focus flags.
     cx.bind_keys([
         KeyBinding::new("up", SlashUp, Some(EDITOR_CONTEXT)),
         KeyBinding::new("down", SlashDown, Some(EDITOR_CONTEXT)),
         KeyBinding::new("enter", SlashConfirm, Some(EDITOR_CONTEXT)),
         KeyBinding::new("escape", SlashCancel, Some(EDITOR_CONTEXT)),
-        KeyBinding::new("tab", InsertTab, Some(EDITOR_CONTEXT)),
-        KeyBinding::new("shift-tab", Outdent, Some(EDITOR_CONTEXT)),
     ]);
     // Paste-image: bind the platform's real paste chord — Cmd+V on macOS, Ctrl+V on
     // Windows/Linux. gpui treats `cmd-` and `ctrl-` as distinct chords, so a bare

--- a/src/app.rs
+++ b/src/app.rs
@@ -3394,6 +3394,14 @@ impl AppView {
             return false;
         };
         let value = editor.read(cx).value().to_string();
+        // Only typed characters / single-char backspaces auto-pair. A programmatic
+        // or multi-char edit (table row/column ops, paste, …) just refreshes the
+        // baseline so the next keystroke compares correctly — without rewriting the
+        // text or moving the caret.
+        if !editor.read(cx).last_edit_was_keystroke() {
+            self.set_autopair_prev(target, value);
+            return false;
+        }
         let cursor = editor.read(cx).cursor().min(value.len());
         let prev = self.autopair_prev(target);
         // Each arm yields the rewritten text and where the caret should land.

--- a/src/app.rs
+++ b/src/app.rs
@@ -701,6 +701,11 @@ impl AppView {
                     this.update_slash(SlashTarget::Day(key.clone()), cx);
                     this.schedule_spellcheck(st.clone(), cx);
                 }
+                EditorEvent::OpenLink(src) => {
+                    if let Some(path) = crate::pdf::resolve_path(src) {
+                        this.open_pdf(path, window, cx);
+                    }
+                }
             },
         );
         // gpui-editor has no Focus/Blur events; listen on its focus handle.
@@ -1415,6 +1420,11 @@ impl AppView {
                     }
                     this.update_slash(SlashTarget::Page(pid), cx);
                     this.schedule_spellcheck(st.clone(), cx);
+                }
+                EditorEvent::OpenLink(src) => {
+                    if let Some(path) = crate::pdf::resolve_path(src) {
+                        this.open_pdf(path, window, cx);
+                    }
                 }
             },
         );
@@ -5473,6 +5483,16 @@ fn make_editor(
         // Inline images (W4): resolve a standalone image's src to its decoded
         // bitmap from the shared store (None until decoding finishes / on fail).
         editor.set_block_image_provider(move |src| image_store.borrow().get(src));
+        // A `![](file.pdf)` renders as a clickable chip (label = file name) that
+        // opens the PDF viewer on click — matching the reading view.
+        editor.set_block_chip_provider(|src| {
+            crate::pdf::is_pdf(src).then(|| {
+                crate::pdf::resolve_path(src)
+                    .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+                    .unwrap_or_else(|| src.to_string())
+                    .into()
+            })
+        });
         editor
     });
     // Live-preview markdown styling when WYSIWYG is on — mirrors the rendered

--- a/src/app.rs
+++ b/src/app.rs
@@ -228,6 +228,47 @@ const MAX_IMAGE_DECODES: usize = 3;
 /// Open rows×cols table-size picker (from the `/table` command). Hovering its
 /// grid sets `rows`/`cols` (1-based; 0 = nothing hovered yet); a click inserts a
 /// table of that size at `start`, replacing the `/table` query.
+/// A table visual design offered by the `/table` picker. Maps to the
+/// `<!-- table:STYLE -->` marker the renderers honor; `Grid` is the default and
+/// writes no marker (a plain table).
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum TableDesign {
+    #[default]
+    Grid,
+    Striped,
+    Header,
+    Minimal,
+}
+
+impl TableDesign {
+    pub const ALL: [TableDesign; 4] = [
+        TableDesign::Grid,
+        TableDesign::Striped,
+        TableDesign::Header,
+        TableDesign::Minimal,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            TableDesign::Grid => "Grid",
+            TableDesign::Striped => "Striped",
+            TableDesign::Header => "Header",
+            TableDesign::Minimal => "Minimal",
+        }
+    }
+
+    /// The hidden `<!-- table:NAME -->` marker line, or `None` for the default
+    /// `Grid` (written without a marker). The names match the editor's parser.
+    fn marker(self) -> Option<&'static str> {
+        match self {
+            TableDesign::Grid => None,
+            TableDesign::Striped => Some("<!-- table:striped -->"),
+            TableDesign::Header => Some("<!-- table:header -->"),
+            TableDesign::Minimal => Some("<!-- table:minimal -->"),
+        }
+    }
+}
+
 pub struct TablePicker {
     target: SlashTarget,
     /// Byte offset of the `/` to replace in the target editor.
@@ -236,6 +277,8 @@ pub struct TablePicker {
     caret: gpui::Bounds<gpui::Pixels>,
     pub rows: usize,
     pub cols: usize,
+    /// The chosen visual design (its marker is prepended on insert).
+    pub style: TableDesign,
     /// Typed custom dimensions, for tables larger than the hover grid.
     pub rows_input: Entity<InputState>,
     pub cols_input: Entity<InputState>,
@@ -1732,6 +1775,7 @@ impl AppView {
                     caret,
                     rows: 0,
                     cols: 0,
+                    style: TableDesign::Grid,
                     rows_input,
                     cols_input,
                 });
@@ -1921,6 +1965,15 @@ impl AppView {
         }
     }
 
+    /// Select a table design in the open picker (highlighted; its marker is
+    /// prepended when a size is then chosen).
+    pub fn table_picker_set_style(&mut self, style: TableDesign, cx: &mut Context<Self>) {
+        if let Some(p) = self.table_picker.as_mut() {
+            p.style = style;
+            cx.notify();
+        }
+    }
+
     /// Close the `/table` picker without inserting.
     pub fn cancel_table_picker(&mut self, cx: &mut Context<Self>) {
         if self.table_picker.take().is_some() {
@@ -1942,7 +1995,16 @@ impl AppView {
         };
         let row = format!("|{}", "  |".repeat(cols));
         let sep = format!("|{}", " --- |".repeat(cols));
-        let mut lines = vec![row.clone(), sep];
+        // The design's hidden marker (if any) goes on the line directly above the
+        // header, so the editor associates it with this table.
+        let mut lines = Vec::new();
+        if let Some(marker) = p.style.marker() {
+            lines.push(marker.to_string());
+        }
+        // Byte length of the marker line(s) + their newline, before the header.
+        let header_off: usize = lines.iter().map(|l| l.len() + 1).sum();
+        lines.push(row.clone());
+        lines.push(sep);
         for _ in 1..rows {
             lines.push(row.clone());
         }
@@ -1951,7 +2013,7 @@ impl AppView {
         let cursor = editor.read(cx).cursor().min(value.len());
         let start = p.start.min(cursor);
         let new = format!("{}{}{}", &value[..start], snippet, &value[cursor..]);
-        let caret_off = start + 2; // first cell, just after "| "
+        let caret_off = start + header_off + 2; // first header cell, just after "| "
         editor.update(cx, |st, cx| {
             st.set_text(new.clone(), cx);
             st.set_cursor(caret_off, cx);

--- a/src/app.rs
+++ b/src/app.rs
@@ -665,7 +665,8 @@ impl AppView {
             .flatten()
             .map(|p| p.content)
             .unwrap_or_default();
-        let state = make_editor(&content, self.wysiwyg, window, cx);
+        let state = make_editor(&content, self.wysiwyg, self.image_store(), window, cx);
+        self.ensure_content_images(&content, cx);
         let key = date.clone();
         let sub = cx.subscribe_in(
             &state,
@@ -1380,7 +1381,8 @@ impl AppView {
             }
         };
         let pid = page.id;
-        let state = make_editor(&page.content, self.wysiwyg, window, cx);
+        let state = make_editor(&page.content, self.wysiwyg, self.image_store(), window, cx);
+        self.ensure_content_images(&page.content, cx);
         let sub = cx.subscribe_in(
             &state,
             window,
@@ -1947,6 +1949,16 @@ impl AppView {
         self.mermaid_lightbox = None;
         window.focus(&self.focus_handle, cx);
         cx.notify();
+    }
+
+    /// Kick off decoding for every standalone image in `content`, so an editor in
+    /// WYSIWYG mode can render them inline (W4) rather than as raw `![](src)`.
+    /// `ensure_image_loaded` dedupes, so re-scanning is cheap; a finished decode
+    /// notifies → repaint → the editor's block-image provider finds the bitmap.
+    fn ensure_content_images(&mut self, content: &str, cx: &mut Context<Self>) {
+        for info in gpui_markdown::images(content) {
+            self.ensure_image_loaded(info.src, cx);
+        }
     }
 
     /// Ensure the image at `src` is decoding/decoded (idempotent). Called from a
@@ -5308,6 +5320,7 @@ fn align_caret_to_click(mut state: CaretAlign, window: &mut Window) {
 fn make_editor(
     content: &str,
     wysiwyg: bool,
+    image_store: Rc<RefCell<crate::images::ImageStore>>,
     window: &mut Window,
     cx: &mut Context<AppView>,
 ) -> Entity<EditorState> {
@@ -5318,6 +5331,9 @@ fn make_editor(
         let mut editor = EditorState::new(window, cx).with_text(content);
         // Right-click a flagged word → the OS's suggestions, fetched lazily.
         editor.on_suggest(|word| spellcheck::SpellChecker::new().suggestions(word));
+        // Inline images (W4): resolve a standalone image's src to its decoded
+        // bitmap from the shared store (None until decoding finishes / on fail).
+        editor.set_block_image_provider(move |src| image_store.borrow().get(src));
         editor
     });
     // Live-preview markdown styling when WYSIWYG is on — mirrors the rendered

--- a/src/app.rs
+++ b/src/app.rs
@@ -687,6 +687,7 @@ impl AppView {
         let state = make_editor(
             &content,
             self.wysiwyg,
+            self.list_indent,
             self.image_store(),
             self.mermaid_store(),
             window,
@@ -1416,6 +1417,7 @@ impl AppView {
         let state = make_editor(
             &page.content,
             self.wysiwyg,
+            self.list_indent,
             self.image_store(),
             self.mermaid_store(),
             window,
@@ -3766,8 +3768,32 @@ impl AppView {
         if !matches!(spaces, 2 | 4 | 8) || spaces == self.list_indent {
             return;
         }
+        let old = self.list_indent;
         self.list_indent = spaces;
         let _ = self.db.set_setting("list_indent", &spaces.to_string());
+        // For every open editor: update its Tab unit, then re-indent its existing
+        // list items from the old width to the new one and persist, so the change
+        // re-flows live. Collect (target, state) first to not borrow `self` across
+        // the updates.
+        let mut targets: Vec<(SlashTarget, Entity<EditorState>)> = self
+            .day_editors
+            .iter()
+            .map(|(d, de)| (SlashTarget::Day(d.clone()), de.state.clone()))
+            .collect();
+        if let Some(pe) = self.page_editor.as_ref() {
+            targets.push((SlashTarget::Page(pe.id), pe.state.clone()));
+        }
+        for (target, state) in targets {
+            state.update(cx, |editor, _| editor.set_tab_indent(spaces));
+            let content = state.read(cx).value().to_string();
+            if let Some(new) = gpui_markdown::reindent(&content, old, spaces) {
+                state.update(cx, |editor, cx| editor.set_text(new.clone(), cx));
+                match &target {
+                    SlashTarget::Day(d) => self.save_journal(d, &new, cx),
+                    SlashTarget::Page(pid) => self.save_page_content(*pid, &new, cx),
+                }
+            }
+        }
         cx.notify();
     }
 
@@ -5496,6 +5522,7 @@ fn align_caret_to_click(mut state: CaretAlign, window: &mut Window) {
 fn make_editor(
     content: &str,
     wysiwyg: bool,
+    list_indent: usize,
     image_store: Rc<RefCell<crate::images::ImageStore>>,
     mermaid_store: Rc<RefCell<crate::mermaid::MermaidStore>>,
     window: &mut Window,
@@ -5528,6 +5555,8 @@ fn make_editor(
                 .borrow()
                 .get(&gpui::SharedString::from(source))
         });
+        // Tab / Shift+Tab indent by the configured number of spaces per level.
+        editor.set_tab_indent(list_indent);
         editor
     });
     // Live-preview markdown styling when WYSIWYG is on — mirrors the rendered

--- a/src/app.rs
+++ b/src/app.rs
@@ -684,8 +684,16 @@ impl AppView {
             .flatten()
             .map(|p| p.content)
             .unwrap_or_default();
-        let state = make_editor(&content, self.wysiwyg, self.image_store(), window, cx);
+        let state = make_editor(
+            &content,
+            self.wysiwyg,
+            self.image_store(),
+            self.mermaid_store(),
+            window,
+            cx,
+        );
         self.ensure_content_images(&content, cx);
+        self.ensure_content_mermaid(&content, cx);
         let key = date.clone();
         let sub = cx.subscribe_in(
             &state,
@@ -1405,8 +1413,16 @@ impl AppView {
             }
         };
         let pid = page.id;
-        let state = make_editor(&page.content, self.wysiwyg, self.image_store(), window, cx);
+        let state = make_editor(
+            &page.content,
+            self.wysiwyg,
+            self.image_store(),
+            self.mermaid_store(),
+            window,
+            cx,
+        );
         self.ensure_content_images(&page.content, cx);
+        self.ensure_content_mermaid(&page.content, cx);
         let sub = cx.subscribe_in(
             &state,
             window,
@@ -2083,6 +2099,17 @@ impl AppView {
     fn ensure_content_images(&mut self, content: &str, cx: &mut Context<Self>) {
         for info in gpui_markdown::images(content) {
             self.ensure_image_loaded(info.src, cx);
+        }
+    }
+
+    /// Kick off the off-thread render of every ```mermaid block in `content`, so
+    /// an editor in WYSIWYG mode can render them as diagrams. Idempotent (the
+    /// store dedupes); a finished render notifies → repaint → the editor's mermaid
+    /// provider finds the bitmap. Uses the editor's extraction so the cache key
+    /// matches what the editor looks up.
+    fn ensure_content_mermaid(&mut self, content: &str, cx: &mut Context<Self>) {
+        for source in gpui_editor::mermaid_sources(content) {
+            self.ensure_mermaid_loaded(source, cx);
         }
     }
 
@@ -5470,6 +5497,7 @@ fn make_editor(
     content: &str,
     wysiwyg: bool,
     image_store: Rc<RefCell<crate::images::ImageStore>>,
+    mermaid_store: Rc<RefCell<crate::mermaid::MermaidStore>>,
     window: &mut Window,
     cx: &mut Context<AppView>,
 ) -> Entity<EditorState> {
@@ -5492,6 +5520,13 @@ fn make_editor(
                     .unwrap_or_else(|| src.to_string())
                     .into()
             })
+        });
+        // A ```mermaid block renders as its diagram from the shared store (None
+        // until the off-thread render finishes — the block shows raw code then).
+        editor.set_block_mermaid_provider(move |source| {
+            mermaid_store
+                .borrow()
+                .get(&gpui::SharedString::from(source))
         });
         editor
     });

--- a/src/app.rs
+++ b/src/app.rs
@@ -262,6 +262,10 @@ pub struct AppView {
     check_updates: bool,
     /// Whether the update check considers pre-releases (betas), persisted.
     include_prerelease: bool,
+    /// WYSIWYG live-preview editing, persisted (default on). On = the editor
+    /// shows inline markdown formatting as you type (W1+); off = "editor mode",
+    /// plain raw markdown in edit + the rendered page on Esc (the classic flow).
+    wysiwyg: bool,
     /// In the feed, the date currently being edited (raw editor); all
     /// other days render as markdown. `None` = every day rendered.
     editing_day: Option<String>,
@@ -524,6 +528,7 @@ impl AppView {
             list_indent: DEFAULT_LIST_INDENT,
             check_updates: true,
             include_prerelease: false,
+            wysiwyg: true,
             editing_day: None,
             page_editing: false,
             loaded_days: 0,
@@ -616,6 +621,11 @@ impl AppView {
             .get_setting("include_prerelease")
             .map(|v| v == "1")
             .unwrap_or(false);
+        this.wysiwyg = this
+            .db
+            .get_setting("wysiwyg")
+            .map(|v| v != "0")
+            .unwrap_or(true);
         // Date/time display formats for /date, /time, and {{date}}/{{time}} —
         // applied to the thread-local in `crate::dates`; validated against the
         // known ids so a stale persisted value can't stick.
@@ -655,7 +665,7 @@ impl AppView {
             .flatten()
             .map(|p| p.content)
             .unwrap_or_default();
-        let state = make_editor(&content, window, cx);
+        let state = make_editor(&content, self.wysiwyg, window, cx);
         let key = date.clone();
         let sub = cx.subscribe_in(
             &state,
@@ -1370,7 +1380,7 @@ impl AppView {
             }
         };
         let pid = page.id;
-        let state = make_editor(&page.content, window, cx);
+        let state = make_editor(&page.content, self.wysiwyg, window, cx);
         let sub = cx.subscribe_in(
             &state,
             window,
@@ -3615,6 +3625,40 @@ impl AppView {
             .set_setting("check_updates", if on { "1" } else { "0" });
     }
 
+    /// Whether WYSIWYG live-preview editing is on (default). Off = "editor mode":
+    /// raw markdown while editing, rendered page on Esc.
+    pub fn wysiwyg(&self) -> bool {
+        self.wysiwyg
+    }
+
+    /// Toggle WYSIWYG live-preview editing; persists, then re-applies to every
+    /// open editor so the change takes effect without reopening notes.
+    pub fn set_wysiwyg(&mut self, on: bool, cx: &mut Context<Self>) {
+        if self.wysiwyg == on {
+            return;
+        }
+        self.wysiwyg = on;
+        let _ = self.db.set_setting("wysiwyg", if on { "1" } else { "0" });
+        // Set or clear live-preview styling on each open editor. Collect the
+        // handles first so we don't hold a borrow of `self` across `update`.
+        let states: Vec<Entity<EditorState>> = self
+            .day_editors
+            .values()
+            .map(|de| de.state.clone())
+            .chain(self.page_editor.as_ref().map(|pe| pe.state.clone()))
+            .collect();
+        for state in states {
+            state.update(cx, |editor, cx| {
+                if on {
+                    editor.set_markdown_style(theme::editor_syntax_style(), cx);
+                } else {
+                    editor.clear_markdown_style(cx);
+                }
+            });
+        }
+        cx.notify();
+    }
+
     /// Include / exclude pre-releases in the update check; persists, then re-runs
     /// the check so the indicator reflects the new preference right away.
     pub fn set_include_prerelease(&mut self, on: bool, cx: &mut Context<Self>) {
@@ -5263,6 +5307,7 @@ fn align_caret_to_click(mut state: CaretAlign, window: &mut Window) {
 /// effectively means "never scroll internally".
 fn make_editor(
     content: &str,
+    wysiwyg: bool,
     window: &mut Window,
     cx: &mut Context<AppView>,
 ) -> Entity<EditorState> {
@@ -5275,11 +5320,14 @@ fn make_editor(
         editor.on_suggest(|word| spellcheck::SpellChecker::new().suggestions(word));
         editor
     });
-    // Live-preview markdown styling — mirrors the rendered view's colors so
-    // formatting (bold/italic/code/links/tags) shows inline as you type (W1).
-    editor.update(cx, |editor, cx| {
-        editor.set_markdown_style(theme::editor_syntax_style(), cx)
-    });
+    // Live-preview markdown styling when WYSIWYG is on — mirrors the rendered
+    // view's colors so formatting (bold/italic/code/links/tags) shows inline as
+    // you type (W1). Off = plain raw markdown ("editor mode").
+    if wysiwyg {
+        editor.update(cx, |editor, cx| {
+            editor.set_markdown_style(theme::editor_syntax_style(), cx)
+        });
+    }
     editor
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -284,6 +284,17 @@ pub struct TablePicker {
     pub cols_input: Entity<InputState>,
 }
 
+/// The floating Left/Center/Right control shown while the caret is in a table
+/// cell, anchored at the caret. Clicking a button rewrites that column's
+/// alignment in the table's `|---|` separator.
+pub struct AlignToolbar {
+    editor: gpui::WeakEntity<EditorState>,
+    /// Caret bounds (window space) to anchor the toolbar.
+    caret: gpui::Bounds<gpui::Pixels>,
+    /// The column's current alignment, so its button reads as selected.
+    current: gpui_editor::CellAlign,
+}
+
 pub struct AppView {
     db: Db,
     /// This view's window, so it can tell whether a cross-window tab drag is
@@ -418,6 +429,8 @@ pub struct AppView {
     slash: Option<Slash>,
     /// Open `/table` rows×cols picker, if any.
     table_picker: Option<TablePicker>,
+    /// The table-column alignment toolbar, shown while the caret is in a table.
+    align_toolbar: Option<AlignToolbar>,
     /// Debounced spell-check for the focused body editor; replacing it cancels
     /// the prior pending run so we don't hit the OS spell service per keystroke.
     spell_task: Option<Task<()>>,
@@ -621,6 +634,7 @@ impl AppView {
             search: crate::search::Results::default(),
             slash: None,
             table_picker: None,
+            align_toolbar: None,
             spell_task: None,
             signal_task: None,
             templates: Vec::new(),
@@ -752,12 +766,14 @@ impl AppView {
                     }
                     this.update_slash(SlashTarget::Day(key.clone()), cx);
                     this.schedule_spellcheck(st.clone(), cx);
+                    this.refresh_align_toolbar(st, cx);
                 }
                 EditorEvent::OpenLink(src) => {
                     if let Some(path) = crate::pdf::resolve_path(src) {
                         this.open_pdf(path, window, cx);
                     }
                 }
+                EditorEvent::SelectionChanged => this.refresh_align_toolbar(st, cx),
             },
         );
         // gpui-editor has no Focus/Blur events; listen on its focus handle.
@@ -1481,12 +1497,14 @@ impl AppView {
                     }
                     this.update_slash(SlashTarget::Page(pid), cx);
                     this.schedule_spellcheck(st.clone(), cx);
+                    this.refresh_align_toolbar(st, cx);
                 }
                 EditorEvent::OpenLink(src) => {
                     if let Some(path) = crate::pdf::resolve_path(src) {
                         this.open_pdf(path, window, cx);
                     }
                 }
+                EditorEvent::SelectionChanged => this.refresh_align_toolbar(st, cx),
             },
         );
         // gpui-editor has no Focus/Blur events; listen on its focus handle.
@@ -1970,6 +1988,26 @@ impl AppView {
     pub fn table_picker_set_style(&mut self, style: TableDesign, cx: &mut Context<Self>) {
         if let Some(p) = self.table_picker.as_mut() {
             p.style = style;
+            cx.notify();
+        }
+    }
+
+    /// Recompute the alignment toolbar from `editor`'s caret: show it (anchored at
+    /// the caret) while the caret is in a table cell, hide it otherwise. Called on
+    /// the editor's `SelectionChanged` / `Changed`; only notifies when it changes.
+    fn refresh_align_toolbar(&mut self, editor: &Entity<EditorState>, cx: &mut Context<Self>) {
+        let ed = editor.read(cx);
+        let next = ed.caret_table_align().and_then(|current| {
+            ed.bounds_for_offset(ed.cursor()).map(|caret| AlignToolbar {
+                editor: editor.downgrade(),
+                caret,
+                current,
+            })
+        });
+        let before = self.align_toolbar.as_ref().map(|t| (t.current, t.caret));
+        let after = next.as_ref().map(|t| (t.current, t.caret));
+        self.align_toolbar = next;
+        if before != after {
             cx.notify();
         }
     }
@@ -4987,6 +5025,22 @@ impl Render for AppView {
             .into_any_element()
         });
 
+        // The table column-alignment toolbar, floated just above the caret while
+        // it's in a table cell. No backdrop — it's a non-modal affordance.
+        let align_toolbar_overlay = self.align_toolbar.as_ref().and_then(|tb| {
+            let editor = tb.editor.upgrade()?;
+            let pos = gpui::point(tb.caret.origin.x, tb.caret.origin.y - px(30.0));
+            Some(
+                gpui::deferred(
+                    gpui::anchored()
+                        .position(pos)
+                        .snap_to_window()
+                        .child(ui::align_toolbar::render(tb.current, editor, cx)),
+                )
+                .into_any_element(),
+            )
+        });
+
         // While resizing an image, a transparent full-window layer captures the
         // mouse so the drag continues even as the pointer leaves the handle.
         let drag_overlay = self.image_drag.as_ref().map(|_| {
@@ -5354,6 +5408,7 @@ impl Render for AppView {
             )
             .children(overlay)
             .children(table_picker_overlay)
+            .children(align_toolbar_overlay)
             .children(drag_overlay)
             .children(calendar_overlay)
             .children(mermaid_lightbox)

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,9 +19,9 @@ use std::rc::Rc;
 use gpui::{
     AnyWindowHandle, App, AppContext, Bounds, ClipboardEntry, ClipboardItem, Context, CursorStyle,
     Entity, EventEmitter, FocusHandle, Focusable, Global, ImageFormat, InteractiveElement,
-    IntoElement, MouseButton, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Point, Render,
-    ScrollHandle, SharedString, StatefulInteractiveElement, Styled, Subscription, Task,
-    TitlebarOptions, WeakEntity, Window, WindowAppearance, WindowBounds, WindowDecorations,
+    IntoElement, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels,
+    Point, Render, ScrollHandle, SharedString, StatefulInteractiveElement, Styled, Subscription,
+    Task, TitlebarOptions, WeakEntity, Window, WindowAppearance, WindowBounds, WindowDecorations,
     WindowHandle, WindowOptions, div, point, px, size,
 };
 use gpui_component::{
@@ -225,6 +225,22 @@ const RECENT_PAGES_LIMIT: usize = 10;
 /// RAM at ~100 MB while loading a photo page ~3× faster than one-at-a-time.
 const MAX_IMAGE_DECODES: usize = 3;
 
+/// Open rows×cols table-size picker (from the `/table` command). Hovering its
+/// grid sets `rows`/`cols` (1-based; 0 = nothing hovered yet); a click inserts a
+/// table of that size at `start`, replacing the `/table` query.
+pub struct TablePicker {
+    target: SlashTarget,
+    /// Byte offset of the `/` to replace in the target editor.
+    start: usize,
+    /// Caret bounds (window space) to anchor the popup.
+    caret: gpui::Bounds<gpui::Pixels>,
+    pub rows: usize,
+    pub cols: usize,
+    /// Typed custom dimensions, for tables larger than the hover grid.
+    pub rows_input: Entity<InputState>,
+    pub cols_input: Entity<InputState>,
+}
+
 pub struct AppView {
     db: Db,
     /// This view's window, so it can tell whether a cross-window tab drag is
@@ -357,6 +373,8 @@ pub struct AppView {
     pub search: crate::search::Results,
     /// Open slash-command menu, if any.
     slash: Option<Slash>,
+    /// Open `/table` rows×cols picker, if any.
+    table_picker: Option<TablePicker>,
     /// Debounced spell-check for the focused body editor; replacing it cancels
     /// the prior pending run so we don't hit the OS spell service per keystroke.
     spell_task: Option<Task<()>>,
@@ -559,6 +577,7 @@ impl AppView {
             collapsed_sections: HashSet::new(),
             search: crate::search::Results::default(),
             slash: None,
+            table_picker: None,
             spell_task: None,
             signal_task: None,
             templates: Vec::new(),
@@ -1658,6 +1677,7 @@ impl AppView {
         enum Act {
             Enter(SlashLevel),
             Insert(String, usize),
+            OpenPicker(SlashTarget, usize, gpui::Bounds<gpui::Pixels>),
         }
         let act = {
             let Some(s) = self.slash.as_ref() else { return };
@@ -1668,11 +1688,27 @@ impl AppView {
             match &item.kind {
                 ItemKind::Category(level) => Act::Enter(*level),
                 ItemKind::Insert { snippet, caret } => Act::Insert(snippet.clone(), *caret),
+                ItemKind::TablePicker => Act::OpenPicker(s.target.clone(), s.start, s.caret),
             }
         };
         match act {
             Act::Enter(level) => self.enter_slash_category(level, cx),
             Act::Insert(snippet, caret) => self.insert_slash(snippet, caret, window, cx),
+            Act::OpenPicker(target, start, caret) => {
+                self.slash = None;
+                let rows_input = cx.new(|cx| InputState::new(window, cx).placeholder("rows"));
+                let cols_input = cx.new(|cx| InputState::new(window, cx).placeholder("cols"));
+                self.table_picker = Some(TablePicker {
+                    target,
+                    start,
+                    caret,
+                    rows: 0,
+                    cols: 0,
+                    rows_input,
+                    cols_input,
+                });
+                cx.notify();
+            }
         }
     }
 
@@ -1844,6 +1880,85 @@ impl AppView {
             SlashTarget::Day(d) => self.day_editors.get(d).map(|de| de.state.clone()),
             SlashTarget::Page(_) => self.page_editor.as_ref().map(|pe| pe.state.clone()),
         }
+    }
+
+    /// Hovering the `/table` picker grid previews a size (1-based; 0 = none).
+    pub fn table_picker_hover(&mut self, rows: usize, cols: usize, cx: &mut Context<Self>) {
+        if let Some(p) = self.table_picker.as_mut()
+            && (p.rows != rows || p.cols != cols)
+        {
+            p.rows = rows;
+            p.cols = cols;
+            cx.notify();
+        }
+    }
+
+    /// Close the `/table` picker without inserting.
+    pub fn cancel_table_picker(&mut self, cx: &mut Context<Self>) {
+        if self.table_picker.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    /// Insert a `rows`×`cols` Markdown table (header + separator + body, empty
+    /// cells) at the picker's start, replacing the `/table` query, caret in the
+    /// first cell.
+    pub fn table_picker_pick(&mut self, rows: usize, cols: usize, cx: &mut Context<Self>) {
+        let Some(p) = self.table_picker.take() else {
+            return;
+        };
+        let (rows, cols) = (rows.max(1), cols.max(1));
+        let Some(editor) = self.editor_for(&p.target) else {
+            cx.notify();
+            return;
+        };
+        let row = format!("|{}", "  |".repeat(cols));
+        let sep = format!("|{}", " --- |".repeat(cols));
+        let mut lines = vec![row.clone(), sep];
+        for _ in 1..rows {
+            lines.push(row.clone());
+        }
+        let snippet = format!("{}\n", lines.join("\n"));
+        let value = editor.read(cx).value().to_string();
+        let cursor = editor.read(cx).cursor().min(value.len());
+        let start = p.start.min(cursor);
+        let new = format!("{}{}{}", &value[..start], snippet, &value[cursor..]);
+        let caret_off = start + 2; // first cell, just after "| "
+        editor.update(cx, |st, cx| {
+            st.set_text(new.clone(), cx);
+            st.set_cursor(caret_off, cx);
+        });
+        match &p.target {
+            SlashTarget::Day(d) => self.save_journal(d, &new, cx),
+            SlashTarget::Page(pid) => self.save_page_content(*pid, &new, cx),
+        }
+        cx.notify();
+    }
+
+    /// Insert a table from the picker's typed custom dimensions (for sizes beyond
+    /// the hover grid). No-op unless both fields are positive numbers.
+    pub fn table_picker_insert_custom(&mut self, cx: &mut Context<Self>) {
+        let (rows, cols) = match self.table_picker.as_ref() {
+            Some(p) => (
+                p.rows_input
+                    .read(cx)
+                    .value()
+                    .trim()
+                    .parse::<usize>()
+                    .unwrap_or(0),
+                p.cols_input
+                    .read(cx)
+                    .value()
+                    .trim()
+                    .parse::<usize>()
+                    .unwrap_or(0),
+            ),
+            None => return,
+        };
+        if rows == 0 || cols == 0 {
+            return;
+        }
+        self.table_picker_pick(rows.min(100), cols.min(100), cx);
     }
 
     /// On Enter with the slash menu closed: continue a markdown list / blockquote
@@ -4724,6 +4839,29 @@ impl Render for AppView {
             .into_any_element()
         });
 
+        // The `/table` size picker: a full-window backdrop (click outside to
+        // cancel) with the hover-grid anchored at the caret.
+        let table_picker_overlay = self.table_picker.as_ref().map(|p| {
+            gpui::deferred(
+                div()
+                    .absolute()
+                    .inset_0()
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this: &mut AppView, _: &MouseDownEvent, _, cx| {
+                            this.cancel_table_picker(cx);
+                        }),
+                    )
+                    .child(
+                        gpui::anchored()
+                            .position(p.caret.bottom_left())
+                            .snap_to_window()
+                            .child(ui::table_picker::render(p, cx)),
+                    ),
+            )
+            .into_any_element()
+        });
+
         // While resizing an image, a transparent full-window layer captures the
         // mouse so the drag continues even as the pointer leaves the handle.
         let drag_overlay = self.image_drag.as_ref().map(|_| {
@@ -5090,6 +5228,7 @@ impl Render for AppView {
                     ),
             )
             .children(overlay)
+            .children(table_picker_overlay)
             .children(drag_overlay)
             .children(calendar_overlay)
             .children(mermaid_lightbox)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,6 +19,7 @@ use gpui_component::{
     dialog::DialogButtonProps,
     select::{Select, SelectEvent, SelectItem, SelectState},
     slider::{Slider, SliderEvent, SliderState},
+    switch::Switch,
 };
 
 use crate::app::AppView;
@@ -497,6 +498,24 @@ impl Render for SettingsView {
                     .child(format!("{qpct}%")),
             );
 
+        // WYSIWYG live-preview toggle (Markdown pane), as a switch. Controlled:
+        // `.checked` reflects the persisted setting each render; the click
+        // persists + re-applies to open editors via `set_wysiwyg`.
+        let wys_on = self
+            .app
+            .upgrade()
+            .map(|a| a.read(cx).wysiwyg())
+            .unwrap_or(true);
+        let wys_app = self.app.clone();
+        let wysiwyg_switch =
+            Switch::new("wysiwyg-toggle")
+                .checked(wys_on)
+                .on_click(move |checked, _window, cx| {
+                    if let Some(app) = wys_app.upgrade() {
+                        app.update(cx, |a, cx| a.set_wysiwyg(*checked, cx));
+                    }
+                });
+
         // Installed-themes card body: the actions + the list (or empty state).
         let actions = div()
             .flex()
@@ -752,12 +771,20 @@ impl Render for SettingsView {
                                      slower machines. 100% = your display's native resolution.",
                                 quality_control,
                             )),
-                            Tab::Markdown => content.child(card(
-                                "List indentation",
-                                "Spaces per nesting level for Tab and bullet nesting. Editing \
+                            Tab::Markdown => content
+                                .child(card(
+                                    "WYSIWYG editing",
+                                    "On shows formatting (bold, headings, links) inline as you \
+                                     type. Off edits plain Markdown and shows the rendered page \
+                                     on Esc.",
+                                    wysiwyg_switch,
+                                ))
+                                .child(card(
+                                    "List indentation",
+                                    "Spaces per nesting level for Tab and bullet nesting. Editing \
                                      and the rendered view use the same width, so they line up.",
-                                Select::new(&self.indent_select).w_full(),
-                            )),
+                                    Select::new(&self.indent_select).w_full(),
+                                )),
                             Tab::Keyboard => {
                                 let app_rows: Vec<(&str, Vec<&str>)> = vec![
                                     ("New tab (new page)", vec![keys::MOD, "T"]),

--- a/src/slash.rs
+++ b/src/slash.rs
@@ -40,6 +40,8 @@ pub enum ItemKind {
     Category(SlashLevel),
     /// Insert `snippet`, caret at byte offset `caret` within it.
     Insert { snippet: String, caret: usize },
+    /// Open the rows×cols table-size picker (instead of inserting a fixed table).
+    TablePicker,
 }
 
 /// One entry in the open palette.
@@ -176,12 +178,18 @@ pub fn build_slash_items(
 fn markdown_items(q: &str, out: &mut Vec<PaletteItem>) {
     for s in SNIPPETS {
         if q.is_empty() || s.label.to_lowercase().contains(q) {
-            out.push(PaletteItem {
-                label: s.label.to_string(),
-                kind: ItemKind::Insert {
+            // "Table" opens the rows×cols picker; everything else inserts directly.
+            let kind = if s.label == "Table" {
+                ItemKind::TablePicker
+            } else {
+                ItemKind::Insert {
                     snippet: s.snippet.to_string(),
                     caret: s.caret,
-                },
+                }
+            };
+            out.push(PaletteItem {
+                label: s.label.to_string(),
+                kind,
             });
         }
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -220,6 +220,7 @@ pub fn editor_syntax_style() -> gpui_editor::SyntaxStyle {
         link: p.accent,
         tag: p.tag,
         quote: p.text_tertiary,
+        mark_bg: gpui::rgba(0xFFD60066).into(),
         mono: gpui::font(mono_font()),
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -219,6 +219,7 @@ pub fn editor_syntax_style() -> gpui_editor::SyntaxStyle {
         code_bg: p.glass,
         link: p.accent,
         tag: p.tag,
+        quote: p.text_tertiary,
         mono: gpui::font(mono_font()),
     }
 }

--- a/src/ui/align_toolbar.rs
+++ b/src/ui/align_toolbar.rs
@@ -1,0 +1,65 @@
+//! The table column-alignment toolbar (Left / Center / Right), shown while the
+//! caret is in a table cell and anchored just above the caret. Clicking a button
+//! rewrites that column's alignment in the table's `|---|` separator row.
+
+use gpui::{
+    Context, Entity, InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement,
+    Styled, div, px,
+};
+use gpui_editor::{CellAlign, EditorState};
+
+use crate::app::AppView;
+use crate::theme;
+
+pub fn render(
+    current: CellAlign,
+    editor: Entity<EditorState>,
+    cx: &mut Context<AppView>,
+) -> impl IntoElement {
+    let mut row = div()
+        .occlude()
+        .flex()
+        .flex_row()
+        .gap(px(2.0))
+        .bg(theme::elevated())
+        .border_1()
+        .border_color(theme::border_subtle())
+        .rounded(px(6.0))
+        .p(px(3.0));
+    for (align, label) in [
+        (CellAlign::Left, "L"),
+        (CellAlign::Center, "C"),
+        (CellAlign::Right, "R"),
+    ] {
+        let selected = current == align;
+        let ed = editor.clone();
+        row = row.child(
+            div()
+                .px(px(8.0))
+                .py(px(2.0))
+                .rounded(px(4.0))
+                .border_1()
+                .border_color(if selected {
+                    theme::accent()
+                } else {
+                    theme::border_subtle()
+                })
+                .bg(theme::glass())
+                .text_size(px(12.0))
+                .text_color(if selected {
+                    theme::text_primary()
+                } else {
+                    theme::text_secondary()
+                })
+                .child(label)
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |_this: &mut AppView, _: &MouseDownEvent, _, cx| {
+                        cx.stop_propagation();
+                        ed.update(cx, |e, cx| e.set_caret_table_align(align, cx));
+                    }),
+                ),
+        );
+    }
+    row
+}

--- a/src/ui/journal.rs
+++ b/src/ui/journal.rs
@@ -68,7 +68,10 @@ fn day_section(
         .text_color(theme::accent())
         .child(app::date_label(i));
 
-    let body = if app.is_editing_day(date) {
+    // WYSIWYG on → the live editor is the only view (it renders fully when
+    // unfocused, reveals on caret while editing). Off → the classic flow: the
+    // rendered reading view, swapped for the editor only while editing this day.
+    let body = if app.wysiwyg() || app.is_editing_day(date) {
         // gpui-editor has no chrome of its own; the wrapper sets the ambient
         // text style (size/color) the editor inherits when it shapes lines.
         div()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,3 +11,4 @@ pub mod search;
 pub mod sidebar;
 pub mod slash_menu;
 pub mod tab_bar;
+pub mod table_picker;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@
 //! journal feed and a single page). Free functions taking the `AppView`
 //! to read and a `Context<AppView>` for event listeners.
 
+pub mod align_toolbar;
 pub mod image;
 pub mod journal;
 pub mod links;

--- a/src/ui/page_view.rs
+++ b/src/ui/page_view.rs
@@ -68,7 +68,9 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
                         // is clickable all the way down.
                         .min_h(relative(1.0))
                         .child(page_title(pe))
-                        .child(if app.is_page_editing() {
+                        // WYSIWYG on → the live editor is the only view; off → the
+                        // rendered reading view, swapped for the editor while editing.
+                        .child(if app.wysiwyg() || app.is_page_editing() {
                             // gpui-editor draws no chrome; the wrapper sets the
                             // ambient text style it inherits when shaping lines.
                             div()

--- a/src/ui/table_picker.rs
+++ b/src/ui/table_picker.rs
@@ -1,0 +1,122 @@
+//! The `/table` rows×cols size picker — a hover grid rendered as an anchored
+//! overlay by `AppView`. Hovering a cell previews that many rows × columns;
+//! clicking inserts a Markdown table of that size at the `/table` position.
+
+use gpui::{
+    Context, InteractiveElement, IntoElement, MouseButton, MouseDownEvent, MouseMoveEvent,
+    ParentElement, Styled, div, px,
+};
+use gpui_component::{Sizable, input::Input};
+
+use crate::app::{AppView, TablePicker};
+use crate::theme;
+
+const MAX_COLS: usize = 8;
+const MAX_ROWS: usize = 8;
+
+pub fn render(picker: &TablePicker, cx: &mut Context<AppView>) -> impl IntoElement {
+    let (hr, hc) = (picker.rows, picker.cols);
+    let label = if hr > 0 && hc > 0 {
+        format!("{hc} × {hr}")
+    } else {
+        "Insert table".to_string()
+    };
+
+    let mut grid = div().flex().flex_col().gap(px(3.0));
+    for r in 0..MAX_ROWS {
+        let mut row = div().flex().flex_row().gap(px(3.0));
+        for c in 0..MAX_COLS {
+            let selected = r < hr && c < hc;
+            let (rr, cc) = (r + 1, c + 1);
+            row = row.child(
+                div()
+                    .size(px(16.0))
+                    .rounded(px(2.0))
+                    .border_1()
+                    .border_color(theme::border_subtle())
+                    .bg(if selected {
+                        theme::accent()
+                    } else {
+                        theme::glass()
+                    })
+                    .on_mouse_move(cx.listener(
+                        move |this: &mut AppView, _: &MouseMoveEvent, _, cx| {
+                            this.table_picker_hover(rr, cc, cx);
+                        },
+                    ))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this: &mut AppView, _: &MouseDownEvent, _, cx| {
+                            cx.stop_propagation();
+                            this.table_picker_pick(rr, cc, cx);
+                        }),
+                    ),
+            );
+        }
+        grid = grid.child(row);
+        // The first row is always the table's header — mark the boundary so the
+        // picker shows what it inserts (header row + `|---|` separator).
+        if r == 0 {
+            grid = grid.child(
+                div()
+                    .w_full()
+                    .h(px(2.0))
+                    .rounded(px(1.0))
+                    .bg(theme::divider()),
+            );
+        }
+    }
+
+    div()
+        .occlude()
+        .bg(theme::elevated())
+        .border_1()
+        .border_color(theme::border_subtle())
+        .rounded(px(8.0))
+        .p(px(8.0))
+        .flex()
+        .flex_col()
+        .gap(px(6.0))
+        .child(grid)
+        .child(
+            div()
+                .text_size(px(12.0))
+                .text_color(theme::text_secondary())
+                .child(label),
+        )
+        // Custom dimensions, for tables larger than the hover grid.
+        .child(
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(5.0))
+                .child(Input::new(&picker.rows_input).small().w(px(46.0)))
+                .child(
+                    div()
+                        .text_size(px(12.0))
+                        .text_color(theme::text_tertiary())
+                        .child("×"),
+                )
+                .child(Input::new(&picker.cols_input).small().w(px(46.0)))
+                .child(
+                    div()
+                        .px(px(8.0))
+                        .py(px(3.0))
+                        .rounded(px(5.0))
+                        .border_1()
+                        .border_color(theme::border_subtle())
+                        .bg(theme::glass())
+                        .text_size(px(12.0))
+                        .text_color(theme::text_secondary())
+                        .child("Insert")
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this: &mut AppView, _: &MouseDownEvent, _, cx| {
+                                cx.stop_propagation();
+                                this.table_picker_insert_custom(cx);
+                            }),
+                        ),
+                ),
+        )
+}

--- a/src/ui/table_picker.rs
+++ b/src/ui/table_picker.rs
@@ -8,7 +8,7 @@ use gpui::{
 };
 use gpui_component::{Sizable, input::Input};
 
-use crate::app::{AppView, TablePicker};
+use crate::app::{AppView, TableDesign, TablePicker};
 use crate::theme;
 
 const MAX_COLS: usize = 8;
@@ -67,6 +67,40 @@ pub fn render(picker: &TablePicker, cx: &mut Context<AppView>) -> impl IntoEleme
         }
     }
 
+    // Design buttons (pick a visual style, then a size). The selected one shows an
+    // accent border; Grid is the plain default.
+    let mut designs = div().flex().flex_row().gap(px(4.0));
+    for d in TableDesign::ALL {
+        let selected = picker.style == d;
+        designs = designs.child(
+            div()
+                .px(px(7.0))
+                .py(px(3.0))
+                .rounded(px(5.0))
+                .border_1()
+                .border_color(if selected {
+                    theme::accent()
+                } else {
+                    theme::border_subtle()
+                })
+                .bg(theme::glass())
+                .text_size(px(11.0))
+                .text_color(if selected {
+                    theme::text_primary()
+                } else {
+                    theme::text_secondary()
+                })
+                .child(d.label())
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this: &mut AppView, _: &MouseDownEvent, _, cx| {
+                        cx.stop_propagation();
+                        this.table_picker_set_style(d, cx);
+                    }),
+                ),
+        );
+    }
+
     div()
         .occlude()
         .bg(theme::elevated())
@@ -77,6 +111,7 @@ pub fn render(picker: &TablePicker, cx: &mut Context<AppView>) -> impl IntoEleme
         .flex()
         .flex_col()
         .gap(px(6.0))
+        .child(designs)
         .child(grid)
         .child(
             div()


### PR DESCRIPTION
Makes the from-scratch `gpui-editor` a true WYSIWYG surface and the **only** renderer when WYSIWYG is on — no more "rendered page vs. raw-markdown line under the caret." Closes #8.

## What's in it

**Single live renderer + per-construct reveal**
- WYSIWYG-on renders every line formatted (unfocused too); markers hide and reveal only around the caret's construct (not the whole line).
- Settings-driven list indent (2/4/8); the editor owns Tab/Shift+Tab (list-aware indent/outdent), re-flowing open notes when the setting changes.

**Full reading-view parity** (every `gpui-markdown` construct now renders live)
- Headings, bold/italic/strike, inline code (highlighted), links / wiki-links / tags.
- Blockquotes, list bullets + numbers, GFM task checkboxes, fenced code blocks (boxed, content-fit), inline images, PDF chips (flat on-theme glyph), mermaid diagrams.
- Thematic rules `---`, footnote refs/defs, reference-style links, `<mark>` highlight, raw-HTML lines (muted).

**Tables — edited in place**
- Render as a grid matching the reading view; caret + selection live *inside* cells; click + Tab navigate cells.
- `/table` picker offers **visual designs** (Grid / Striped / Header / Minimal), stored in a hidden `<!-- table:STYLE -->` marker honored by both renderers.
- **Alignment toolbar** (L/C/R) when the caret is in a header cell; **right-click menu** to insert/delete rows + columns.

## Known issue (deferred — tracked in TODO.md on main)
Deleting the **last** row/column drops the caret just below the table (computed offset is correct in-table, but a later step in the change flow moves it to the doc end). Other rows/columns are fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)