### PR TITLE
Editor: scroll the caret into view on vertical moves

### DIFF
--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1411,6 +1411,25 @@ impl EditorState {
         cx.notify();
     }
 
+    /// The caret's bounds in window space (its painted Y range), or `None` before
+    /// the first paint. Lets a host scroll the caret into view; computed from the
+    /// layout stored at the last paint, so it's valid for caret moves that don't
+    /// change the text (arrow keys, click).
+    pub fn caret_screen_bounds(&self) -> Option<Bounds<Pixels>> {
+        let bounds = self.last_bounds?;
+        let (row, col) = self.row_col(self.cursor_offset());
+        let lh = self.line_h(row);
+        let p = self
+            .wrapped
+            .get(row)?
+            .position_for_index(self.display_col(row, col), lh)?;
+        let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
+        Some(Bounds::from_corners(
+            point(bounds.left(), top),
+            point(bounds.left(), top + lh),
+        ))
+    }
+
     fn cursor_offset(&self) -> usize {
         if self.selection_reversed {
             self.selected_range.start

--- a/src/app.rs
+++ b/src/app.rs
@@ -760,7 +760,9 @@ impl AppView {
                         this.open_pdf(path, window, cx);
                     }
                 }
-                EditorEvent::SelectionChanged => {}
+                EditorEvent::SelectionChanged => {
+                    this.scroll_caret_into_view(st, &this.feed_scroll, cx)
+                }
             },
         );
         // gpui-editor has no Focus/Blur events; listen on its focus handle.
@@ -1430,6 +1432,36 @@ impl AppView {
         self.page_scroll.set_offset(gpui::point(px(0.0), new_y));
     }
 
+    /// Scroll `scroll` so the editor's caret stays comfortably in view — used on
+    /// caret moves (arrow keys) so it doesn't slip off-screen as it crosses the
+    /// viewport edge. Mirrors `scroll_to_current_match`'s clamp-at-top behavior.
+    fn scroll_caret_into_view(
+        &self,
+        editor: &Entity<EditorState>,
+        scroll: &ScrollHandle,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(cb) = editor.read(cx).caret_screen_bounds() else {
+            return;
+        };
+        let viewport = scroll.bounds();
+        if viewport.size.height <= px(0.0) {
+            return;
+        }
+        let margin = px(24.0);
+        let (c_top, c_bottom) = (cb.origin.y, cb.origin.y + cb.size.height);
+        let (v_top, v_bottom) = (viewport.origin.y, viewport.origin.y + viewport.size.height);
+        if c_top >= v_top + margin && c_bottom <= v_bottom - margin {
+            return; // already comfortably visible
+        }
+        let new_y = if c_top < v_top + margin {
+            scroll.offset().y + (v_top + margin - c_top)
+        } else {
+            scroll.offset().y - (c_bottom - (v_bottom - margin))
+        };
+        scroll.set_offset(gpui::point(px(0.0), new_y.min(px(0.0))));
+    }
+
     /// Close the in-page find bar.
     pub fn close_page_find(&mut self, cx: &mut Context<Self>) {
         if self.page_find.take().is_some() {
@@ -1490,7 +1522,9 @@ impl AppView {
                         this.open_pdf(path, window, cx);
                     }
                 }
-                EditorEvent::SelectionChanged => {}
+                EditorEvent::SelectionChanged => {
+                    this.scroll_caret_into_view(st, &this.page_scroll, cx)
+                }
             },
         );
         // gpui-editor has no Focus/Blur events; listen on its focus handle.


### PR DESCRIPTION
Arrow up/down (and any caret move) now keeps the caret on-screen, in both the single-page view and the journal feed.

- The editor exposes the caret's window Y via `caret_screen_bounds` (computed from the layout stored at the last paint, so it's valid for moves that don't change the text).
- The host scrolls the active page/feed handle on `SelectionChanged` when the caret would cross the viewport edge — a 24px margin, and only when it isn't already comfortably visible (so left/right and in-view moves don't jiggle the page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)