### PR TITLE
App: in-titlebar File/Edit/View menu for Windows/Linux

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -128,8 +128,16 @@ pub fn bind_keys(cx: &mut App) {
 /// the keymap, so this must run *after* [`bind_keys`]. The Edit items reuse
 /// gpui-component's input actions, which it already binds in focused editors.
 pub fn set_app_menu(cx: &mut App) {
+    // The native (macOS) menu bar, plus a mirror into gpui-component's GlobalState
+    // so the Windows/Linux titlebar `AppMenuBar` renders the same items.
+    cx.set_menus(build_app_menus());
+    let owned = build_app_menus().into_iter().map(|m| m.owned()).collect();
+    gpui_component::GlobalState::global_mut(cx).set_app_menus(owned);
+}
+
+fn build_app_menus() -> Vec<Menu> {
     use gpui_component::input;
-    cx.set_menus([
+    vec![
         Menu {
             name: "Zorite".into(),
             items: vec![
@@ -177,5 +185,5 @@ pub fn set_app_menu(cx: &mut App) {
             ],
             disabled: false,
         },
-    ]);
+    ]
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -338,6 +338,10 @@ pub struct AppView {
     pub day_editors: HashMap<String, DayEditor>,
     pub feed_scroll: ScrollHandle,
 
+    /// The Windows/Linux in-titlebar menu bar (File/Edit/View). macOS shows the
+    /// native menu bar instead; this gives the other OSes visual parity.
+    app_menu_bar: Entity<gpui_component::menu::AppMenuBar>,
+
     // Single-page view.
     pub page_editor: Option<PageEditor>,
 
@@ -608,6 +612,7 @@ impl AppView {
             pdf_views: HashMap::new(),
             whiteboard_views: HashMap::new(),
             feed_scroll: ScrollHandle::new(),
+            app_menu_bar: gpui_component::menu::AppMenuBar::new(cx),
             page_editor: None,
             pages: Vec::new(),
             whiteboards: Vec::new(),
@@ -5377,17 +5382,25 @@ impl Render for AppView {
                     .text_color(theme::text_secondary())
                     .child("Zorite");
                 let row = div().flex().flex_row().items_center().w_full();
-                // Put the toggle opposite the platform's window controls: right on
-                // macOS (traffic lights sit left), left on Windows/Linux (min /
-                // max / close sit right).
+                // macOS: the native menu bar carries File/Edit/View, so the titlebar
+                // keeps just the title + theme toggle. Windows/Linux: the AppMenuBar
+                // leads (it already includes the "Zorite" app menu), then the toggle —
+                // and the redundant title label is dropped. `.occlude()` keeps clicks
+                // off the titlebar's drag region.
                 if cfg!(target_os = "macos") {
                     row.justify_between()
                         .child(label)
                         .child(div().mr_2().child(toggle))
                 } else {
-                    row.child(div().ml_1().mr_2().child(toggle))
-                        .child(label)
-                        .child(div().flex_1())
+                    row.child(
+                        div()
+                            .occlude()
+                            .flex()
+                            .items_center()
+                            .child(self.app_menu_bar.clone()),
+                    )
+                    .child(div().mr_2().child(toggle))
+                    .child(div().flex_1())
                 }
             }))
             .child(


### PR DESCRIPTION
gpui's native menu bar is macOS-only, so Windows and Linux had no visible application menu. This renders gpui-component's `AppMenuBar` (which reads the same menu definitions, now also mirrored into its `GlobalState` alongside `cx.set_menus`) inside the titlebar on those platforms — the File/Edit/View dropdowns lead, then the theme toggle.

- **macOS:** unchanged — native top-of-screen bar + the titlebar title/toggle.
- **Windows/Linux:** the `AppMenuBar` (which already includes the "Zorite" app menu) leads, and the redundant title label is dropped so the name isn't shown twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)