### PR TITLE
docs: cover v0.3.0 editor features

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Developed in close collaboration with Claude (Anthropic).
 - **As-you-type completion** — `[[` suggests pages (and offers to create one),
   `#` suggests tags, `{{` suggests template placeholders; brackets and quotes
   auto-pair (prose-aware, so `don't` is left alone).
+- **Edit in place** — tables behave like a small spreadsheet (arrow keys move
+  cell-to-cell keeping your column, Enter drops to the next row; hover or
+  right-click for row/column handles, alignment, and delete); lists and to-dos
+  continue on Enter and exit on an empty item; `⌘B` / `⌘I` / `⌘E` toggle bold,
+  italic, and inline code; and to-do checkboxes toggle with a click.
 - **Full-text search**, **type-aware** — a trigram FTS5 index over titles and
   content, with results that also include the PDF and image *files* and the
   whiteboards referenced in your notes. Filter by a `pdf:` / `img:` / `wb:` /
@@ -88,9 +93,10 @@ Developed in close collaboration with Claude (Anthropic).
   window to move it there, or release it on empty space to **tear it off into a
   new window**. Every window is independent and edits **sync live** across all of
   them.
-- **Inline images** — `![](path-or-url)` images render for real; **paste** or
-  **drag-and-drop** a file to add one (copied into the data dir's `images/`),
-  and drag the corner handle to resize (saved as `{width=N}`).
+- **Inline images** — `![](path-or-url)` images render for real (now including
+  **HEIC/HEIF and AVIF** — iPhone photos); **paste** or **drag-and-drop** a file
+  to add one (copied into the data dir's `images/`), and drag the corner handle to
+  resize (saved as `{width=N}`).
 - **PDF viewer** — link a PDF with `[[file.pdf]]` / `![](file.pdf)` or drop one
   onto a note to open it in a dedicated **page-virtualized** viewer tab (only
   pages near the viewport are rasterized; scrolled-away pages free their memory

--- a/crates/gpui-editor/README.md
+++ b/crates/gpui-editor/README.md
@@ -16,20 +16,23 @@ selection.
 - **Editing:** insert / backspace / delete / newline, arrow + Home/End +
   word-wise navigation, visual-row up/down, copy / cut / paste, IME, undo / redo
   (coalesced), click + drag selection, double-click word / triple-click line.
+  **Lists continue on Enter** (an empty item exits the list), and **bold /
+  italic / inline-code** toggles (`cmd`/`ctrl`-`b`/`i`/`e`).
 - **Soft-wrap** with content-driven height.
 - **Spell-check squiggles:** the host feeds in misspelled byte ranges
   ([`Diagnostic`]); a right-click menu offers replacements via a lazy provider.
 - **Live-preview Markdown ("WYSIWYG"):** with a [`SyntaxStyle`] installed, the
   editor styles its own content as you type — headings (variable line height),
   bold / italic / strikethrough, inline code, links / wiki-links / tags,
-  blockquotes, lists, task checkboxes, fenced code blocks, thematic rules,
+  blockquotes, lists, clickable task checkboxes, fenced code blocks, thematic rules,
   footnotes, reference links, `<mark>` — with the raw Markdown markers hidden and
   revealed only around the caret.
 - **Block widgets:** standalone images, file chips (e.g. PDF embeds), and mermaid
   diagrams render in place via host-supplied providers (raw source under the
   caret).
-- **Tables:** rendered as a grid and edited *in the cells*; host-driven column
-  alignment and row/column insert/delete.
+- **Tables:** rendered as a grid and edited *in the cells* — arrow keys move
+  cell-to-cell keeping the column and Enter drops to the row below; host-driven
+  column alignment, row/column insert/delete, and whole-table delete.
 
 ## Adding the dependency
 
@@ -100,6 +103,7 @@ equivalent.
 | `alt-←` / `alt-→` | word left / right |
 | `shift-` + any move | extend selection |
 | `cmd-a` | select all |
+| `cmd-b` / `cmd-i` / `cmd-e` | bold / italic / inline code (toggle on selection) |
 | `tab` / `shift-tab` | indent / outdent (list-aware) |
 | `cmd-c` / `cmd-x` / `cmd-v` | copy / cut / paste |
 | `cmd-z` / `cmd-shift-z` (`ctrl-y`) | undo / redo |
@@ -108,7 +112,9 @@ equivalent.
 
 `tab`/`shift-tab` indent or outdent the caret's list item by [`set_tab_indent`]
 spaces (or insert/remove that many spaces elsewhere), and move between cells when
-the caret is in a table.
+the caret is in a table. **Enter** continues a list or task (an empty item exits)
+and, inside a table, moves to the cell below; the **arrow keys** walk a table
+cell-by-cell, keeping your column.
 
 ## Events
 
@@ -240,6 +246,7 @@ fn insert_table_row(&mut self, below: bool, cx: &mut Context<Self>)   // above /
 fn delete_table_row(&mut self, cx: &mut Context<Self>)                // body rows only
 fn insert_table_column(&mut self, right: bool, cx: &mut Context<Self>)  // left / right of the caret's column
 fn delete_table_column(&mut self, cx: &mut Context<Self>)             // not the last column
+fn delete_table(&mut self, cx: &mut Context<Self>)                    // the whole table block
 ```
 
 `caret_table_align` returns `Some` only while the caret is in the **header** row

--- a/docs/src/content/docs/usage/journal.md
+++ b/docs/src/content/docs/usage/journal.md
@@ -57,6 +57,21 @@ or inline formatting — or a **Template**, or insert the current date or time w
 `/date` and `/time`. Typing filters across everything; click an item or press
 Enter to insert it.
 
+## Editing tables, lists, and text
+
+Everything you insert stays editable in place:
+
+- **Tables** behave like a small spreadsheet. The arrow keys move from cell to
+  cell and keep your column; `Tab` / `Shift+Tab` step through cells, and `Enter`
+  drops to the row below. Hover a table for `+` / `−` handles to add or delete a
+  row or column, or right-click it for the same plus per-column alignment and
+  **Delete table**.
+- **Lists and to-dos continue themselves** — press `Enter` and the `-`, `1.`, or
+  `- [ ]` marker carries to the next line; press it again on an empty item to end
+  the list. Click a to-do's checkbox to toggle it.
+- **Inline formatting** — select text and press `⌘B` / `⌘I` / `⌘E` (`Ctrl` on
+  Windows and Linux) to wrap it in bold, italic, or inline code.
+
 ## Templates
 
 Create a page named `Templates` and define snippets with `!name` headers. Every

--- a/docs/src/content/docs/usage/shortcuts.md
+++ b/docs/src/content/docs/usage/shortcuts.md
@@ -38,6 +38,7 @@ The tab-switch chords are `Ctrl+Tab` / `Ctrl+Shift+Tab` on every platform
 | Close the slash menu | `Esc` |
 | Indent / nest list item | `Tab` |
 | Outdent | `Shift+Tab` |
+| Bold / italic / inline code | `⌘B` / `⌘I` / `⌘E` |
 | Copy | `⌘C` / `Ctrl+C` |
 | Cut | `⌘X` / `Ctrl+X` |
 | Paste (image-aware) | `⌘V` / `Ctrl+V` |
@@ -48,6 +49,11 @@ The tab-switch chords are `Ctrl+Tab` / `Ctrl+Shift+Tab` on every platform
 Click into a note to edit its raw Markdown; click away (or press `Esc` out of the
 slash menu and click out) to re-render. `⌘V` / `Ctrl+V` pastes an image from the
 clipboard if there is one, and otherwise pastes text as usual.
+
+**Enter** continues a list or to-do — the `-`, `1.`, or `- [ ]` marker carries to
+the next line, and an empty item ends the list. **Inside a table**, `Tab` /
+`Shift+Tab` and the arrow keys move from cell to cell (the arrows keep your
+column) and `Enter` drops to the row below.
 
 <picture>
   <source media="(prefers-color-scheme: light)" srcset="/zorite/screenshots/zorite-edit-light.png" />
@@ -114,8 +120,13 @@ A few things are mouse-driven rather than keyboard-bound:
 - **Drag a tab** to reorder it, drop it on another window to move it there, or
   release it on empty space to tear it off into a new window.
 - **Drag a corner handle** on an inline image to resize it.
+- **Click a to-do checkbox** to toggle it.
+- **Hover a table** for `+` / `−` handles to add or delete a row or column, or
+  **right-click** it for insert / delete, column alignment, and **Delete table**.
 - **Drag to highlight** a passage in the PDF viewer.
 - The **⚙ Settings** button and a quick **light/dark toggle** live in the title
   bar.
 
-> **Import from Logseq** lives in the **File** menu and has no keyboard shortcut.
+> **Import from Logseq** lives in the **File** menu — the native menu bar on
+> macOS, the in-titlebar **File / Edit / View** menu on Windows and Linux — and
+> has no keyboard shortcut.


### PR DESCRIPTION
Documents the v0.3.0 editor features the hand-written docs missed (the changelog + crate-reference pages auto-sync separately on the docs build).

- **README → Highlights:** an **Edit in place** bullet (spreadsheet-style tables, list continuation, ⌘B/I/E, clickable checkboxes) and **HEIC/HEIF/AVIF** in the inline-images bullet.
- **docs/usage/shortcuts.md:** ⌘B/I/E, in-table cell navigation, the checkbox/table mouse affordances, and where the File/Edit/View menu lives per OS.
- **docs/usage/journal.md:** a new **Editing tables, lists, and text** section.
- **crates/gpui-editor/README.md** (auto-syncs → docs reference): ⌘B/I/E in the key bindings, list continuation, clickable checkboxes, cell-aware nav, and `delete_table`.

Merging redeploys the docs site (`docs.yml` on push to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)