### PR TITLE
refactor: apply over-engineering audit cuts

### DIFF
--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -4375,7 +4375,8 @@ fn shape_document(
                             let math_h = line_inline_math
                                 .iter()
                                 .map(|im| im.height)
-                                .fold(px(0.), |a, b| if b > a { b } else { a });
+                                .max()
+                                .unwrap_or(px(0.));
                             (fs * LINE_HEIGHT_RATIO).max(math_h + px(INLINE_MATH_ROW_PAD))
                         }
                     },
@@ -4577,7 +4578,7 @@ fn table_column_widths(
         *w = (*w).max(px(48.));
     }
     if let Some(avail) = wrap_width {
-        let total = widths.iter().fold(px(0.), |a, &w| a + w);
+        let total = widths.iter().sum::<Pixels>();
         if total > avail && total > px(0.) {
             let scale = f32::from(avail) / f32::from(total);
             for w in &mut widths {
@@ -4667,7 +4668,7 @@ fn table_caret_pos(
     let range = t.cell_ranges.get(cell)?;
     let content = t.cells.get(cell)?;
     let in_cell = col.saturating_sub(range.start).min(content.len());
-    let cell_x = left + t.col_widths[..cell].iter().fold(px(0.), |a, &w| a + w);
+    let cell_x = left + t.col_widths[..cell].iter().sum::<Pixels>();
     let cw = t.col_widths.get(cell).copied().unwrap_or(px(0.));
     // The header is bold, so shape with the bold font or the caret lands left of
     // the (wider) bold glyphs; position_for_index gives the exact kerned x.
@@ -4733,7 +4734,7 @@ fn paint_table_row(
     // A single rule under the header (Striped/Minimal) vs a divider under every
     // row (Grid) vs none (Header).
     let header_rule = matches!(style, TableStyle::Striped | TableStyle::Minimal);
-    let table_w = t.col_widths.iter().fold(px(0.), |a, &w| a + w);
+    let table_w = t.col_widths.iter().sum();
     // Row shading (painted first, behind everything): the header for the Header
     // style; alternate body rows for Striped.
     let shaded = match style {
@@ -5015,7 +5016,7 @@ impl Element for EditorElement {
                         let (top, bot) = code_pads(*bg);
                         *h * (line.wrap_boundaries().len() + 1) as f32 + top + bot
                     })
-                    .fold(px(0.), |a, b| a + b)
+                    .sum::<Pixels>()
                     .max(base_lh)
             };
             let width = wrap_width.or(known.width).unwrap_or(px(0.));
@@ -5713,7 +5714,7 @@ impl Element for EditorElement {
                             None => break,
                         }
                     }
-                    let table_w = t.col_widths.iter().fold(px(0.), |a, &w| a + w);
+                    let table_w = t.col_widths.iter().sum();
                     window.paint_quad(PaintQuad {
                         bounds: Bounds::new(
                             point(origin.x + px(TABLE_GUTTER), origin.y),

--- a/crates/gpui-pdf/src/text.rs
+++ b/crates/gpui-pdf/src/text.rs
@@ -232,26 +232,45 @@ impl PageText {
         self.runs.is_empty()
     }
 
+    /// The whitespace-stripped, lowercased search key for `s` — the same normalization
+    /// `letters` is built with, so a key produced here matches against it.
+    fn search_key(s: &str) -> String {
+        s.chars()
+            .filter(|c| !c.is_whitespace())
+            .flat_map(|c| c.to_lowercase())
+            .collect()
+    }
+
     /// A readable reconstruction of the page text (spaces inserted on horizontal
     /// gaps, newlines on baseline changes). For search / display — `locate` uses the
     /// whitespace-insensitive index instead.
     pub fn text(&self) -> String {
+        Self::join_runs(&self.runs, true)
+    }
+
+    /// Walk `runs`, appending each run's text with a break inserted between two *real*
+    /// glyphs (the PDF's own space glyphs carry word breaks, so spaces are excluded from
+    /// the compare — an unreliable space rect mustn't force a break). With `newlines`, a
+    /// baseline change becomes a newline and a horizontal gap a space (the readable
+    /// reconstruction); without it, either one becomes a single space (the one-line join).
+    fn join_runs(runs: &[Run], newlines: bool) -> String {
         let mut out = String::new();
         let mut prev: Option<&Run> = None;
-        for run in &self.runs {
-            // The PDF's own space glyphs carry the word breaks, so only compare two
-            // *real* glyphs — to detect a line wrap (or a positioning-based gap with no
-            // space glyph). This keeps an unreliable space rect from forcing a break.
+        for run in runs {
             if let Some(p) = prev
                 && run.text != " "
                 && p.text != " "
             {
                 let line_h = run.rect.h.max(p.rect.h).max(0.001);
-                if (run.rect.center_y() - p.rect.center_y()).abs() > line_h * 0.6 {
-                    out.push('\n');
-                } else if run.rect.x - p.rect.right() > line_h * 0.6
-                    && !out.ends_with(|c: char| c.is_whitespace())
-                {
+                let new_line = (run.rect.center_y() - p.rect.center_y()).abs() > line_h * 0.6;
+                let gap = run.rect.x - p.rect.right() > line_h * 0.6;
+                if newlines {
+                    if new_line {
+                        out.push('\n');
+                    } else if gap && !out.ends_with(|c: char| c.is_whitespace()) {
+                        out.push(' ');
+                    }
+                } else if new_line || gap {
                     out.push(' ');
                 }
             }
@@ -265,11 +284,7 @@ impl PageText {
     /// `needle` on the page and return one normalized rect per line it spans (so a
     /// wrapped quote highlights as multiple line boxes). Empty if not found.
     pub fn locate(&self, needle: &str, occurrence: usize) -> Vec<NormRect> {
-        let key: String = needle
-            .chars()
-            .filter(|c| !c.is_whitespace())
-            .flat_map(|c| c.to_lowercase())
-            .collect();
+        let key = Self::search_key(needle);
         if key.is_empty() {
             return Vec::new();
         }
@@ -304,11 +319,7 @@ impl PageText {
     /// Matches are returned in reading order. (`search` feature.)
     #[cfg(feature = "search")]
     pub fn find_matches(&self, needle: &str) -> Vec<Vec<NormRect>> {
-        let key: String = needle
-            .chars()
-            .filter(|c| !c.is_whitespace())
-            .flat_map(|c| c.to_lowercase())
-            .collect();
+        let key = Self::search_key(needle);
         if key.is_empty() {
             return Vec::new();
         }
@@ -375,23 +386,7 @@ impl PageText {
     /// The text of runs `lo..=hi` joined into one line (gaps and line breaks become
     /// spaces), suitable for storing as a one-line quote.
     fn runs_text(&self, lo: usize, hi: usize) -> String {
-        let mut out = String::new();
-        let mut prev: Option<&Run> = None;
-        for run in &self.runs[lo..=hi] {
-            // Only compare two real glyphs (see `text`); recorded spaces carry breaks.
-            if let Some(p) = prev
-                && run.text != " "
-                && p.text != " "
-            {
-                let line_h = run.rect.h.max(p.rect.h).max(0.001);
-                let new_line = (run.rect.center_y() - p.rect.center_y()).abs() > line_h * 0.6;
-                if new_line || run.rect.x - p.rect.right() > line_h * 0.6 {
-                    out.push(' ');
-                }
-            }
-            out.push_str(&run.text);
-            prev = Some(run);
-        }
+        let out = Self::join_runs(&self.runs[lo..=hi], false);
         // Collapse recorded + inserted spaces to single spaces, trim.
         out.split_whitespace().collect::<Vec<_>>().join(" ")
     }
@@ -399,11 +394,7 @@ impl PageText {
     /// Which occurrence (0-based) of `quote` on the page the run at `lo` begins — so
     /// the stored highlight re-locates to the right match.
     fn occurrence_at(&self, lo: usize, quote: &str) -> usize {
-        let key: String = quote
-            .chars()
-            .filter(|c| !c.is_whitespace())
-            .flat_map(|c| c.to_lowercase())
-            .collect();
+        let key = Self::search_key(quote);
         if key.is_empty() {
             return 0;
         }

--- a/crates/gpui-whiteboard/src/font.rs
+++ b/crates/gpui-whiteboard/src/font.rs
@@ -87,13 +87,9 @@ impl Font {
     }
 
     /// Lay out `content` at `font_size` (world units) into local-space outlines.
-    /// Newlines break lines; the block's origin is its top-left corner.
-    pub fn layout(&self, content: &str, font_size: f32) -> TextLayout {
-        self.layout_wrapped(content, font_size, None)
-    }
-
-    /// Like [`layout`](Self::layout) but word-wraps to `max_width` (world units)
-    /// when `Some` — for fitting a label inside a shape. Glyph positions come
+    /// Newlines break lines; the block's origin is its top-left corner. Word-wraps
+    /// to `max_width` (world units) when `Some` — for fitting a label inside a
+    /// shape; `None` lays out unwrapped. Glyph positions come
     /// from the same [`line_stops`](Self::line_stops) the caret uses, so the
     /// caret always lands exactly between the rendered glyphs.
     pub fn layout_wrapped(
@@ -456,12 +452,8 @@ impl Font {
 
     /// The content byte offset whose caret sits nearest the local point `p`
     /// (text-local space). Picks the line by y, then the closest caret stop by x —
-    /// so a click lands the caret between letters like a real text field.
-    pub fn index_at(&self, content: &str, font_size: f32, p: [f32; 2]) -> usize {
-        self.index_at_wrapped(content, font_size, None, p)
-    }
-
-    /// [`index_at`](Self::index_at) honoring a `max_width` wrap (label editing).
+    /// so a click lands the caret between letters like a real text field. Honors a
+    /// `max_width` wrap (label editing) when `Some`.
     pub fn index_at_wrapped(
         &self,
         content: &str,
@@ -689,7 +681,7 @@ mod tests {
     #[test]
     fn default_font_parses_and_lays_out() {
         let f = Font::default();
-        let l = f.layout("A", 20.0);
+        let l = f.layout_wrapped("A", 20.0, None);
         assert!(l.width > 0.0, "width {}", l.width);
         assert!(l.line_height > 0.0);
         assert!(
@@ -709,14 +701,14 @@ mod tests {
         let two = f.measure("x\ny", 20.0).1;
         assert!((two - 2.0 * one).abs() < 0.5, "{one} {two}");
         // The caret of a two-line block sits on the lower line.
-        let l = f.layout("x\ny", 20.0);
+        let l = f.layout_wrapped("x\ny", 20.0, None);
         assert!(l.caret[1] > 0.0, "caret {:?}", l.caret);
     }
 
     #[test]
     fn empty_content_has_no_segments_but_a_caret() {
         let f = Font::default();
-        let l = f.layout("", 20.0);
+        let l = f.layout_wrapped("", 20.0, None);
         assert!(l.segs.is_empty());
         assert_eq!(l.caret, [0.0, 0.0]);
         assert!(l.height > 0.0);
@@ -731,7 +723,7 @@ mod tests {
     fn caret_pos_walks_per_char_and_across_lines() {
         let f = Font::default();
         let a = f.measure("M", 20.0).0; // monospace advance
-        let lh = f.layout("M", 20.0).line_height;
+        let lh = f.layout_wrapped("M", 20.0, None).line_height;
         // One stop per boundary on a line.
         assert_eq!(f.caret_pos("MMM", 20.0, 0), [0.0, 0.0]);
         assert!((f.caret_pos("MMM", 20.0, 1)[0] - a).abs() < 0.5);
@@ -748,14 +740,14 @@ mod tests {
     fn index_at_picks_the_nearest_boundary() {
         let f = Font::default();
         let a = f.measure("M", 20.0).0;
-        let lh = f.layout("M", 20.0).line_height;
+        let lh = f.layout_wrapped("M", 20.0, None).line_height;
         // Just past the first glyph's midpoint rounds to the next boundary.
-        assert_eq!(f.index_at("MMM", 20.0, [0.4 * a, 0.0]), 0);
-        assert_eq!(f.index_at("MMM", 20.0, [0.6 * a, 0.0]), 1);
+        assert_eq!(f.index_at_wrapped("MMM", 20.0, None, [0.4 * a, 0.0]), 0);
+        assert_eq!(f.index_at_wrapped("MMM", 20.0, None, [0.6 * a, 0.0]), 1);
         // Way off to the right clamps to the line end; clicking the lower line
         // (by y) lands on it.
-        assert_eq!(f.index_at("MMM", 20.0, [99.0 * a, 0.0]), 3);
-        assert_eq!(f.index_at("M\nMM", 20.0, [0.0, lh]), 2); // start of line 2
+        assert_eq!(f.index_at_wrapped("MMM", 20.0, None, [99.0 * a, 0.0]), 3);
+        assert_eq!(f.index_at_wrapped("M\nMM", 20.0, None, [0.0, lh]), 2); // start of line 2
     }
 
     #[test]

--- a/crates/gpui-whiteboard/src/lib.rs
+++ b/crates/gpui-whiteboard/src/lib.rs
@@ -2002,16 +2002,23 @@ impl WhiteboardView {
         });
     }
 
-    /// Open or close the color picker. Opening seeds the controls from the
-    /// stroke color (selection's, else active, else a default).
-    fn toggle_picker(&mut self, cx: &mut Context<Self>) {
+    /// Close every popover/flyout (only one shows at a time). Called at the top
+    /// of each `toggle_*` so each then only flips its own field.
+    fn close_popovers(&mut self) {
+        self.picker = None;
         self.open_group = None;
         self.templates_open = false;
         self.width_open = false;
         self.font_open = false;
-        if self.picker.is_some() {
-            self.picker = None;
-        } else {
+        self.context_menu = None;
+    }
+
+    /// Open or close the color picker. Opening seeds the controls from the
+    /// stroke color (selection's, else active, else a default).
+    fn toggle_picker(&mut self, cx: &mut Context<Self>) {
+        let was_open = self.picker.is_some();
+        self.close_popovers();
+        if !was_open {
             self.seed_picker(PickerTarget::Stroke);
         }
         cx.notify();
@@ -2019,12 +2026,9 @@ impl WhiteboardView {
 
     /// Open / close the thickness-preset flyout (closing the other popovers).
     fn toggle_width(&mut self, cx: &mut Context<Self>) {
-        self.picker = None;
-        self.open_group = None;
-        self.templates_open = false;
-        self.context_menu = None;
-        self.font_open = false;
-        self.width_open = !self.width_open;
+        let open = !self.width_open;
+        self.close_popovers();
+        self.width_open = open;
         cx.notify();
     }
 
@@ -2066,38 +2070,30 @@ impl WhiteboardView {
     /// Open the given tool category's flyout (or close it if already open).
     /// Closes the color picker so only one popover shows at a time.
     fn toggle_group(&mut self, group: ToolGroup, cx: &mut Context<Self>) {
-        self.picker = None;
-        self.templates_open = false;
-        self.width_open = false;
-        self.font_open = false;
-        self.open_group = if self.open_group == Some(group) {
+        let next = if self.open_group == Some(group) {
             None
         } else {
             Some(group)
         };
+        self.close_popovers();
+        self.open_group = next;
         cx.notify();
     }
 
     /// Open / close the templates gallery modal (closing the other popovers).
     fn toggle_templates(&mut self, cx: &mut Context<Self>) {
-        self.picker = None;
-        self.open_group = None;
-        self.width_open = false;
-        self.context_menu = None;
-        self.font_open = false;
-        self.templates_open = !self.templates_open;
+        let open = !self.templates_open;
+        self.close_popovers();
+        self.templates_open = open;
         cx.notify();
     }
 
     /// Open / close the font flyout (upload a face / revert to default), closing
     /// the other popovers.
     fn toggle_font(&mut self, cx: &mut Context<Self>) {
-        self.picker = None;
-        self.open_group = None;
-        self.width_open = false;
-        self.templates_open = false;
-        self.context_menu = None;
-        self.font_open = !self.font_open;
+        let open = !self.font_open;
+        self.close_popovers();
+        self.font_open = open;
         cx.notify();
     }
 
@@ -4531,6 +4527,25 @@ fn text_extent(t: &TextGeom) -> (f32, f32) {
     (cols * t.size * TEXT_CHAR_W, rows * t.size * TEXT_LINE_H)
 }
 
+/// Scale a `(x, y, w, h)` box in place by the per-axis maps `fx`/`fy`,
+/// normalizing to non-negative width/height. Shared by the box-shaped arms of
+/// [`resize_about`].
+fn resize_box(
+    x: &mut f32,
+    y: &mut f32,
+    w: &mut f32,
+    h: &mut f32,
+    fx: impl Fn(f32) -> f32,
+    fy: impl Fn(f32) -> f32,
+) {
+    let (x0, x1) = (fx(*x), fx(*x + *w));
+    let (y0, y1) = (fy(*y), fy(*y + *h));
+    *x = x0.min(x1);
+    *w = (x1 - x0).abs();
+    *y = y0.min(y1);
+    *h = (y1 - y0).abs();
+}
+
 /// Scale an element's geometry about `(ax, ay)` by `(sx, sy)` (world space).
 /// Stroke width is left unchanged.
 fn resize_about(kind: &mut ElementKind, ax: f32, ay: f32, sx: f32, sy: f32) {
@@ -4550,12 +4565,7 @@ fn resize_about(kind: &mut ElementKind, ax: f32, ay: f32, sx: f32, sy: f32) {
         | ElementKind::RoundRect(b)
         | ElementKind::Star(b)
         | ElementKind::Hexagon(b) => {
-            let (x0, x1) = (fx(b.x), fx(b.x + b.w));
-            let (y0, y1) = (fy(b.y), fy(b.y + b.h));
-            b.x = x0.min(x1);
-            b.w = (x1 - x0).abs();
-            b.y = y0.min(y1);
-            b.h = (y1 - y0).abs();
+            resize_box(&mut b.x, &mut b.y, &mut b.w, &mut b.h, fx, fy);
         }
         ElementKind::Line(s) | ElementKind::Arrow(s) => {
             s.x1 = fx(s.x1);
@@ -4573,20 +4583,10 @@ fn resize_about(kind: &mut ElementKind, ax: f32, ay: f32, sx: f32, sy: f32) {
             t.size = (t.size * (sx.abs() * sy.abs()).sqrt()).max(0.5);
         }
         ElementKind::Embed(em) => {
-            let (x0, x1) = (fx(em.x), fx(em.x + em.w));
-            let (y0, y1) = (fy(em.y), fy(em.y + em.h));
-            em.x = x0.min(x1);
-            em.w = (x1 - x0).abs();
-            em.y = y0.min(y1);
-            em.h = (y1 - y0).abs();
+            resize_box(&mut em.x, &mut em.y, &mut em.w, &mut em.h, fx, fy);
         }
         ElementKind::Image(im) => {
-            let (x0, x1) = (fx(im.x), fx(im.x + im.w));
-            let (y0, y1) = (fy(im.y), fy(im.y + im.h));
-            im.x = x0.min(x1);
-            im.w = (x1 - x0).abs();
-            im.y = y0.min(y1);
-            im.h = (y1 - y0).abs();
+            resize_box(&mut im.x, &mut im.y, &mut im.w, &mut im.h, fx, fy);
         }
     }
 }
@@ -4860,6 +4860,31 @@ fn paint_stroke(
     }
 }
 
+/// Fill (when `fill` is `Some`) then stroke a closed path built by `trace`.
+/// The stroke width is the world `width` scaled to screen by `z`, floored at
+/// 0.5px. Shared epilogue of the box-shape painters.
+fn fill_then_stroke(
+    trace: impl Fn(&mut PathBuilder),
+    width: f32,
+    z: f32,
+    ink: Hsla,
+    fill: Option<Hsla>,
+    window: &mut Window,
+) {
+    if let Some(fill) = fill {
+        let mut fb = PathBuilder::fill();
+        trace(&mut fb);
+        if let Ok(path) = fb.build() {
+            window.paint_path(path, fill);
+        }
+    }
+    let mut pb = PathBuilder::stroke(px((width * z).max(0.5)));
+    trace(&mut pb);
+    if let Ok(path) = pb.build() {
+        window.paint_path(path, ink);
+    }
+}
+
 fn paint_rect(
     b: &BoxGeom,
     cam: Camera,
@@ -4877,18 +4902,7 @@ fn paint_rect(
         pb.line_to(to_screen(c[3][0], c[3][1], cam, origin));
         pb.close();
     };
-    if let Some(fill) = fill {
-        let mut fb = PathBuilder::fill();
-        trace(&mut fb);
-        if let Ok(path) = fb.build() {
-            window.paint_path(path, fill);
-        }
-    }
-    let mut pb = PathBuilder::stroke(px((b.width * z).max(0.5)));
-    trace(&mut pb);
-    if let Ok(path) = pb.build() {
-        window.paint_path(path, ink);
-    }
+    fill_then_stroke(trace, b.width, z, ink, fill, window);
 }
 
 fn paint_ellipse(
@@ -4917,18 +4931,7 @@ fn paint_ellipse(
         pb.cubic_bezier_to(s(cx + rx, cy), s(cx + kx, cy - ry), s(cx + rx, cy - ky));
         pb.close();
     };
-    if let Some(fill) = fill {
-        let mut fb = PathBuilder::fill();
-        trace(&mut fb);
-        if let Ok(path) = fb.build() {
-            window.paint_path(path, fill);
-        }
-    }
-    let mut pb = PathBuilder::stroke(px((b.width * z).max(0.5)));
-    trace(&mut pb);
-    if let Ok(path) = pb.build() {
-        window.paint_path(path, ink);
-    }
+    fill_then_stroke(trace, b.width, z, ink, fill, window);
 }
 
 /// Vertices of box-fitting polygons in box-relative coords: `(±1, ±1)` is the
@@ -4991,18 +4994,7 @@ fn paint_box_polygon(
             pb.close();
         }
     };
-    if let Some(fill) = fill {
-        let mut fb = PathBuilder::fill();
-        trace(&mut fb);
-        if let Ok(path) = fb.build() {
-            window.paint_path(path, fill);
-        }
-    }
-    let mut pb = PathBuilder::stroke(px((b.width * z).max(0.5)));
-    trace(&mut pb);
-    if let Ok(path) = pb.build() {
-        window.paint_path(path, ink);
-    }
+    fill_then_stroke(trace, b.width, z, ink, fill, window);
 }
 
 /// A rounded rectangle: straight edges joined by quarter-circle corners (radius
@@ -5037,18 +5029,7 @@ fn paint_round_rect(
         pb.cubic_bezier_to(s(x0 + r, y0), s(x0, y0 + r - k), s(x0 + r - k, y0));
         pb.close();
     };
-    if let Some(fill) = fill {
-        let mut fb = PathBuilder::fill();
-        trace(&mut fb);
-        if let Ok(path) = fb.build() {
-            window.paint_path(path, fill);
-        }
-    }
-    let mut pb = PathBuilder::stroke(px((b.width * z).max(0.5)));
-    trace(&mut pb);
-    if let Ok(path) = pb.build() {
-        window.paint_path(path, ink);
-    }
+    fill_then_stroke(trace, b.width, z, ink, fill, window);
 }
 
 fn paint_segment(

--- a/crates/ratex-gpui/src/editor/geometry.rs
+++ b/crates/ratex-gpui/src/editor/geometry.rs
@@ -32,42 +32,6 @@ pub fn layout_row(row: &Row) -> LayoutBox {
 }
 
 // ---------------------------------------------------------------------------
-// Top-row caret (kept for its unit tests; `caret_rect` supersedes it generally).
-// ---------------------------------------------------------------------------
-
-/// Caret rect for the cursor at `index` (`0..=atom_count`) in the **top-level** row.
-pub fn caret_in_top_row(row: &Row, index: usize) -> Rect {
-    let lbox = layout_row(row);
-    let x = match &lbox.content {
-        BoxContent::HBox(children) => caret_x_in_hbox(children, index),
-        _ if index == 0 => 0.0,
-        _ => lbox.width,
-    };
-    Rect {
-        x,
-        y: 0.0,
-        w: 0.0,
-        h: lbox.height + lbox.depth,
-    }
-}
-
-/// Left edge of the `index`-th non-kern child of an HBox.
-fn caret_x_in_hbox(children: &[LayoutBox], index: usize) -> f64 {
-    let mut x = 0.0;
-    let mut atoms = 0usize;
-    for c in children {
-        if !matches!(c.content, BoxContent::Kern) {
-            if atoms == index {
-                return x;
-            }
-            atoms += 1;
-        }
-        x += c.width;
-    }
-    x
-}
-
-// ---------------------------------------------------------------------------
 // General caret geometry (top row + nested slots).
 // ---------------------------------------------------------------------------
 
@@ -571,61 +535,6 @@ mod tests {
 
     fn width(row: &Row) -> f64 {
         layout_row(row).width
-    }
-
-    #[test]
-    fn caret_start_is_zero() {
-        assert!(caret_in_top_row(&Row::syms("abc"), 0).x.abs() < 1e-9);
-    }
-
-    #[test]
-    fn caret_end_is_full_width() {
-        let r = Row::syms("abc");
-        let end = caret_in_top_row(&r, 3).x;
-        assert!((end - width(&r)).abs() < 1e-6, "end caret {end} != width");
-    }
-
-    #[test]
-    fn carets_are_monotonic_across_operators() {
-        let r = Row::syms("a+b=c");
-        let xs: Vec<f64> = (0..=r.atoms.len())
-            .map(|i| caret_in_top_row(&r, i).x)
-            .collect();
-        for w in xs.windows(2) {
-            assert!(w[1] >= w[0] - 1e-9, "caret x not monotonic: {xs:?}");
-        }
-        assert!(xs[0].abs() < 1e-9);
-        assert!((xs[xs.len() - 1] - width(&r)).abs() < 1e-6);
-    }
-
-    #[test]
-    fn caret_between_atoms_is_interior() {
-        let r = Row::syms("ab");
-        let mid = caret_in_top_row(&r, 1).x;
-        let full = width(&r);
-        assert!(mid > 0.0 && mid < full, "mid {mid} not inside (0, {full})");
-    }
-
-    #[test]
-    fn caret_has_height() {
-        assert!(caret_in_top_row(&Row::syms("x"), 0).h > 0.0);
-    }
-
-    #[test]
-    fn caret_rect_matches_top_row_when_flat() {
-        // For a script-free row, the general walk agrees with the top-row helper on x.
-        for s in ["abc", "a+b=c"] {
-            let r = Row::syms(s);
-            for i in 0..=r.atoms.len() {
-                let cur = Cursor {
-                    path: vec![],
-                    index: i,
-                };
-                let got = caret_rect(&r, &cur).expect("top caret").x;
-                let want = caret_in_top_row(&r, i).x;
-                assert!((got - want).abs() < 1e-6, "{s}@{i}: {got} != {want}");
-            }
-        }
     }
 
     fn frac(n: &str, d: &str) -> Atom {

--- a/src/app.rs
+++ b/src/app.rs
@@ -2297,12 +2297,8 @@ impl AppView {
     /// paints: claims the slot, then renders mermaid → SVG → bitmap off-thread
     /// (it's a layout-heavy parse) and repaints when it lands.
     pub fn ensure_mermaid_loaded(&mut self, source: SharedString, cx: &mut Context<Self>) {
-        {
-            let mut store = self.mermaid_store.borrow_mut();
-            if store.started(&source) {
-                return; // already rendering / ready / failed
-            }
-            store.begin(source.clone());
+        if !self.mermaid_store.borrow_mut().begin(source.clone()) {
+            return; // already rendering / ready / failed
         }
         // Build the diagram theme from Zorite's current palette now (it's a
         // thread-local read on this main thread); the result is `Send`.
@@ -2331,10 +2327,9 @@ impl AppView {
         {
             let mut store = self.math_store.borrow_mut();
             store.set_color(color);
-            if store.started(&source) {
+            if !store.begin(source.clone()) {
                 return; // already rendering / ready / failed
             }
-            store.begin(source.clone());
         }
         let store = self.math_store.clone();
         cx.spawn(async move |this, cx| {
@@ -2342,12 +2337,13 @@ impl AppView {
             let result = cx
                 .background_executor()
                 .spawn(async move {
-                    crate::math::render_to_image(
+                    ratex_gpui::render::render_latex(
                         &src,
                         crate::math::FONT_SIZE,
                         crate::math::DPR,
                         color,
                     )
+                    .map(|r| (r.image, r.width, r.height))
                 })
                 .await;
             store.borrow_mut().finish(source, result);
@@ -3281,13 +3277,14 @@ impl AppView {
             log::warn!("not a usable font: {}", path.display());
             return;
         }
-        let rel = match crate::images::import_font(&path) {
-            Ok(rel) => rel,
-            Err(e) => {
-                log::error!("import font {}: {e}", path.display());
-                return;
-            }
-        };
+        let rel =
+            match crate::images::import_into(&path, &crate::paths::fonts_dir(), "fonts", "ttf") {
+                Ok(rel) => rel,
+                Err(e) => {
+                    log::error!("import font {}: {e}", path.display());
+                    return;
+                }
+            };
         let _ = self.db.set_setting(&board_font_key(board_id), &rel);
         self.apply_board_font(board_id, cx);
     }
@@ -3903,7 +3900,7 @@ impl AppView {
             let imported = if crate::images::is_supported(path) {
                 crate::images::import_file(path)
             } else if crate::pdf::is_pdf(&path.to_string_lossy()) {
-                crate::images::import_pdf(path)
+                crate::images::import_into(path, &crate::paths::pdf_dir(), "pdf", "pdf")
             } else {
                 continue;
             };

--- a/src/db.rs
+++ b/src/db.rs
@@ -16,6 +16,19 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use crate::models::{Backlink, Page};
 use crate::paths;
 
+/// Read a single `settings` value by key, best-effort (`None` if absent or the
+/// query fails). Used by the read-only boot probes below.
+fn read_setting(conn: &Connection, key: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT value FROM settings WHERE key = ?1",
+        params![key],
+        |r| r.get::<_, String>(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+}
+
 /// Read the saved `theme_skin` and `theme_mode` from a database file, read-only
 /// and without migrating or write-locking it — used to theme the data-move
 /// progress window before the database is opened normally. Best-effort:
@@ -28,17 +41,10 @@ pub fn read_theme(path: &Path) -> (Option<String>, Option<String>) {
     ) else {
         return (None, None);
     };
-    let read = |key: &str| {
-        conn.query_row(
-            "SELECT value FROM settings WHERE key = ?1",
-            params![key],
-            |r| r.get::<_, String>(0),
-        )
-        .optional()
-        .ok()
-        .flatten()
-    };
-    (read("theme_skin"), read("theme_mode"))
+    (
+        read_setting(&conn, "theme_skin"),
+        read_setting(&conn, "theme_mode"),
+    )
 }
 
 /// Read the update-check preferences from a database file, read-only. Used by
@@ -51,18 +57,10 @@ pub fn read_update_prefs(path: &Path) -> (bool, bool) {
     ) else {
         return (true, false);
     };
-    let read = |key: &str| {
-        conn.query_row(
-            "SELECT value FROM settings WHERE key = ?1",
-            params![key],
-            |r| r.get::<_, String>(0),
-        )
-        .optional()
-        .ok()
-        .flatten()
-    };
-    let check = read("check_updates").map(|v| v != "0").unwrap_or(true);
-    let prerelease = read("include_prerelease")
+    let check = read_setting(&conn, "check_updates")
+        .map(|v| v != "0")
+        .unwrap_or(true);
+    let prerelease = read_setting(&conn, "include_prerelease")
         .map(|v| v == "1")
         .unwrap_or(false);
     (check, prerelease)
@@ -762,7 +760,7 @@ impl Db {
             out.push(Backlink {
                 source_page_id: id,
                 source_page_title: title,
-                snippet: snippet_for(&content, &target.title),
+                snippet: snippet(&content, &format!("[[{}]]", target.title)),
             });
         }
         Ok(out)
@@ -853,10 +851,10 @@ fn escape_like(s: &str) -> String {
         .replace('_', "\\_")
 }
 
-/// The first content line containing `query` (case-insensitive), else
+/// The first content line containing `needle` (case-insensitive), else
 /// the first non-empty line, trimmed and length-capped.
-pub(crate) fn snippet_for_query(content: &str, query: &str) -> String {
-    let needle = query.to_lowercase();
+pub(crate) fn snippet(content: &str, needle: &str) -> String {
+    let needle = needle.to_lowercase();
     let line = content
         .lines()
         .find(|l| l.to_lowercase().contains(&needle))
@@ -879,24 +877,6 @@ fn row_to_page(row: &rusqlite::Row) -> rusqlite::Result<Page> {
         journal_date: row.get(3)?,
         content: row.get(4)?,
     })
-}
-
-/// The line of `content` that contains `[[target]]` (else the first
-/// non-empty line), trimmed and length-capped for the backlinks panel.
-fn snippet_for(content: &str, target_title: &str) -> String {
-    let needle = format!("[[{target_title}]]").to_lowercase();
-    let line = content
-        .lines()
-        .find(|l| l.to_lowercase().contains(&needle))
-        .or_else(|| content.lines().find(|l| !l.trim().is_empty()))
-        .unwrap_or("")
-        .trim();
-    const MAX: usize = 140;
-    if line.chars().count() > MAX {
-        line.chars().take(MAX).collect::<String>() + "…"
-    } else {
-        line.to_string()
-    }
 }
 
 // --- v1 → v2 migration -----------------------------------------------------

--- a/src/images.rs
+++ b/src/images.rs
@@ -39,21 +39,9 @@ pub fn import_file(src: &Path) -> std::io::Result<String> {
     import_into(src, &paths::images_dir(), "images", "png")
 }
 
-/// Copy an external PDF into the pdf dir; return its `pdf/<name>` reference (the
-/// PDF viewer resolves it against the data dir).
-pub fn import_pdf(src: &Path) -> std::io::Result<String> {
-    import_into(src, &paths::pdf_dir(), "pdf", "pdf")
-}
-
-/// Copy an external font file into the fonts dir; return its `fonts/<name>`
-/// reference (a whiteboard's chosen face, resolved against the data dir).
-pub fn import_font(src: &Path) -> std::io::Result<String> {
-    import_into(src, &paths::fonts_dir(), "fonts", "ttf")
-}
-
 /// Copy `src` into `dir`, giving it a unique, sanitized name; return the relative
 /// `<rel_prefix>/<name>` reference. `default_ext` is used if `src` has none.
-fn import_into(
+pub fn import_into(
     src: &Path,
     dir: &Path,
     rel_prefix: &str,

--- a/src/import/logseq.rs
+++ b/src/import/logseq.rs
@@ -186,33 +186,18 @@ fn read_favorites(root: &Path) -> Vec<String> {
 /// Parse the `:favorites ["A" "B/C" …]` vector out of a `config.edn` string,
 /// returning the names as Zorite titles. Empty if the key is absent.
 fn parse_favorites(edn: &str) -> Vec<String> {
-    // Drop `;`-to-end-of-line EDN comments so a commented-out example isn't read
-    // instead of the live key.
-    let src: String = edn
-        .lines()
-        .map(|l| l.split(';').next().unwrap_or(""))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let Some((_, after)) = src.split_once(":favorites") else {
-        return Vec::new();
-    };
-    let Some(open) = after.find('[') else {
-        return Vec::new();
-    };
-    let Some(end) = after[open..].find(']') else {
-        return Vec::new();
-    };
-    // Pull the quoted names out of the vector and convert each to a Zorite title.
-    let mut out = Vec::new();
-    let mut rest = &after[open + 1..open + end];
-    while let Some(s) = rest.find('"') {
-        let Some(e) = rest[s + 1..].find('"') else {
-            break;
-        };
-        out.push(name_to_title(&rest[s + 1..s + 1 + e]));
-        rest = &rest[s + 1 + e + 1..];
-    }
-    out
+    edn::parse(edn)
+        .as_ref()
+        .and_then(|e| e.get("favorites"))
+        .and_then(Edn::as_seq)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Edn::as_str)
+                .map(name_to_title)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 // --- Whiteboards (best-effort tldraw-EDN → Zorite scene) ---
@@ -826,13 +811,7 @@ impl Converter {
                     if let Some(props) = page_props.as_deref_mut() {
                         match key {
                             "title" => {
-                                props.title = Some(
-                                    value
-                                        .split('/')
-                                        .map(str::trim)
-                                        .collect::<Vec<_>>()
-                                        .join("::"),
-                                );
+                                props.title = Some(name_to_title(value));
                                 continue;
                             }
                             "alias" => {

--- a/src/math.rs
+++ b/src/math.rs
@@ -45,11 +45,6 @@ impl MathStore {
         matches!(self.slots.get(source), Some(Slot::Failed))
     }
 
-    /// Whether `source` already has a slot, so the render is kicked off at most once.
-    pub fn started(&self, source: &SharedString) -> bool {
-        self.slots.contains_key(source)
-    }
-
     /// Set the text color formulas are tinted for. If it changed (a theme switch), drop the
     /// cached rasters so they re-render in the new color. Call before kicking off renders.
     pub fn set_color(&mut self, color: Hsla) {
@@ -59,9 +54,14 @@ impl MathStore {
         }
     }
 
-    /// Mark `source` as rendering.
-    pub fn begin(&mut self, source: SharedString) {
+    /// Claim `source` for rendering. Returns `false` if it already has a slot, so the
+    /// render is kicked off at most once.
+    pub fn begin(&mut self, source: SharedString) -> bool {
+        if self.slots.contains_key(&source) {
+            return false;
+        }
         self.slots.insert(source, Slot::Loading);
+        true
     }
 
     /// Record a finished render (ready or failed).
@@ -75,11 +75,4 @@ impl MathStore {
         };
         self.slots.insert(source, slot);
     }
-}
-
-/// Typeset `latex` to a bitmap + logical size via `ratex-gpui` (RaTeX). Pure CPU — safe
-/// off-thread. `None` if the LaTeX fails to parse / lay out / rasterize.
-pub fn render_to_image(latex: &str, font_size: f32, dpr: f32, color: Hsla) -> Option<Image> {
-    let r = ratex_gpui::render::render_latex(latex, font_size, dpr, color)?;
-    Some((r.image, r.width, r.height))
 }

--- a/src/mermaid.rs
+++ b/src/mermaid.rs
@@ -37,15 +37,14 @@ impl MermaidStore {
         matches!(self.slots.get(source), Some(Slot::Failed))
     }
 
-    /// Whether `source` already has a slot (loading / ready / failed), so the
-    /// render is kicked off at most once.
-    pub fn started(&self, source: &SharedString) -> bool {
-        self.slots.contains_key(source)
-    }
-
-    /// Mark `source` as rendering.
-    pub fn begin(&mut self, source: SharedString) {
+    /// Claim `source` for rendering. Returns `false` if it already has a slot
+    /// (loading / ready / failed), so the render is kicked off at most once.
+    pub fn begin(&mut self, source: SharedString) -> bool {
+        if self.slots.contains_key(&source) {
+            return false;
+        }
         self.slots.insert(source, Slot::Loading);
+        true
     }
 
     /// Record a finished render (ready or failed).

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -62,9 +62,11 @@ const PALETTE: &[(&str, f32, f32, f32)] = &[
     ("orange", 0.07, 0.90, 0.55),
 ];
 
-/// The default highlight fill (yellow) — used for entries with no `{color}` tag.
+/// The default highlight fill (yellow, `PALETTE[0]`) — used for entries with no
+/// `{color}` tag.
 fn default_highlight_color() -> gpui::Hsla {
-    gpui::hsla(0.14, 0.95, 0.55, 1.0)
+    let (_, h, s, l) = PALETTE[0];
+    gpui::hsla(h, s, l, 1.0)
 }
 
 /// Resolve a stored color name to its fill, or `None` if it isn't a known palette

--- a/src/search.rs
+++ b/src/search.rs
@@ -188,7 +188,7 @@ fn collect(db: &Db, term: &str) -> Vec<Hit> {
         hits.push(Hit {
             kind: Kind::Page,
             title: title.clone(),
-            subtitle: crate::db::snippet_for_query(content, term),
+            subtitle: crate::db::snippet(content, term),
             target: Target::Page(*id),
         });
         // PDFs referenced here whose filename matches the term.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -376,12 +376,6 @@ impl SettingsView {
         )
     }
 
-    fn reveal_themes_folder(&self, cx: &Context<Self>) {
-        if let Some(app) = self.app.upgrade() {
-            app.read(cx).reveal_themes_folder();
-        }
-    }
-
     /// Re-scan themes on disk and rebuild the theme dropdown to include them.
     fn reload_skins(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let Some(app) = self.app.upgrade() else {
@@ -781,7 +775,11 @@ impl Render for SettingsView {
                 "reveal-themes",
                 "Reveal themes folder",
                 cx,
-                |this, _w, cx| this.reveal_themes_folder(cx),
+                |this, _w, cx| {
+                    if let Some(app) = this.app.upgrade() {
+                        app.read(cx).reveal_themes_folder();
+                    }
+                },
             ))
             .child(text_button("reload-themes", "Reload", cx, |this, w, cx| {
                 this.reload_skins(w, cx)

--- a/src/skins.rs
+++ b/src/skins.rs
@@ -51,12 +51,12 @@ impl Skin {
     /// as dark so the derived overlays/borders stay correct), and the window
     /// chrome / titlebar is forced dark via `dark_only`.
     fn builtin_dark(id: &str, name: &str, dark: Base) -> Self {
-        let palette = || make_palette(dark.0, dark.1, dark.2, dark.3, dark.4, dark.5, dark.6, true);
+        let palette = make_palette(dark.0, dark.1, dark.2, dark.3, dark.4, dark.5, dark.6, true);
         Self {
             id: id.to_string(),
             name: name.to_string(),
-            dark: palette(),
-            light: palette(),
+            dark: palette,
+            light: palette,
             dark_only: true,
             is_builtin: true,
         }


### PR DESCRIPTION
## Summary

Applies a repo-wide over-engineering audit: dedup, stdlib reuse, and dead-code removal across the app and crates. **Net −190 lines** (209 insertions / 399 deletions) over 15 files, no new dependencies.

- **Dead code:** dropped ratex-gpui's `caret_in_top_row`/`caret_x_in_hbox` (superseded by `caret_rect`, test-only callers), the `reveal_themes_folder` forwarder, and single-caller `import_*` wrappers.
- **Dedup:** collapsed `snippet_for`/`snippet_for_query`, the `read_theme`/`read_update_prefs` lookup closure, whiteboard's 4 paint epilogues + 5 popover-reset blocks + 3 `resize_about` arms, and gpui-pdf's `text()`/`runs_text()` walk and 3× search-key rebuild.
- **Stdlib / reuse:** `parse_favorites` now reuses `edn::parse`; `.fold(px(0.), …)` → `.sum()`/`.max()`; `default_highlight_color` derives from `PALETTE[0]`; inline title-split → `name_to_title`.

## Behavior notes

Behavior-preserving except two intended changes:

- `parse_favorites` via `edn::parse` also fixes a latent bug where a `;` inside a string was treated as a comment.
- whiteboard `toggle_picker`/`toggle_group` now also dismiss an open right-click menu, consistent with the other three toggles.

## Verification

`cargo fmt` · `cargo clippy --workspace --all-targets -- -D warnings` (zero warnings) · `cargo test --workspace` (302 passed, 0 failed) · clean debug build.
