### PR TITLE
0.5.1: Windows lock/unlock handoff + list selection fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ log: <https://github.com/packetThrower/zorite/releases>.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-03
+
+Two fixes, one urgent: Windows users could be locked out of an encrypted
+database.
+
+### Fixed
+
+- **Windows: unlocking, Lock now, and auto-lock closed the app** — entering
+  a correct password (without "Remember on this device"), pressing Lock
+  now, or hitting the idle auto-lock exited Zorite entirely. The window
+  handoff let the open-window count touch zero, which ends the app on
+  Windows (macOS tolerates it, which hid the bug). The successor window now
+  always opens before the old one closes. Your data was never at risk —
+  the app just exited before showing it.
+- **Selecting across a list no longer breaks its rendering** — rows kept
+  their numbering (`a.`, `i.`) and indentation instead of snapping to raw
+  source mid-drag; the body still reveals inline markers so the highlighted
+  text is exactly what's copied. Copies now include the first item's list
+  marker, and ordered items copy with the numbering the screen showed
+  (still plain-markdown digits, so pastes rebuild real lists anywhere).
+
 ## [0.5.0] - 2026-07-03
 
 The biggest Zorite release yet: encrypt your notes with a password, see them

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1619,9 +1619,44 @@ impl EditorState {
 
     fn copy(&mut self, _: &Copy, _: &mut Window, cx: &mut Context<Self>) {
         if !self.selected_range.is_empty() {
-            cx.write_to_clipboard(ClipboardItem::new_string(
-                self.content[self.selected_range.clone()].to_string(),
-            ));
+            let range = self.copy_range();
+            // Ordered markers copy at their DISPLAYED positions (still digit
+            // markdown), so a paste counts the way the screen did.
+            let text = if self.markdown_style.is_some() {
+                markdown_syntax::renumber_copy(&self.content, range)
+            } else {
+                self.content[range].to_string()
+            };
+            cx.write_to_clipboard(ClipboardItem::new_string(text));
+        }
+    }
+
+    /// What a copy takes: the selection — extended back over the first
+    /// line's hidden list/task/quote prefix when the selection is multi-line
+    /// and starts exactly at that line's body start. With markers painted
+    /// (not text), "select the whole list" visually anchors AFTER the first
+    /// `1. `, so a verbatim copy dropped the first marker while every other
+    /// line kept its own. Raw mode (no markdown style) copies verbatim.
+    fn copy_range(&self) -> std::ops::Range<usize> {
+        let (start, end) = (
+            self.selected_range.start.min(self.selected_range.end),
+            self.selected_range.start.max(self.selected_range.end),
+        );
+        if self.markdown_style.is_none() || !self.content[start..end].contains('\n') {
+            return start..end;
+        }
+        let line_start = self.content[..start].rfind('\n').map_or(0, |i| i + 1);
+        let line_end = self.content[line_start..]
+            .find('\n')
+            .map_or(self.content.len(), |i| line_start + i);
+        let line = &self.content[line_start..line_end];
+        let prefix_len = markdown_syntax::task_prefix(line)
+            .map(|(l, ..)| l)
+            .or_else(|| markdown_syntax::list_prefix(line).map(|(l, ..)| l))
+            .or_else(|| markdown_syntax::blockquote_prefix(line));
+        match prefix_len {
+            Some(plen) if start == line_start + plen => line_start..end,
+            _ => start..end,
         }
     }
 
@@ -4657,8 +4692,8 @@ fn shape_document(
         // caret parked beside it (Word-style; see the widget gate above).
         let chip_line =
             md.is_some() && img_row.is_some() && !matches!(widget, Some(Block::Image(_)));
-        let full_source = (!sel_empty && selection.0 <= line_end && selection.1 >= line_start)
-            || (caret_col.is_some() && chip_line);
+        let sel_touches = !sel_empty && selection.0 <= line_end && selection.1 >= line_start;
+        let full_source = sel_touches || (caret_col.is_some() && chip_line);
         // This line's diagnostics, clipped + shifted to line-local byte offsets —
         // used as spell-check squiggles whether the line shows source or hides its
         // markers.
@@ -4801,6 +4836,12 @@ fn shape_document(
             .as_ref()
             .zip(caret_col)
             .is_some_and(|(&(plen, _), col)| col < plen);
+        // A selection across a gutter line keeps the mark too: the whole-line
+        // raw reveal made list rows renumber (source digits) and jump to raw
+        // indent mid-select. The BODY still reveals its inline markers (see
+        // `reveal_inline` below) so what's highlighted is what's copied.
+        let full_source = full_source && gutter.is_none();
+        let reveal_inline = sel_touches && gutter.is_some();
         let mark = if is_rule {
             md.map(|st| LineMark::Rule(st.rule))
         } else {
@@ -4904,6 +4945,7 @@ fn shape_document(
                 caret_col,
                 reveal_prefix,
                 hide_prefix,
+                reveal_inline,
                 st,
             );
             // Inline `$…$` math: swap each ready formula's glyphs for a spacer to paint over.

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -239,6 +239,10 @@ pub(crate) fn hidden_runs(
     // — the line-level prefix while its gutter mark (bullet/number/box) is
     // painted, else the glyph and the raw marker would BOTH show.
     hide_prefix: usize,
+    // Show every inline marker (a selection touches this line, so the
+    // highlighted glyphs must be the copied bytes) while the prefix stays
+    // hidden behind its painted mark.
+    reveal_inline: bool,
     md: &SyntaxStyle,
 ) -> (String, Vec<TextRun>, Vec<usize>) {
     let mut spans = scan(line, md);
@@ -264,7 +268,7 @@ pub(crate) fn hidden_runs(
         let in_construct = reveal.start <= span.range.start && span.range.end <= reveal.end;
         let in_prefix = span.range.end <= reveal_prefix;
         let force = span.range.end <= hide_prefix;
-        let hidden = span.style.hide && (force || (!in_construct && !in_prefix));
+        let hidden = span.style.hide && (force || (!reveal_inline && !in_construct && !in_prefix));
         if !hidden {
             segs.push((span.range.clone(), Some(&span.style)));
         }
@@ -874,6 +878,52 @@ pub(crate) fn ordered_numbers(lines: &[&str]) -> Vec<(u32, usize)> {
     out
 }
 
+/// A copied slice with its ordered markers rewritten to their DISPLAYED
+/// positions — still digit markdown (letters/romans are display-only), so a
+/// nested block pastes starting at 1 and a continuation pastes as `3.`,
+/// exactly the counting the screen showed, in any markdown app. Lines whose
+/// marker sits outside the slice are copied verbatim. Positions come from
+/// the WHOLE document, so a mid-list copy keeps its true numbering.
+pub(crate) fn renumber_copy(content: &str, range: std::ops::Range<usize>) -> String {
+    let lines: Vec<&str> = content.split('\n').collect();
+    let nums = ordered_numbers(&lines);
+    let mut out = String::with_capacity(range.len());
+    let mut line_start = 0;
+    for (i, line) in lines.iter().enumerate() {
+        let line_end = line_start + line.len();
+        // The slice of this line (excluding its newline) inside the range.
+        let seg_start = range.start.max(line_start);
+        let seg_end = range.end.min(line_end);
+        if seg_start <= seg_end && range.start <= line_end && range.end >= line_start {
+            let rel = (seg_start - line_start)..(seg_end - line_start);
+            let marker = list_prefix(line).filter(|&(_, _, ordered, _)| ordered);
+            match marker {
+                // Rewrite only when the whole marker is inside the slice.
+                Some((plen, indent, _, _))
+                    if rel.start == 0 && rel.end >= plen && nums[i].0 > 0 =>
+                {
+                    out.push_str(&line[..indent]);
+                    out.push_str(&nums[i].0.to_string());
+                    // Keep the source's `.`/`)` punctuation and the body.
+                    let digits_end = indent
+                        + line.as_bytes()[indent..]
+                            .iter()
+                            .take_while(|b| b.is_ascii_digit())
+                            .count();
+                    out.push_str(&line[digits_end..rel.end]);
+                }
+                _ => out.push_str(&line[rel]),
+            }
+        }
+        // The newline between this line and the next, when it's in range.
+        if range.start <= line_end && line_end < range.end && i + 1 < lines.len() {
+            out.push('\n');
+        }
+        line_start = line_end + 1;
+    }
+    out
+}
+
 /// If `line` is a GFM task item — a list item whose body starts with `[ ]`,
 /// `[x]`, or `[X]` then a space — return `(prefix_len, indent, checked)`, where
 /// `prefix_len` covers the list marker plus the checkbox. The editor hides this
@@ -1451,6 +1501,44 @@ mod tests {
     use super::*;
 
     #[test]
+    fn copies_renumber_to_displayed_positions() {
+        // Source digits are stale (7., 9.) and the nested list starts at 3 —
+        // the copy carries what the SCREEN showed: 1,2 nested from 1.
+        let doc = "1. a\n7. b\n  3. c\n  9. d\n5. e";
+        assert_eq!(
+            renumber_copy(doc, 0..doc.len()),
+            "1. a\n2. b\n  1. c\n  2. d\n3. e"
+        );
+        // A mid-list copy keeps its true positions (paste renders 2,3).
+        let from = doc.find("7.").unwrap();
+        assert_eq!(
+            renumber_copy(doc, from..doc.len()),
+            "2. b\n  1. c\n  2. d\n3. e"
+        );
+        // A partial first line (marker outside the slice) is verbatim.
+        let from = doc.find("b").unwrap();
+        assert_eq!(
+            renumber_copy(doc, from..doc.find('c').unwrap() + 1),
+            "b\n  1. c"
+        );
+        // Non-list text passes through untouched.
+        assert_eq!(renumber_copy("plain\ntext", 0..10), "plain\ntext");
+    }
+
+    #[test]
+    fn selection_reveal_shows_inline_but_not_prefix() {
+        let (font, c, st) = (Font::default(), Hsla::default(), test_style());
+        // A selected list line: the `- ` prefix stays hidden behind its
+        // painted bullet, while inline markers come back so highlighted
+        // glyphs equal copied bytes.
+        let (disp, _, _) = hidden_runs("- a **b** c", &font, c, &[], None, 0, 2, true, &st);
+        assert_eq!(disp, "a **b** c");
+        // Same line unselected: both prefix and inline markers hidden.
+        let (disp, _, _) = hidden_runs("- a **b** c", &font, c, &[], None, 0, 2, false, &st);
+        assert_eq!(disp, "a b c");
+    }
+
+    #[test]
     fn scan_line_survives_multibyte_text() {
         // Regression: byte-wise scanning once str-sliced at continuation
         // bytes and panicked on this exact line.
@@ -1732,7 +1820,7 @@ mod tests {
         let font = gpui::font("Helvetica");
         let c = hsla(0., 0., 0., 1.);
         let st = test_style();
-        let (disp, ..) = hidden_runs("- ### Notes", &font, c, &[], None, 0, 0, &st);
+        let (disp, ..) = hidden_runs("- ### Notes", &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "Notes");
     }
 
@@ -1795,20 +1883,20 @@ mod tests {
         let st = test_style();
 
         // "**bold**" → "bold"; display 0 maps to source 2, end (4) to 8.
-        let (disp, _, map) = hidden_runs("**bold**", &font, c, &[], None, 0, 0, &st);
+        let (disp, _, map) = hidden_runs("**bold**", &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "bold");
         assert_eq!(map.len(), disp.len() + 1);
         assert_eq!(map[0], 2);
         assert_eq!(map[4], 8);
 
         // "## Hi" → "Hi"; the `## ` prefix is gone, display 0 maps to source 3.
-        let (disp, _, map) = hidden_runs("## Hi", &font, c, &[], None, 0, 0, &st);
+        let (disp, _, map) = hidden_runs("## Hi", &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "Hi");
         assert_eq!(map[0], 3);
         assert_eq!(map[2], 5);
 
         // No markers → unchanged, identity map.
-        let (disp, _, map) = hidden_runs("plain text", &font, c, &[], None, 0, 0, &st);
+        let (disp, _, map) = hidden_runs("plain text", &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "plain text");
         assert_eq!(map, (0..=10).collect::<Vec<_>>());
     }
@@ -1823,11 +1911,21 @@ mod tests {
         let font = gpui::font("Helvetica");
         let c = hsla(0., 0., 0., 1.);
         let st = test_style();
-        let (disp, ..) = hidden_runs("![](images/a.png)", &font, c, &[], None, 0, 0, &st);
+        let (disp, ..) = hidden_runs("![](images/a.png)", &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "");
 
         // A named alt still shows it, same as a plain link.
-        let (disp, ..) = hidden_runs("![alt](images/a.png)", &font, c, &[], None, 0, 0, &st);
+        let (disp, ..) = hidden_runs(
+            "![alt](images/a.png)",
+            &font,
+            c,
+            &[],
+            None,
+            0,
+            0,
+            false,
+            &st,
+        );
         assert_eq!(disp, "alt");
     }
 
@@ -1847,6 +1945,7 @@ mod tests {
             None,
             0,
             0,
+            false,
             &st,
         );
         assert_eq!(disp, "bold");
@@ -1862,6 +1961,7 @@ mod tests {
             None,
             0,
             0,
+            false,
             &st,
         );
         assert_eq!(disp, "plain text");
@@ -1881,16 +1981,16 @@ mod tests {
 
         let line = "**bold** *it*";
         // Caret in "bold" reveals the bold markers; the italic stays hidden.
-        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(4), 0, 0, &st);
+        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(4), 0, 0, false, &st);
         assert_eq!(disp, "**bold** it");
         // Caret in "it" reveals the italic; the bold hides.
-        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(11), 0, 0, &st);
+        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(11), 0, 0, false, &st);
         assert_eq!(disp, "bold *it*");
         // Caret in plain text reveals nothing.
-        let (disp, _, _) = hidden_runs("a **b**", &font, c, &[], Some(0), 0, 0, &st);
+        let (disp, _, _) = hidden_runs("a **b**", &font, c, &[], Some(0), 0, 0, false, &st);
         assert_eq!(disp, "a b");
         // No caret on the line → fully hidden (W6).
-        let (disp, _, _) = hidden_runs(line, &font, c, &[], None, 0, 0, &st);
+        let (disp, _, _) = hidden_runs(line, &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "bold it");
     }
 
@@ -1916,13 +2016,13 @@ mod tests {
         let font = gpui::font("Helvetica");
         let c = hsla(0., 0., 0., 1.);
         let st = test_style();
-        let (disp, _, map) = hidden_runs("> a **b**", &font, c, &[], None, 0, 0, &st);
+        let (disp, _, map) = hidden_runs("> a **b**", &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "a b"); // "> " + "**" hidden
         assert_eq!(map[0], 2); // display 0 ('a') ← source 2
 
         // With the prefix revealed (caret on the line) the `> ` shows even when
         // the caret isn't in it; inline markers still hide unless under the caret.
-        let (disp, _, _) = hidden_runs("> a **b**", &font, c, &[], Some(3), 2, 0, &st);
+        let (disp, _, _) = hidden_runs("> a **b**", &font, c, &[], Some(3), 2, 0, false, &st);
         assert_eq!(disp, "> a b");
     }
 
@@ -1976,7 +2076,7 @@ mod tests {
         let font = gpui::font("Helvetica");
         let c = hsla(0., 0., 0., 1.);
         let st = test_style();
-        let (disp, _, map) = hidden_runs("  - hi", &font, c, &[], None, 0, 0, &st);
+        let (disp, _, map) = hidden_runs("  - hi", &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "hi");
         assert_eq!(map[0], 4); // display 0 ('h') ← source 4
     }
@@ -1994,7 +2094,7 @@ mod tests {
         let font = gpui::font("Helvetica");
         let c = hsla(0., 0., 0., 1.);
         let st = test_style();
-        let (disp, _, map) = hidden_runs("- [x] go", &font, c, &[], None, 0, 0, &st);
+        let (disp, _, map) = hidden_runs("- [x] go", &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "go");
         assert_eq!(map[0], 6); // display 0 ('g') ← source 6
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,10 +219,13 @@ pub(crate) fn lock_now(cx: &mut App) {
         return;
     }
     security::set_session_key(None);
-    for window in cx.windows() {
+    // Snapshot first, open the unlock window, THEN close the app windows —
+    // the count must never hit zero (Windows exits on the last close).
+    let doomed = cx.windows();
+    unlock::open_unlock_window(cx);
+    for window in doomed {
         let _ = window.update(cx, |_, window, _| window.remove_window());
     }
-    unlock::open_unlock_window(cx);
 }
 
 /// Open the main application window. On failure (no usable graphics device) pop a

--- a/src/unlock.rs
+++ b/src/unlock.rs
@@ -57,11 +57,16 @@ impl UnlockView {
             if self.remember {
                 crate::security::remember_password(&password);
             }
-            // Open the main window first, then retire this one.
-            cx.defer(|cx| {
+            // Open the main window BEFORE retiring this one, in one deferred
+            // step: on Windows gpui exits when the window count hits zero,
+            // and the old defer ran the open AFTER the removal — a correct
+            // password closed both windows and the app (macOS survives a
+            // windowless beat, which hid the bug).
+            let this_window = window.window_handle();
+            cx.defer(move |cx| {
                 crate::open_main_window(cx);
+                let _ = this_window.update(cx, |_, window, _| window.remove_window());
             });
-            window.remove_window();
         } else {
             self.error = true;
             self.input.update(cx, |s, cx| {


### PR DESCRIPTION
## What

- **fix(security): keep a window alive through lock/unlock handoffs** — on Windows, gpui ends the app when the open-window count hits zero. The unlock→main handoff and `lock_now` both let the count touch zero, so entering a correct password (without keychain remember), Lock now, and the idle auto-lock all exited the app. The successor window now always opens before the predecessor closes. Verified on macOS; Windows verification via this release's artifacts.
- **fix(editor): selections and copies keep list rendering honest** — selecting across list/task/quote lines kept the rendered gutter (no renumber/jump mid-drag), copies extend over the first item's hidden marker, and ordered items copy at their displayed numbering in digit form (valid markdown everywhere).
- Changelog for 0.5.1.

## Why now

The Windows bug locks users out of an encrypted database entirely — an access blocker in a 0.5.0 headline feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)