### PR TITLE
feat(notebooks): multiple data folders with a switcher (Phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,11 @@ change must stay cross-platform.
   (e.g. `paths::desktop_dir()`) and gate platform code with `#[cfg(...)]`.
 - **Optional functionality sits behind a Cargo feature** so consumers can drop it
   (ratex-gpui's default-on `editor`; gpui-pdf's opt-in `markup`/`search`).
+- **Chrome controls are `.small()`.** gpui-component controls in app chrome —
+  settings cards, side panels, popovers, find bars, in-pane prompts — take
+  `Sizable::small()`, and the settings `text_button` matches that scale (its
+  per-row `nb_button` sits a notch below). Dialog bodies/footers and focal
+  surfaces (the unlock screen, the page-title field) keep the default size.
 
 ## Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ log: <https://github.com/packetThrower/zorite/releases>.
   in Dropbox works) — then confirm and Zorite relaunches into it. Rename
   (the name travels with the folder), reveal, or remove a notebook from the
   list without touching its files; the window title shows which notebook
-  you're in once there's more than one. An encrypted notebook lands on its
-  unlock screen, exactly like a normal launch.
+  you're in once there's more than one. Settings gained a **Notebooks** tab
+  with the same management (plus the per-notebook data-location move, which
+  used to live under General). An encrypted notebook lands on its unlock
+  screen, exactly like a normal launch.
 - **Nix flake** — `nix run github:packetThrower/zorite` builds and launches
   Zorite from source on NixOS and other Linux systems with Nix, desktop entry
   and icon included; `nix develop` gives a ready dev shell. A CI job keeps the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ log: <https://github.com/packetThrower/zorite/releases>.
 
 ### Added
 
+- **Notebooks** — keep more than one set of notes, each a self-contained
+  folder (database, images, PDFs, themes), and switch between them from a
+  chip at the bottom of the sidebar. Add a notebook by picking a folder — an
+  empty one starts fresh, one holding a Zorite database opens as-is (a folder
+  in Dropbox works) — then confirm and Zorite relaunches into it. Rename
+  (the name travels with the folder), reveal, or remove a notebook from the
+  list without touching its files; the window title shows which notebook
+  you're in once there's more than one. An encrypted notebook lands on its
+  unlock screen, exactly like a normal launch.
 - **Nix flake** — `nix run github:packetThrower/zorite` builds and launches
   Zorite from source on NixOS and other Linux systems with Nix, desktop entry
   and icon included; `nix develop` gives a ready dev shell. A CI job keeps the

--- a/TODO.md
+++ b/TODO.md
@@ -110,7 +110,9 @@ per-notebook settings sync.
 - [ ] Multi-window: same-page **concurrent edits** are last-write-wins — editing the *same* page/day in two windows at once can drop one side's changes. True resolution needs a CRDT/OT layer (out of scope for a single-user app); revisit only if real-time collaboration is ever wanted
 
 ## Settings window
-- [ ] Use small versions of components
+- [x] Use small versions of components — DONE on `feat/notebooks` (115e826),
+  and extended app-wide: chrome controls take `Sizable::small()` (convention
+  in AGENTS.md); dialogs and focal surfaces keep the default size
 
 ## Import & export
 - [ ] Logseq import follow-ups: an in-progress indicator with real progress (it's a bare "may take a minute" dialog today); surface imported pages in the sidebar right away (a fresh DB shows "No recent pages" until things are visited)

--- a/TODO.md
+++ b/TODO.md
@@ -32,8 +32,8 @@ work is collected under [Completed](#completed) at the bottom.
 Obsidian-style multiple "vaults" — separate, self-contained data sets the user
 switches between (work / personal / a shared folder in Dropbox). **Not called
 vaults**; working name **Notebooks** (alternatives considered: Spaces,
-Workspaces, Collections). **Phase 1 BUILT on `feat/notebooks`** (2026-07-08,
-live-tested); the Settings fold-in below and Phase 2 remain.
+Workspaces, Collections). **Phase 1 COMPLETE on `feat/notebooks`** (2026-07-08,
+live-tested end to end); only Phase 2 remains, if demand appears.
 
 **Why this is cheaper than it sounds — what already exists:**
 - A data dir is already a fully self-contained bundle: `zorite.db` + `images/`
@@ -70,13 +70,20 @@ live-tested); the Settings fold-in below and Phase 2 remain.
   macOS that goes through `open`/LaunchServices, which pops a Terminal window
   for a bare (non-.app) binary and drops the environment; the app respawns
   `current_exe` directly and quits (`relaunch()` in app.rs).
-- [x] Window title gains the notebook name when more than one is registered
-  (main + torn-off windows; set at window creation, so a rename of the active
-  notebook shows after the next relaunch).
-- [ ] Settings → General's existing "data location" pane folds into this
-  (Move becomes a per-notebook action; Switch is superseded by the registry).
-  `set_location` already keeps the registry coherent (a Move retargets the
-  moved notebook's entry), so this is UI-only.
+- [x] Window title gains the notebook name when more than one is registered.
+  GOTCHA: the visible title is the app's own drawn `TitleBar` label in
+  AppView::render (`window_label`), NOT the native `WindowOptions` title
+  (which only names Mission Control / the taskbar) — both are set. Updates
+  live on rename/add/remove via the `AppView.notebooks` cache (refreshed on
+  popover open + mutations; the sidebar must NOT call `paths::notebooks()`
+  per render — that's a pointer-file read per keystroke).
+- [x] Settings grew a **Notebooks tab** (user-upgraded scope from "fold the
+  pane in"): the registry list with per-row Switch / Rename / Reveal /
+  Remove + "Add notebook…", live-syncing the chip + title via
+  `AppView::notebooks_changed`. The Data-location card moved into the tab
+  (Move-only now — a target holding a database directs to the switcher
+  instead of silently repointing). Shared validation in
+  `paths::register_dir`.
 - [x] `ZORITE_DATA` keeps top precedence (dev/test). Note: registry writes
   still land in the real pointer file under the override, and a relaunch now
   inherits the env — sandbox live tests with an overridden `HOME` instead.

--- a/TODO.md
+++ b/TODO.md
@@ -5,24 +5,95 @@ work is collected under [Completed](#completed) at the bottom.
 
 ## Contents
 
+- [UX papercuts (v0.6.2 candidate)](#ux-papercuts-v062-candidate)
 - [Notes & navigation](#notes--navigation)
 - [Notebooks (multiple data folders)](#notebooks-multiple-data-folders)
 - [Performance](#performance)
 - [App & polish](#app--polish)
-- [Settings window](#settings-window)
 - [Import & export](#import--export)
 - [Crates](#crates)
 - [Maybe](#maybe)
 - [Completed](#completed)
+
+## UX papercuts (v0.6.2 candidate)
+
+Found by the 2026-07-08 four-way UX audit (editor interaction paths,
+cross-view parity, app flows, known-gap mining), plus the overlapping items
+moved in from other sections. The spine for a possible **v0.6.2**.
+
+**Editor interaction (gpui-editor):**
+- [ ] **Home lands before hidden markers** — on a list/task/quote line, Home
+  seats the caret at the raw line start (before the invisible `- [ ]` prefix),
+  so the caret looks wrong and typing lands inside the marker (`home()`)
+- [ ] **Enter inside a property panel breaks it** — `newline()` guards tables
+  (`caret_in_table`) but not property blocks, so Enter splices a raw newline
+  into `key:: value` source; should commit/step like the table path
+- [ ] **Double/triple-click on formulas bypass click-to-edit** — the construct
+  checks (math/property/image) run only at `click_count == 1`; double-click
+  word-selects inside `$x^2$` instead of opening the math editor, triple-click
+  selects the raw `$$` fences
+- [ ] **Backspace/Delete at a math boundary strips a `$`** and dumps raw
+  LaTeX — images delete atomically (Word-style); math wants the same guard
+- [ ] **Selections can include hidden markers** — shift-click, shift-arrows,
+  and drag extend into hidden `$$`/fence regions, so copied text contains
+  markers that were invisible on screen
+- [ ] Word-jump (⌥←/→) stops inside hidden constructs (`$x` splits as two
+  words) instead of hopping the whole formula
+
+**Cross-view parity:**
+- [ ] **`![](file.pdf)` file chips render only in WYSIWYG** — the reader has
+  no file-chip path at all (cross-view-rule violation); the same markdown
+  should read as the same chip in both views
+- [ ] VERIFY: **image resize inside an embed** may write the embedding page
+  instead of the target — editor embeds reuse the main image provider where
+  the reader has a separate read-only embed-image path
+- [ ] Reader opens bare URLs via `cx.open_url` directly, bypassing the host
+  hook the editor's `OpenLink` event goes through
+
+**App flows:**
+- [ ] **Unified right-click menu for page rows everywhere** — All Pages rows,
+  search results, backlink rows, and graph nodes are left-click-only today;
+  extract the sidebar's page menu (open in new tab/window, favorite, rename,
+  delete, export PDF, new sub-page) into one shared builder used by every
+  page-like surface (tabs included), and grow it with **copy/paste actions**:
+  Copy link (`[[Title]]`) and Copy contents (markdown) at minimum
+- [ ] **Error-dialog sweep** — user-facing operations that log failures
+  silently: page rename (dialog AND inline title — a duplicate name is a
+  silent no-op), alias save, notebook rename/forget, math PNG/SVG export
+  (`let _ = fs::write`), image import, PDF form-field writes. Surface each
+  through the existing `show_error_dialog` helper
+- [ ] **Deleting a page in one window leaves it open and editable in
+  others** — the cross-window sync (`apply_external_edit`) detects content
+  changes but not deletion; the ghost tab should close (or mark deleted)
+- [ ] Embeds: the box **height estimate undershoots** for image/math/mermaid-heavy
+  content (it's a line-count heuristic — `ensure_content_embeds`), so those boxes
+  scroll more than they should; measure or estimate rendered heights instead
+- [ ] Sidebar: remember the collapsed state across launches, and add a keyboard
+  shortcut to toggle it
+
+**PDF:**
+- [ ] **A failed load is silent and permanent** (2026-07-06 API audit) — an
+  unreadable/malformed PDF only `log::error!`s and `PdfView` sits on the
+  "Loading PDF…" placeholder forever, no error state, event, or retry; a
+  retry-unlock failing with `LoadError::Other` is likewise eventless, so the
+  password prompt gets no signal. Wants an explicit error state + `PdfEvent`
+  (overlaps the graceful-fallback item under Import & export)
+- [ ] `is_pdf` misses query-string refs (`report.pdf?v=2`) — it only checks
+  `ends_with(".pdf")` after trimming trailing whitespace (API audit)
+
+**Platform (from the crate audit):**
+- [ ] `os-spellcheck`: the Windows backend creates its checker for a
+  **hardcoded `en-US`** — follow the system UI language
+  (`GetUserDefaultLocaleName`), falling back gracefully when unsupported
+- [ ] `ratex-gpui`: `MathEditor` rasterizes at a **hard-coded `dpr: 2.0`**
+  (`view.rs` `with_root`) instead of the window's scale factor — slightly soft
+  on 1× displays, wasteful on 3×
 
 ## Notes & navigation
 - [ ] Aliases: offer a page's aliases as suggestions in `[[` autocomplete
 - [ ] Block references: **"Copy block link"** — auto-generate a ` ^id` on a line
   (right-click / command) and put `[[Page#^id]]` on the clipboard, so linking to
   a block doesn't require inventing an id by hand
-- [ ] Embeds: the box **height estimate undershoots** for image/math/mermaid-heavy
-  content (it's a line-count heuristic — `ensure_content_embeds`), so those boxes
-  scroll more than they should; measure or estimate rendered heights instead
 - [ ] Properties: **typed values** (list / date / number) — today every value is
   text; types would enable sorting/filtering on the Properties page and smarter
   pills
@@ -33,60 +104,8 @@ Obsidian-style multiple "vaults" — separate, self-contained data sets the user
 switches between (work / personal / a shared folder in Dropbox). **Not called
 vaults**; working name **Notebooks** (alternatives considered: Spaces,
 Workspaces, Collections). **Phase 1 COMPLETE on `feat/notebooks`** (2026-07-08,
-live-tested end to end); only Phase 2 remains, if demand appears.
-
-**Why this is cheaper than it sounds — what already exists:**
-- A data dir is already a fully self-contained bundle: `zorite.db` + `images/`
-  + `pdf/` + `themes/` + `fonts/` + the window-bounds sidecar. Nothing lives
-  outside it except the location-pointer file (`data_location.json`, fixed home
-  = the OS-default dir). Settings, favorites, recents, theme — all in the DB,
-  so they're per-notebook for free.
-- `paths.rs` already points the app at an arbitrary dir: `plan_relocation`
-  distinguishes **Switch** (target already holds a `zorite.db` → point at it in
-  place) from **Move** (relocate current data) — so "open a different data set"
-  exists internally today; it lacks only a registry, a switcher UI, and a
-  restart hook. `ZORITE_DATA` proves the isolation (it's how all live testing
-  runs).
-- gpui has `cx.restart()` (Zed's updater uses it) — a clean relaunch is
-  available for switch-by-restart.
-
-**Phase 1 — registry + switcher, switch = relaunch (BUILT, with deviations):**
-- [x] Registry in `data_location.json`: the existing `dir` stays the active
-  pointer; a `notebooks: [{name, dir}]` list rides along (serde-compatible
-  both ways, tested). The active dir is synthesized as **"Main"** until the
-  first registry write; a move/settle never deletes the pointer file while it
-  holds a registry.
-- [x] Switcher chip at the bottom of the sidebar. Deviations from the sketch:
-  ONE **Add notebook…** item instead of New/Add-existing (the picked folder
-  decides — empty = create fresh, holds a `zorite.db` = open existing; the
-  confirm dialog says which); per-row inline buttons (✎ rename / reveal /
-  ✕ remove-from-list) instead of a right-click menu — a nested context menu
-  anchored inside the hand-rolled popover dies to its click-away dismissal;
-  and the chip always shows (it's the only entry point for a second notebook
-  until the Settings fold-in lands). Names default to the folder name; a
-  rename persists to a `notebook-name` sidecar INSIDE the notebook dir, so
-  custom names survive remove/re-add and travel with the folder.
-- [x] Switch = write the pointer + relaunch — but NOT `cx.restart()`: on
-  macOS that goes through `open`/LaunchServices, which pops a Terminal window
-  for a bare (non-.app) binary and drops the environment; the app respawns
-  `current_exe` directly and quits (`relaunch()` in app.rs).
-- [x] Window title gains the notebook name when more than one is registered.
-  GOTCHA: the visible title is the app's own drawn `TitleBar` label in
-  AppView::render (`window_label`), NOT the native `WindowOptions` title
-  (which only names Mission Control / the taskbar) — both are set. Updates
-  live on rename/add/remove via the `AppView.notebooks` cache (refreshed on
-  popover open + mutations; the sidebar must NOT call `paths::notebooks()`
-  per render — that's a pointer-file read per keystroke).
-- [x] Settings grew a **Notebooks tab** (user-upgraded scope from "fold the
-  pane in"): the registry list with per-row Switch / Rename / Reveal /
-  Remove + "Add notebook…", live-syncing the chip + title via
-  `AppView::notebooks_changed`. The Data-location card moved into the tab
-  (Move-only now — a target holding a database directs to the switcher
-  instead of silently repointing). Shared validation in
-  `paths::register_dir`.
-- [x] `ZORITE_DATA` keeps top precedence (dev/test). Note: registry writes
-  still land in the real pointer file under the override, and a relaunch now
-  inherits the env — sandbox live tests with an overridden `HOME` instead.
+live-tested end to end — the checklist lives under Completed); only Phase 2
+remains, if demand appears.
 
 **Phase 2 — restartless switching / notebooks open side-by-side (only if
 Phase 1 proves demand):**
@@ -106,13 +125,7 @@ per-notebook settings sync.
 
 ## App & polish
 - [ ] **Visual design pass** — make the UI look professional and easy on the eyes (spacing, typography, color, density)
-- [ ] Sidebar: remember the collapsed state across launches, and add a keyboard shortcut to toggle it
 - [ ] Multi-window: same-page **concurrent edits** are last-write-wins — editing the *same* page/day in two windows at once can drop one side's changes. True resolution needs a CRDT/OT layer (out of scope for a single-user app); revisit only if real-time collaboration is ever wanted
-
-## Settings window
-- [x] Use small versions of components — DONE on `feat/notebooks` (115e826),
-  and extended app-wide: chrome controls take `Sizable::small()` (convention
-  in AGENTS.md); dialogs and focal surfaces keep the default size
 
 ## Import & export
 - [ ] Logseq import follow-ups: an in-progress indicator with real progress (it's a bare "may take a minute" dialog today); surface imported pages in the sidebar right away (a fresh DB shows "No recent pages" until things are visited)
@@ -120,8 +133,6 @@ per-notebook settings sync.
 - [ ] PDF: **area (image-region) highlights** — only text-anchored highlights exist so far; a box-drag over a scanned region would cover figures / pages with no text layer
 - [ ] PDF: **garbled quotes from decorative fonts** — some heading fonts decode to shifted/garbled unicode (e.g. a −29 glyph shift), so a highlight on them stores garbled text (it still re-locates, since garbled matches garbled); body text is correct. Upstream hayro limitation
 - [ ] PDF: **graceful fallback for unsupported files** — encrypted PDFs now open behind a password prompt (RC4 / AES-128 / AES-256), but hayro can still fail on an *unsupported* encryption algorithm (e.g. a public-key / certificate handler) or exotic transparency / blend modes; on such a load/parse failure, show an "Open in default app" affordance (hand off to the OS viewer) instead of a blank pane
-- [ ] PDF: **a failed load is silent and permanent** (found in the 2026-07-06 API audit) — an unreadable file or malformed PDF only `log::error!`s and `PdfView` sits on the "Loading PDF…" placeholder forever, with no error state, event, or retry; and a retry-unlock failing with `LoadError::Other` (e.g. unsupported encryption discovered at unlock time) is logged but **eventless**, so the password prompt gets no signal. Both want an explicit error state + `PdfEvent`; overlaps with the graceful-fallback item above
-- [ ] PDF: `is_pdf` misses query-string refs (`report.pdf?v=2`) — it only checks `ends_with(".pdf")` after trimming trailing whitespace (API audit)
 - [ ] PDF forms, follow-ups — the AcroForm feature SHIPPED 2026-07-06 (see
   Completed): remaining niceties are **choice-field dropdowns** (Ch fields
   edit as free text today; `FormField::options` already carries `/Opt`),
@@ -138,12 +149,6 @@ findings worth fixing rather than just documenting):
   table — the ⟨⟩ delimiter pair shadows the `\angle` symbol entry (first-match
   lookup), so the symbol is unreachable by name; rename one (e.g. `langle`
   `rangle` for the delimiters, matching LaTeX)
-- [ ] `ratex-gpui`: `MathEditor` rasterizes at a **hard-coded `dpr: 2.0`**
-  (`view.rs` `with_root`) instead of the window's scale factor — slightly soft
-  on 1× displays, wasteful on 3×
-- [ ] `os-spellcheck`: the Windows backend creates its checker for a
-  **hardcoded `en-US`** — follow the system UI language
-  (`GetUserDefaultLocaleName`), falling back gracefully when unsupported
 - [ ] `gpui-whiteboard`: `Font::layout_wrapped` / `layout_styled` are `pub` but
   return **crate-private types** (unnameable outside — `layout_styled` is
   effectively uncallable externally); demote to `pub(crate)` or export the types
@@ -223,6 +228,29 @@ Ideas worth keeping, not yet committed to.
   > API.md per the crate-docs convention.
 
 ## Completed
+
+### Notebooks Phase 1 + UI polish (unreleased, feat/notebooks / PR #41)
+- [x] **Notebooks (multiple data folders), Phase 1** — registry in
+  `data_location.json` (`notebooks: [{name, dir}]` beside the active `dir`;
+  serde-compatible both ways, tested; active synthesizes as "Main" until the
+  first write; moves/settles never delete a pointer holding a registry); a
+  **sidebar-bottom chip switcher** (list with ✓, per-row ✎ rename / reveal /
+  ✕ remove buttons — inline instead of a context menu, which dies to the
+  popover's click-away; one "Add notebook…" whose picked folder decides
+  create-fresh vs open-existing); a **Settings → Notebooks tab** with the same
+  management + the Data-location card (Move-only; a has-db target directs to
+  the switcher); switch = pointer write + relaunch by **respawning
+  `current_exe`** (NOT `cx.restart()` — macOS `open`/LaunchServices pops a
+  Terminal for bare binaries and drops the env); names persist to a
+  `notebook-name` sidecar inside the folder (survive remove/re-add, travel
+  with the data, carried by moves); window title gains the notebook name —
+  the app's drawn TitleBar label (live-updating via the cached registry), the
+  native title only names Mission Control; `ZORITE_DATA` keeps precedence.
+  Phase 2 (restartless / side-by-side) remains under Notebooks above
+- [x] **Small chrome controls app-wide** (115e826) — gpui-component controls
+  in app chrome take `Sizable::small()` (settings cards, sidebar search, graph
+  panel, find bars, PDF prompts); the settings `text_button` shrank to match;
+  dialogs and focal surfaces keep the default size. Convention in AGENTS.md
 
 ### Obsidian parity (0.6.0)
 - [x] **Properties (`key:: value` anywhere)** (PR #32) — any-line properties render as a two-column panel (per-key icons, `#tag` / `[[link]]` values as clickable pills, hover highlight) in BOTH views; an **in-place property editor** seated in the note (click or arrow in; key dropdown fed by every key in the vault; full keyboard nav; writes `key:: value` back on blur); and a **Properties index page** (All pages → Properties): every key with its values + pages, icon overrides / pre-mapping from a picker, and rename-a-key-across-the-vault. Recognition shared in `gpui_markdown::syntax`; `alias::` keeps its `page_aliases` DB resolution

--- a/TODO.md
+++ b/TODO.md
@@ -32,8 +32,8 @@ work is collected under [Completed](#completed) at the bottom.
 Obsidian-style multiple "vaults" — separate, self-contained data sets the user
 switches between (work / personal / a shared folder in Dropbox). **Not called
 vaults**; working name **Notebooks** (alternatives considered: Spaces,
-Workspaces, Collections). **Held for 0.7.0** (planned 2026-07-06; not in the
-next release).
+Workspaces, Collections). **Phase 1 BUILT on `feat/notebooks`** (2026-07-08,
+live-tested); the Settings fold-in below and Phase 2 remain.
 
 **Why this is cheaper than it sounds — what already exists:**
 - A data dir is already a fully self-contained bundle: `zorite.db` + `images/`
@@ -50,25 +50,36 @@ next release).
 - gpui has `cx.restart()` (Zed's updater uses it) — a clean relaunch is
   available for switch-by-restart.
 
-**Phase 1 — registry + switcher, switch = relaunch:**
-- [ ] Extend `data_location.json` into a registry: `{active, notebooks:
-  [{name, dir}]}`. Serde compat both ways (old builds ignore unknown fields;
-  `#[serde(default)]` reads old files). First launch after the update
-  auto-registers the current dir as **"Main"**.
-- [ ] **Switcher at the bottom of the sidebar** (user-picked spot): a compact
-  chip showing the active notebook's name; clicking opens a popover — the
-  notebook list (✓ on active, click to switch), **New notebook…** (name + a
-  folder picker; seeds a fresh empty dir), **Add existing…** (pick a folder
-  that holds a `zorite.db`), right-click → rename / **remove from list**
-  (forgets the entry, never deletes files) / Reveal in Finder. Hide the chip
-  (or show "Main" quietly) when only one notebook is registered.
-- [ ] Switch = write `active` to the pointer file + `cx.restart()`. An
-  encrypted target notebook lands on its unlock screen naturally, and restart
-  sidesteps the Windows zero-window-exit gotcha entirely.
-- [ ] Window title gains the notebook name when more than one is registered.
+**Phase 1 — registry + switcher, switch = relaunch (BUILT, with deviations):**
+- [x] Registry in `data_location.json`: the existing `dir` stays the active
+  pointer; a `notebooks: [{name, dir}]` list rides along (serde-compatible
+  both ways, tested). The active dir is synthesized as **"Main"** until the
+  first registry write; a move/settle never deletes the pointer file while it
+  holds a registry.
+- [x] Switcher chip at the bottom of the sidebar. Deviations from the sketch:
+  ONE **Add notebook…** item instead of New/Add-existing (the picked folder
+  decides — empty = create fresh, holds a `zorite.db` = open existing; the
+  confirm dialog says which); per-row inline buttons (✎ rename / reveal /
+  ✕ remove-from-list) instead of a right-click menu — a nested context menu
+  anchored inside the hand-rolled popover dies to its click-away dismissal;
+  and the chip always shows (it's the only entry point for a second notebook
+  until the Settings fold-in lands). Names default to the folder name; a
+  rename persists to a `notebook-name` sidecar INSIDE the notebook dir, so
+  custom names survive remove/re-add and travel with the folder.
+- [x] Switch = write the pointer + relaunch — but NOT `cx.restart()`: on
+  macOS that goes through `open`/LaunchServices, which pops a Terminal window
+  for a bare (non-.app) binary and drops the environment; the app respawns
+  `current_exe` directly and quits (`relaunch()` in app.rs).
+- [x] Window title gains the notebook name when more than one is registered
+  (main + torn-off windows; set at window creation, so a rename of the active
+  notebook shows after the next relaunch).
 - [ ] Settings → General's existing "data location" pane folds into this
   (Move becomes a per-notebook action; Switch is superseded by the registry).
-- [ ] `ZORITE_DATA` keeps top precedence (dev/test), bypassing the registry.
+  `set_location` already keeps the registry coherent (a Move retargets the
+  moved notebook's entry), so this is UI-only.
+- [x] `ZORITE_DATA` keeps top precedence (dev/test). Note: registry writes
+  still land in the real pointer file under the override, and a relaunch now
+  inherits the env — sandbox live tests with an overridden `HOME` instead.
 
 **Phase 2 — restartless switching / notebooks open side-by-side (only if
 Phase 1 proves demand):**

--- a/assets/icons/pencil.svg
+++ b/assets/icons/pencil.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.18.0 - ISC -->
+<svg
+  class="lucide lucide-pencil"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" />
+  <path d="m15 5 4 4" />
+</svg>

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,7 +25,7 @@ use gpui::{
     WindowHandle, WindowOptions, div, point, px, size,
 };
 use gpui_component::{
-    Root, TitleBar, WindowExt,
+    Root, Sizable, TitleBar, WindowExt,
     button::{Button, ButtonVariant, ButtonVariants},
     dialog::{DialogButtonProps, DialogFooter},
     input::{Input, InputEvent, InputState},
@@ -5144,7 +5144,7 @@ impl AppView {
                             .text_color(theme::text_primary())
                             .child("🔒 This PDF is password protected"),
                     )
-                    .child(Input::new(&self.pdf_password_input).mask_toggle())
+                    .child(Input::new(&self.pdf_password_input).small().mask_toggle())
                     .children(failed.then(|| {
                         div()
                             .text_size(px(12.0))
@@ -5154,6 +5154,7 @@ impl AppView {
                     .child(
                         div().flex().justify_end().child(
                             Button::new("pdf-unlock")
+                                .small()
                                 .label("Unlock")
                                 .primary()
                                 .on_click(cx.listener(move |this, _, window, cx| {
@@ -7970,7 +7971,7 @@ impl Render for AppView {
                                         e.field.name
                                     )),
                             )
-                            .child(Input::new(&e.input)),
+                            .child(Input::new(&e.input).small()),
                     ),
             )
             .into_any_element()

--- a/src/app.rs
+++ b/src/app.rs
@@ -602,6 +602,11 @@ pub struct AppView {
     /// rename dialog targets (its dir — the dialog shares `rename_input`).
     pub notebook_popover: bool,
     notebook_rename_target: Option<String>,
+    /// The notebook registry, cached (the pointer file isn't re-read every
+    /// render) — refreshed when the popover opens and after any mutation.
+    /// `window_label` is the title-bar text derived from it.
+    pub notebooks: Vec<crate::paths::Notebook>,
+    window_label: SharedString,
     /// The text field for the password prompt shown when an encrypted PDF tab is
     /// locked (one field shared across PDF tabs — only the active one prompts).
     pdf_password_input: Entity<InputState>,
@@ -847,6 +852,8 @@ impl AppView {
             rename_target: None,
             notebook_popover: false,
             notebook_rename_target: None,
+            notebooks: crate::paths::notebooks(),
+            window_label: crate::paths::window_title().into(),
             pdf_password_input,
             db_error,
             db_error_shown: false,
@@ -7597,6 +7604,24 @@ impl AppView {
 
     pub fn toggle_notebook_popover(&mut self, cx: &mut Context<Self>) {
         self.notebook_popover = !self.notebook_popover;
+        if self.notebook_popover {
+            // Opening shows a fresh view of the registry (another window or
+            // an older build may have written it).
+            self.refresh_notebooks();
+        }
+        cx.notify();
+    }
+
+    /// Re-read the registry cache + the title-bar label after a mutation.
+    fn refresh_notebooks(&mut self) {
+        self.notebooks = crate::paths::notebooks();
+        self.window_label = crate::paths::window_title().into();
+    }
+
+    /// The registry changed outside this view (Settings → Notebooks) —
+    /// refresh the chip + title.
+    pub fn notebooks_changed(&mut self, cx: &mut Context<Self>) {
+        self.refresh_notebooks();
         cx.notify();
     }
 
@@ -7685,39 +7710,14 @@ impl AppView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Nested data dirs would let one notebook's move/sweep eat another.
-        let current = crate::paths::data_dir();
-        if dir != current && (dir.starts_with(&current) || current.starts_with(&dir)) {
-            self.show_error_dialog(
-                "Can’t use that folder",
-                "Pick a folder that's neither inside nor the parent of the current data folder."
-                    .to_string(),
-                window,
-                cx,
-            );
-            return;
+        match crate::paths::register_dir(&dir) {
+            Ok(nb) => {
+                self.refresh_notebooks();
+                cx.notify();
+                self.switch_notebook(nb, window, cx);
+            }
+            Err(e) => self.show_error_dialog("Can’t use that folder", e, window, cx),
         }
-        // A name saved inside the folder (a previously renamed notebook being
-        // re-added) wins over the folder's own name.
-        let name = crate::paths::saved_notebook_name(&dir).unwrap_or_else(|| {
-            dir.file_name().map_or_else(
-                || "Notebook".to_string(),
-                |n| n.to_string_lossy().into_owned(),
-            )
-        });
-        if let Err(e) = crate::paths::add_notebook(&name, &dir) {
-            self.show_error_dialog("Couldn’t add notebook", e.to_string(), window, cx);
-            return;
-        }
-        cx.notify();
-        self.switch_notebook(
-            crate::paths::Notebook {
-                name,
-                dir: dir.to_string_lossy().into_owned(),
-            },
-            window,
-            cx,
-        );
     }
 
     /// The row's ✎ button: the shared rename dialog, targeted at a notebook.
@@ -7784,6 +7784,7 @@ impl AppView {
         if let Err(e) = crate::paths::rename_notebook(&dir, name) {
             log::error!("rename notebook: {e}");
         }
+        self.refresh_notebooks();
         cx.notify();
     }
 
@@ -7796,6 +7797,7 @@ impl AppView {
         if let Err(e) = crate::paths::forget_notebook(&nb.dir) {
             log::error!("forget notebook: {e}");
         }
+        self.refresh_notebooks();
         cx.notify();
     }
 
@@ -8402,11 +8404,14 @@ impl Render for AppView {
                     .on_click(cx.listener(|this: &mut AppView, _, window, cx| {
                         this.cycle_theme_mode(window, cx);
                     }));
+                // "Zorite — <notebook>" once more than one notebook is
+                // registered (the drawn label; the native title only names
+                // Mission Control / the taskbar).
                 let label = div()
                     .px_2()
                     .text_size(px(13.0))
                     .text_color(theme::text_secondary())
-                    .child("Zorite");
+                    .child(self.window_label.clone());
                 let row = div().flex().flex_row().items_center().w_full();
                 // macOS: the native menu bar carries File/Edit/View, so the titlebar
                 // keeps just the title + theme toggle. Windows/Linux: the AppMenuBar
@@ -8830,12 +8835,13 @@ fn spell_diagnostics(text: &str) -> Vec<Diagnostic> {
 }
 
 /// Relaunch the app so the next boot picks up the re-pointed data dir (a
-/// notebook switch). NOT gpui's `restart()`: on macOS that goes through
-/// `open`/LaunchServices, which pops a Terminal window for a bare (non-.app)
-/// binary and drops the caller's environment — so respawn our own executable
-/// directly (inheriting env, identical bundled or not) and quit. The old and
-/// new instances overlap only for a moment, and on different data dirs.
-fn relaunch(cx: &mut App) {
+/// notebook switch — from the sidebar chip or Settings → Notebooks). NOT
+/// gpui's `restart()`: on macOS that goes through `open`/LaunchServices,
+/// which pops a Terminal window for a bare (non-.app) binary and drops the
+/// caller's environment — so respawn our own executable directly (inheriting
+/// env, identical bundled or not) and quit. The old and new instances overlap
+/// only for a moment, and on different data dirs.
+pub(crate) fn relaunch(cx: &mut App) {
     match std::env::current_exe() {
         Ok(exe) => match std::process::Command::new(exe).spawn() {
             Ok(_) => cx.quit(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -598,6 +598,10 @@ pub struct AppView {
     /// The rename dialog's text field, and the page being renamed.
     rename_input: Entity<InputState>,
     rename_target: Option<i64>,
+    /// The sidebar's notebook-switcher popover open state, and the notebook a
+    /// rename dialog targets (its dir — the dialog shares `rename_input`).
+    pub notebook_popover: bool,
+    notebook_rename_target: Option<String>,
     /// The text field for the password prompt shown when an encrypted PDF tab is
     /// locked (one field shared across PDF tabs — only the active one prompts).
     pdf_password_input: Entity<InputState>,
@@ -841,6 +845,8 @@ impl AppView {
             doc_signal,
             rename_input: cx.new(|cx| InputState::new(window, cx)),
             rename_target: None,
+            notebook_popover: false,
+            notebook_rename_target: None,
             pdf_password_input,
             db_error,
             db_error_shown: false,
@@ -6348,7 +6354,7 @@ impl AppView {
             WindowOptions {
                 window_bounds: Some(WindowBounds::Windowed(bounds)),
                 titlebar: Some(TitlebarOptions {
-                    title: Some("Zorite".into()),
+                    title: Some(crate::paths::window_title().into()),
                     ..TitleBar::title_bar_options()
                 }),
                 app_id: Some("zorite".into()),
@@ -7565,6 +7571,238 @@ impl AppView {
         }
     }
 
+    // --- Notebooks: the sidebar switcher chip's flows -------------------------
+
+    /// A one-button error dialog (the notebook flows' failure path).
+    fn show_error_dialog(
+        &mut self,
+        title: &'static str,
+        body: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.open_alert_dialog(cx, move |dialog, _window, _cx| {
+            let body = body.clone();
+            dialog
+                .title(title)
+                .description(SharedString::from(body))
+                .button_props(
+                    DialogButtonProps::default()
+                        .ok_text("OK")
+                        .show_cancel(false),
+                )
+                .on_ok(|_, _window, _cx| true)
+        });
+    }
+
+    pub fn toggle_notebook_popover(&mut self, cx: &mut Context<Self>) {
+        self.notebook_popover = !self.notebook_popover;
+        cx.notify();
+    }
+
+    /// Confirm, point the location pointer at `nb`, and relaunch into it. The
+    /// restart (rather than an in-place swap) keeps every store on the one
+    /// process-wide data dir honest, lands an encrypted target on its unlock
+    /// screen naturally, and sidesteps the Windows zero-window exit.
+    pub fn switch_notebook(
+        &mut self,
+        nb: crate::paths::Notebook,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.notebook_popover = false;
+        cx.notify();
+        if nb.is_active() {
+            return;
+        }
+        let fresh = !std::path::Path::new(&nb.dir).join("zorite.db").exists();
+        let (title, body): (&'static str, String) = if fresh {
+            (
+                "Create notebook",
+                format!(
+                    "Zorite will relaunch with a fresh, empty notebook “{}” in:\n{}",
+                    nb.name, nb.dir
+                ),
+            )
+        } else {
+            (
+                "Switch notebook",
+                format!("Zorite will relaunch into “{}”:\n{}", nb.name, nb.dir),
+            )
+        };
+        window.open_alert_dialog(cx, move |dialog, _window, _cx| {
+            let nb = nb.clone();
+            let body = body.clone();
+            dialog
+                .title(title)
+                .description(SharedString::from(body))
+                .button_props(
+                    DialogButtonProps::default()
+                        .ok_text("Relaunch")
+                        .cancel_text("Cancel")
+                        .show_cancel(true),
+                )
+                .on_ok(move |_, _window, cx| {
+                    match crate::paths::switch_notebook(&nb.dir) {
+                        Ok(()) => relaunch(cx),
+                        Err(e) => log::error!("switch notebook failed: {e}"),
+                    }
+                    true
+                })
+        });
+    }
+
+    /// "Add notebook…": pick a folder, register it under its folder name, and
+    /// offer the relaunch. The folder's contents decide what happens — one
+    /// holding a `zorite.db` opens as an existing notebook, an empty one
+    /// starts fresh (the confirm dialog says which).
+    pub fn add_notebook_via_picker(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.notebook_popover = false;
+        cx.notify();
+        let rx = cx.prompt_for_paths(gpui::PathPromptOptions {
+            files: false,
+            directories: true,
+            multiple: false,
+            prompt: Some("Use folder".into()),
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            let Ok(Ok(Some(paths))) = rx.await else {
+                return;
+            };
+            let Some(dir) = paths.into_iter().next() else {
+                return;
+            };
+            let _ = this.update_in(cx, |this, window, cx| {
+                this.register_notebook(dir, window, cx);
+            });
+        })
+        .detach();
+    }
+
+    fn register_notebook(
+        &mut self,
+        dir: std::path::PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // Nested data dirs would let one notebook's move/sweep eat another.
+        let current = crate::paths::data_dir();
+        if dir != current && (dir.starts_with(&current) || current.starts_with(&dir)) {
+            self.show_error_dialog(
+                "Can’t use that folder",
+                "Pick a folder that's neither inside nor the parent of the current data folder."
+                    .to_string(),
+                window,
+                cx,
+            );
+            return;
+        }
+        // A name saved inside the folder (a previously renamed notebook being
+        // re-added) wins over the folder's own name.
+        let name = crate::paths::saved_notebook_name(&dir).unwrap_or_else(|| {
+            dir.file_name().map_or_else(
+                || "Notebook".to_string(),
+                |n| n.to_string_lossy().into_owned(),
+            )
+        });
+        if let Err(e) = crate::paths::add_notebook(&name, &dir) {
+            self.show_error_dialog("Couldn’t add notebook", e.to_string(), window, cx);
+            return;
+        }
+        cx.notify();
+        self.switch_notebook(
+            crate::paths::Notebook {
+                name,
+                dir: dir.to_string_lossy().into_owned(),
+            },
+            window,
+            cx,
+        );
+    }
+
+    /// The row's ✎ button: the shared rename dialog, targeted at a notebook.
+    pub fn rename_notebook_dialog(
+        &mut self,
+        nb: crate::paths::Notebook,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.notebook_popover = false;
+        self.notebook_rename_target = Some(nb.dir.clone());
+        self.rename_input
+            .update(cx, |s, cx| s.set_value(nb.name, window, cx));
+        let input = self.rename_input.clone();
+        let weak = cx.entity().downgrade();
+        window.open_dialog(cx, move |dialog, _window, _cx| {
+            let input_body = input.clone();
+            let input_btn = input.clone();
+            let input_key = input.clone();
+            let weak_btn = weak.clone();
+            let weak_key = weak.clone();
+            dialog
+                .title("Rename notebook")
+                .w(px(420.0))
+                .child(Input::new(&input_body))
+                .footer(
+                    DialogFooter::new()
+                        .child(
+                            Button::new("nb-rename-cancel")
+                                .label("Cancel")
+                                .on_click(|_, window, cx| window.close_dialog(cx)),
+                        )
+                        .child(
+                            Button::new("nb-rename-ok")
+                                .primary()
+                                .label("Rename")
+                                .on_click(move |_, window, cx| {
+                                    let name = input_btn.read(cx).value().to_string();
+                                    let _ = weak_btn.update(cx, |this, cx| {
+                                        this.commit_notebook_rename(name, cx)
+                                    });
+                                    window.close_dialog(cx);
+                                }),
+                        ),
+                )
+                .on_ok(move |_, _window, cx| {
+                    let name = input_key.read(cx).value().to_string();
+                    let _ = weak_key.update(cx, |this, cx| this.commit_notebook_rename(name, cx));
+                    true
+                })
+                .on_cancel(|_, _window, _cx| true)
+        });
+        self.rename_input.update(cx, |s, cx| s.focus(window, cx));
+    }
+
+    fn commit_notebook_rename(&mut self, name: String, cx: &mut Context<Self>) {
+        let Some(dir) = self.notebook_rename_target.take() else {
+            return;
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            return;
+        }
+        if let Err(e) = crate::paths::rename_notebook(&dir, name) {
+            log::error!("rename notebook: {e}");
+        }
+        cx.notify();
+    }
+
+    /// The row's ✕ button: forgets the registry entry (files are never
+    /// touched). The active notebook's row doesn't offer it.
+    pub fn forget_notebook(&mut self, nb: crate::paths::Notebook, cx: &mut Context<Self>) {
+        if nb.is_active() {
+            return;
+        }
+        if let Err(e) = crate::paths::forget_notebook(&nb.dir) {
+            log::error!("forget notebook: {e}");
+        }
+        cx.notify();
+    }
+
+    pub fn reveal_notebook(&mut self, nb: crate::paths::Notebook, cx: &mut Context<Self>) {
+        cx.reveal_path(std::path::Path::new(&nb.dir));
+    }
+
     /// Rename the open page from its inline title field. Updates state in
     /// place (no tab reload) so the title field keeps focus; reverts the
     /// field if the new name is empty, a duplicate, or a journal.
@@ -8589,6 +8827,22 @@ fn spell_diagnostics(text: &str) -> Vec<Diagnostic> {
         .into_iter()
         .map(|range| Diagnostic { range })
         .collect()
+}
+
+/// Relaunch the app so the next boot picks up the re-pointed data dir (a
+/// notebook switch). NOT gpui's `restart()`: on macOS that goes through
+/// `open`/LaunchServices, which pops a Terminal window for a bare (non-.app)
+/// binary and drops the caller's environment — so respawn our own executable
+/// directly (inheriting env, identical bundled or not) and quit. The old and
+/// new instances overlap only for a moment, and on different data dirs.
+fn relaunch(cx: &mut App) {
+    match std::env::current_exe() {
+        Ok(exe) => match std::process::Command::new(exe).spawn() {
+            Ok(_) => cx.quit(),
+            Err(e) => log::error!("relaunch: spawn failed: {e}"),
+        },
+        Err(e) => log::error!("relaunch: current_exe: {e}"),
+    }
 }
 
 /// The auto-link match for a just-completed line slice (text up to the typed

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,8 @@ const ALERT_OCTAGON: &[u8] = include_bytes!("../assets/icons/octagon-alert.svg")
 // Sidebar "All pages" browser button.
 const LAYOUT_LIST: &[u8] = include_bytes!("../assets/icons/layout-list.svg");
 const WAYPOINTS: &[u8] = include_bytes!("../assets/icons/waypoints.svg");
+// Notebook-switcher row buttons (rename).
+const PENCIL: &[u8] = include_bytes!("../assets/icons/pencil.svg");
 // Property-key icons: ONE list drives both the picker's choices and the
 // embedded bytes, so a face offered on the Properties page can never be
 // missing from a release build (the on-disk lucide set is dev-only — a
@@ -185,6 +187,7 @@ impl AssetSource for Assets {
             "icons/octagon-alert.svg" => Some(ALERT_OCTAGON),
             "icons/layout-list.svg" => Some(LAYOUT_LIST),
             "icons/waypoints.svg" => Some(WAYPOINTS),
+            "icons/pencil.svg" => Some(PENCIL),
             _ => property_icon_bytes(path),
         };
         if let Some(bytes) = custom {
@@ -358,7 +361,7 @@ pub(crate) fn open_main_window(cx: &mut App) {
         WindowOptions {
             window_bounds: Some(window_bounds),
             titlebar: Some(TitlebarOptions {
-                title: Some("Zorite".into()),
+                title: Some(paths::window_title().into()),
                 ..TitleBar::title_bar_options()
             }),
             app_id: Some("zorite".into()),

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -162,6 +162,27 @@ struct LocationPointer {
     /// before opening the database; cleared once the move completes.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     migrate_from: String,
+    /// Registered notebooks — every data directory the user has created or
+    /// added, including the active one. Empty until a second notebook exists
+    /// (or one is renamed), so a plain single-data-set install keeps the old
+    /// pointer shape; old builds ignore the field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    notebooks: Vec<Notebook>,
+}
+
+/// One registered notebook: a self-contained data directory (database +
+/// assets) the user can switch to. See [`notebooks`].
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Debug)]
+pub struct Notebook {
+    pub name: String,
+    /// Absolute path of the notebook's data directory.
+    pub dir: String,
+}
+
+impl Notebook {
+    pub fn is_active(&self) -> bool {
+        Path::new(&self.dir) == data_dir()
+    }
 }
 
 /// The pointer file's fixed home — the OS default dir, so it survives the data
@@ -235,19 +256,151 @@ pub fn plan_relocation(target: &Path) -> Relocation {
 /// schedules a move of the current data into it on the next startup. Takes
 /// effect after the app restarts.
 pub fn set_location(target: &Path) -> std::io::Result<()> {
-    let mut p = LocationPointer {
-        dir: target.to_string_lossy().into_owned(),
-        migrate_from: String::new(),
-    };
-    if !target.join("zorite.db").exists() {
-        p.migrate_from = data_dir().to_string_lossy().into_owned();
-    }
-    write_pointer(&p)
+    let current = data_dir();
+    update_pointer(|p| {
+        p.dir = target.to_string_lossy().into_owned();
+        p.migrate_from.clear();
+        if !target.join("zorite.db").exists() {
+            p.migrate_from = current.to_string_lossy().into_owned();
+            // A move relocates the active notebook — its entry follows the data.
+            for n in &mut p.notebooks {
+                if Path::new(&n.dir) == current {
+                    n.dir = p.dir.clone();
+                }
+            }
+        }
+    })
 }
 
 /// Send the data back to the OS-default location (moving it there on restart).
 pub fn reset_location() -> std::io::Result<()> {
     set_location(&default_data_dir())
+}
+
+// --- Notebooks: registered data directories the user switches between --------
+// The registry lives in the location-pointer file; `dir` stays the single
+// source of truth for what's active, so switching notebooks is rewriting
+// `dir` and relaunching. `ZORITE_DATA` outranks all of it (resolve_data_dir).
+
+/// Read-modify-write the pointer file, preserving whatever fields the closure
+/// doesn't touch. An absent/blank `dir` is seeded with the OS default so a
+/// registry write never accidentally repoints the data.
+fn update_pointer(f: impl FnOnce(&mut LocationPointer)) -> std::io::Result<()> {
+    let mut p = read_pointer().unwrap_or_default();
+    if p.dir.trim().is_empty() {
+        p.dir = default_data_dir().to_string_lossy().into_owned();
+    }
+    f(&mut p);
+    write_pointer(&p)
+}
+
+/// Registered notebooks, with the active data directory always present. When
+/// the registry doesn't know it yet (first launch after the update, or a
+/// pointer written by an older build) the active entry is synthesized — named
+/// "Main", or by its folder when other notebooks exist — and persisted on the
+/// first registry mutation.
+pub fn notebooks() -> Vec<Notebook> {
+    let mut list = read_pointer().map(|p| p.notebooks).unwrap_or_default();
+    if !list.iter().any(Notebook::is_active) {
+        let active = data_dir();
+        let name = saved_notebook_name(&active).unwrap_or_else(|| {
+            if list.is_empty() {
+                "Main".to_string()
+            } else {
+                active
+                    .file_name()
+                    .map_or_else(|| "Main".to_string(), |n| n.to_string_lossy().into_owned())
+            }
+        });
+        list.insert(
+            0,
+            Notebook {
+                name,
+                dir: active.to_string_lossy().into_owned(),
+            },
+        );
+    }
+    list
+}
+
+/// The active notebook's name when more than one is registered — the switcher
+/// chip label and the window-title suffix stay quiet for a single data set.
+pub fn active_notebook_name() -> Option<String> {
+    let list = notebooks();
+    (list.len() > 1)
+        .then(|| list.into_iter().find(Notebook::is_active))
+        .flatten()
+        .map(|n| n.name)
+}
+
+/// The note-window title: "Zorite", gaining the notebook's name when more
+/// than one is registered.
+pub fn window_title() -> String {
+    match active_notebook_name() {
+        Some(name) => format!("Zorite — {name}"),
+        None => "Zorite".to_string(),
+    }
+}
+
+/// Register `dir` as a notebook named `name` (no-op when already registered).
+/// The first mutation also persists the synthesized active entry, so the
+/// registry is complete from then on.
+pub fn add_notebook(name: &str, dir: &Path) -> std::io::Result<()> {
+    let all = notebooks();
+    update_pointer(move |p| {
+        p.notebooks = all;
+        if !p.notebooks.iter().any(|n| Path::new(&n.dir) == dir) {
+            p.notebooks.push(Notebook {
+                name: name.to_string(),
+                dir: dir.to_string_lossy().into_owned(),
+            });
+        }
+    })
+}
+
+/// A notebook's display name, persisted as a tiny sidecar *inside* its data
+/// dir — so a custom name survives remove/re-add and travels when the folder
+/// is shared or moved. The registry stays the display source of truth; this
+/// file only seeds it. (Renaming never touches the folder itself: the active
+/// notebook's directory is a live, open database.)
+fn notebook_name_file(dir: &Path) -> PathBuf {
+    dir.join("notebook-name")
+}
+
+/// The name saved inside a notebook dir, if any.
+pub fn saved_notebook_name(dir: &Path) -> Option<String> {
+    let s = std::fs::read_to_string(notebook_name_file(dir)).ok()?;
+    let s = s.trim();
+    (!s.is_empty()).then(|| s.to_string())
+}
+
+pub fn rename_notebook(dir: &str, new_name: &str) -> std::io::Result<()> {
+    // Best-effort: the name rides inside the notebook so re-adding finds it.
+    let _ = std::fs::write(notebook_name_file(Path::new(dir)), new_name);
+    let all = notebooks();
+    update_pointer(move |p| {
+        p.notebooks = all;
+        for n in &mut p.notebooks {
+            if n.dir == dir {
+                n.name = new_name.to_string();
+            }
+        }
+    })
+}
+
+/// Drop a notebook from the registry. Its files are never touched.
+pub fn forget_notebook(dir: &str) -> std::io::Result<()> {
+    update_pointer(|p| p.notebooks.retain(|n| n.dir != dir))
+}
+
+/// Point the next launch at `dir`. Unlike [`set_location`] this never
+/// schedules a move: an empty notebook directory boots a fresh database, a
+/// populated one opens in place. The caller relaunches the app.
+pub fn switch_notebook(dir: &str) -> std::io::Result<()> {
+    update_pointer(|p| {
+        p.dir = dir.to_string();
+        p.migrate_from.clear();
+    })
 }
 
 /// Shared progress for a startup data move: total bytes to move, bytes done so
@@ -314,27 +467,27 @@ pub fn pending_migration() -> Option<(PathBuf, PathBuf, u64)> {
 /// while the data still sits at the source. Marks `progress` finished when done.
 pub fn run_migration(source: &Path, target: &Path, progress: &MigrationProgress) {
     match relocate(source, target, &progress.done) {
-        Ok(()) => {
-            if target == default_data_dir().as_path() {
-                // Back at the default → no pointer needed.
-                let _ = std::fs::remove_file(pointer_path());
-            } else if let Some(mut p) = read_pointer() {
-                p.migrate_from.clear();
-                let _ = write_pointer(&p);
-            }
-        }
+        Ok(()) => settle_pointer(target),
         Err(e) => {
             log::error!("data move {source:?} -> {target:?} failed: {e}; keeping data in place");
-            if source == default_data_dir().as_path() {
-                let _ = std::fs::remove_file(pointer_path());
-            } else if let Some(mut p) = read_pointer() {
-                p.dir = source.to_string_lossy().into_owned();
-                p.migrate_from.clear();
-                let _ = write_pointer(&p);
-            }
+            settle_pointer(source);
         }
     }
     progress.finished.store(true, Ordering::Release);
+}
+
+/// After a move settles, record `dir` as the location with the move flag
+/// cleared. A pointer at the OS default with no notebook registry is
+/// redundant and is removed instead — but a registry always keeps the file.
+fn settle_pointer(dir: &Path) {
+    let Some(mut p) = read_pointer() else { return };
+    if dir == default_data_dir().as_path() && p.notebooks.is_empty() {
+        let _ = std::fs::remove_file(pointer_path());
+        return;
+    }
+    p.dir = dir.to_string_lossy().into_owned();
+    p.migrate_from.clear();
+    let _ = write_pointer(&p);
 }
 
 /// Total size of the entries a move would carry — the `zorite.db*` files plus
@@ -360,15 +513,17 @@ fn move_total_bytes(source: &Path) -> u64 {
 /// Move Zorite's managed data from `source` into `target`, rename-first with a
 /// cross-filesystem copy+remove fallback, adding copied bytes to `done`. Moves
 /// every `zorite.db*` file (the database, its `-wal`/`-shm` sidecars, the
-/// rollback journal, and any migration `.bak-*` backups) plus the `images/`,
-/// `pdf/`, `themes/`, `fonts/` asset folders. Only those entries move, so
-/// unrelated files (and the pointer in the default dir) stay put.
+/// rollback journal, and any migration `.bak-*` backups), the `notebook-name`
+/// sidecar, plus the `images/`, `pdf/`, `themes/`, `fonts/` asset folders.
+/// Only those entries move, so unrelated files (and the pointer in the
+/// default dir) stay put.
 fn relocate(source: &Path, target: &Path, done: &AtomicU64) -> std::io::Result<()> {
     std::fs::create_dir_all(target)?;
     for entry in std::fs::read_dir(source)? {
         let entry = entry?;
         let name = entry.file_name();
-        if name.to_string_lossy().starts_with("zorite.db") {
+        // The db + sidecars, and the notebook's display-name sidecar.
+        if name.to_string_lossy().starts_with("zorite.db") || name == "notebook-name" {
             move_path(&entry.path(), &target.join(&name), done)?;
         }
     }
@@ -522,6 +677,25 @@ pub fn resolve_local(src: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pointer_file_is_compatible_both_ways() {
+        // A pointer written by a pre-notebooks build reads cleanly (empty
+        // registry)…
+        let old: LocationPointer = serde_json::from_str(r#"{"dir": "/x/y"}"#).unwrap();
+        assert_eq!(old.dir, "/x/y");
+        assert!(old.notebooks.is_empty());
+        // …and one we write without a registry keeps the old shape, so a
+        // downgrade reads it too.
+        assert_eq!(serde_json::to_string(&old).unwrap(), r#"{"dir":"/x/y"}"#);
+        // The registry round-trips.
+        let new: LocationPointer = serde_json::from_str(
+            r#"{"dir": "/a", "notebooks": [{"name": "Main", "dir": "/a"}, {"name": "Work", "dir": "/b"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(new.notebooks.len(), 2);
+        assert_eq!(new.notebooks[1].name, "Work");
+    }
 
     #[test]
     fn relative_resolves_under_data_dir() {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -342,6 +342,31 @@ pub fn window_title() -> String {
     }
 }
 
+/// Validate and register a picked folder as a notebook: rejects nesting with
+/// the current data dir (one notebook's move/sweep could eat another), names
+/// it from its `notebook-name` sidecar (a previously renamed notebook being
+/// re-added) or its folder name. Shared by the sidebar switcher and Settings.
+pub fn register_dir(dir: &Path) -> Result<Notebook, String> {
+    let current = data_dir();
+    if *dir != current && (dir.starts_with(&current) || current.starts_with(dir)) {
+        return Err(
+            "Pick a folder that's neither inside nor the parent of the current data folder."
+                .to_string(),
+        );
+    }
+    let name = saved_notebook_name(dir).unwrap_or_else(|| {
+        dir.file_name().map_or_else(
+            || "Notebook".to_string(),
+            |n| n.to_string_lossy().into_owned(),
+        )
+    });
+    add_notebook(&name, dir).map_err(|e| e.to_string())?;
+    Ok(Notebook {
+        name,
+        dir: dir.to_string_lossy().into_owned(),
+    })
+}
+
 /// Register `dir` as a notebook named `name` (no-op when already registered).
 /// The first mutation also persists the synthesized active entry, so the
 /// registry is complete from then on.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,7 +15,7 @@ use gpui::{
     Subscription, WeakEntity, Window, div, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
-    Disableable, IndexPath, Root, TitleBar, WindowExt,
+    Disableable, IndexPath, Root, Sizable, TitleBar, WindowExt,
     button::{Button, ButtonVariants as _},
     dialog::{DialogButtonProps, DialogFooter},
     input::{Input, InputEvent, InputState},
@@ -1343,6 +1343,7 @@ impl SettingsView {
             .w(px(220.0))
             .child(
                 Input::new(&self.filter_input)
+                    .small()
                     .appearance(true)
                     .text_size(px(13.0)),
             )
@@ -1408,14 +1409,14 @@ impl Render for SettingsView {
             .map(|a| a.read(cx).wysiwyg())
             .unwrap_or(true);
         let wys_app = self.app.clone();
-        let wysiwyg_switch =
-            Switch::new("wysiwyg-toggle")
-                .checked(wys_on)
-                .on_click(move |checked, _window, cx| {
-                    if let Some(app) = wys_app.upgrade() {
-                        app.update(cx, |a, cx| a.set_wysiwyg(*checked, cx));
-                    }
-                });
+        let wysiwyg_switch = Switch::new("wysiwyg-toggle")
+            .small()
+            .checked(wys_on)
+            .on_click(move |checked, _window, cx| {
+                if let Some(app) = wys_app.upgrade() {
+                    app.update(cx, |a, cx| a.set_wysiwyg(*checked, cx));
+                }
+            });
 
         // Auto-link-as-you-type toggle (Markdown pane).
         let al_on = self
@@ -1424,14 +1425,14 @@ impl Render for SettingsView {
             .map(|a| a.read(cx).auto_link())
             .unwrap_or(false);
         let al_app = self.app.clone();
-        let auto_link_switch =
-            Switch::new("auto-link-toggle")
-                .checked(al_on)
-                .on_click(move |checked, _window, cx| {
-                    if let Some(app) = al_app.upgrade() {
-                        app.update(cx, |a, _cx| a.set_auto_link(*checked));
-                    }
-                });
+        let auto_link_switch = Switch::new("auto-link-toggle")
+            .small()
+            .checked(al_on)
+            .on_click(move |checked, _window, cx| {
+                if let Some(app) = al_app.upgrade() {
+                    app.update(cx, |a, _cx| a.set_auto_link(*checked));
+                }
+            });
 
         // Updates pane toggles — switches, like the WYSIWYG one. Controlled by
         // the persisted prefs; the click persists + (for pre-releases) re-checks.
@@ -1442,6 +1443,7 @@ impl Render for SettingsView {
             .unwrap_or(true);
         let check_app = self.app.clone();
         let check_updates_switch = Switch::new("check-updates-toggle")
+            .small()
             .checked(check_on)
             .on_click(move |checked, _window, cx| {
                 if let Some(app) = check_app.upgrade() {
@@ -1454,20 +1456,21 @@ impl Render for SettingsView {
             .map(|a| a.read(cx).include_prerelease())
             .unwrap_or(false);
         let pre_app = self.app.clone();
-        let prerelease_switch = Switch::new("prerelease-toggle").checked(pre_on).on_click(
-            move |checked, _window, cx| {
+        let prerelease_switch = Switch::new("prerelease-toggle")
+            .small()
+            .checked(pre_on)
+            .on_click(move |checked, _window, cx| {
                 if let Some(app) = pre_app.upgrade() {
                     app.update(cx, |a, cx| a.set_include_prerelease(*checked, cx));
                 }
-            },
-        );
+            });
 
         // Font card body: the family dropdown + an import button.
         let font_control = div()
             .flex()
             .flex_col()
             .gap(px(8.0))
-            .child(Select::new(&self.font_select).w_full())
+            .child(Select::new(&self.font_select).small().w_full())
             .child(div().flex().flex_row().child(text_button(
                 "font-add",
                 "Add font file…",
@@ -1548,6 +1551,7 @@ impl Render for SettingsView {
         let window_bounds_switch = {
             let weak = cx.entity().downgrade();
             Switch::new("window-bounds")
+                .small()
                 .checked(crate::paths::window_bounds_enabled())
                 .on_click(move |on: &bool, _w, cx| {
                     if *on {
@@ -1633,6 +1637,7 @@ impl Render for SettingsView {
                 .gap(px(8.0))
                 .child(
                     Switch::new("sec-remember")
+                        .small()
                         .checked(encrypted && crate::security::is_remembered())
                         .disabled(!encrypted)
                         .on_click(move |on: &bool, _w, cx| {
@@ -1922,25 +1927,25 @@ impl Render for SettingsView {
                                     "Date format",
                                     "How /date and the {{date}} template placeholder are \
                                          inserted. Journal day headers are unaffected.",
-                                    Select::new(&self.date_format_select).w_full(),
+                                    Select::new(&self.date_format_select).small().w_full(),
                                 ))
                                 .child(self.section_card(
                                     "Time format",
                                     "How /time and the {{time}} template placeholder are \
                                          inserted.",
-                                    Select::new(&self.time_format_select).w_full(),
+                                    Select::new(&self.time_format_select).small().w_full(),
                                 )),
                             Tab::Appearance => content
                                 .child(self.section_card(
                                     "App Theme",
                                     "Pick a built-in theme or one of your own.",
-                                    Select::new(&self.theme_select).w_full(),
+                                    Select::new(&self.theme_select).small().w_full(),
                                 ))
                                 .child(self.section_card(
                                     "Appearance",
                                     "Light or dark variant of the active theme. Auto follows \
                                          your system.",
-                                    Select::new(&self.appearance_select).w_full(),
+                                    Select::new(&self.appearance_select).small().w_full(),
                                 ))
                                 .child(self.section_card(
                                     "Font",
@@ -1954,7 +1959,7 @@ impl Render for SettingsView {
                                     "Text size",
                                     "Size of note text when editing and reading. Headings and \
                                          inline math scale with it.",
-                                    Select::new(&self.text_size_select).w_full(),
+                                    Select::new(&self.text_size_select).small().w_full(),
                                 ))
                                 .child(self.section_card(
                                     "Installed themes",
@@ -1980,7 +1985,7 @@ impl Render for SettingsView {
                                     "List indentation",
                                     "Spaces per nesting level for Tab and bullet nesting. Editing \
                                      and the rendered view use the same width, so they line up.",
-                                    Select::new(&self.indent_select).w_full(),
+                                    Select::new(&self.indent_select).small().w_full(),
                                 ))
                                 .child(self.section_card(
                                     "Auto-link page titles",
@@ -2344,16 +2349,18 @@ fn text_button(
     cx: &mut Context<SettingsView>,
     on: impl Fn(&mut SettingsView, &mut Window, &mut Context<SettingsView>) + 'static,
 ) -> impl IntoElement {
+    // Sized to sit beside gpui-component's `.small()` controls (the cards'
+    // dropdowns/switches) — a notch above the per-notebook row buttons.
     div()
         .id(id)
-        .px(px(12.0))
-        .py(px(7.0))
-        .rounded(px(8.0))
+        .px(px(10.0))
+        .py(px(5.0))
+        .rounded(px(7.0))
         .border_1()
         .border_color(theme::border_subtle())
         .bg(theme::glass())
         .text_color(theme::text_secondary())
-        .text_size(px(13.0))
+        .text_size(px(12.0))
         .cursor_pointer()
         .hover(|h| {
             h.bg(theme::glass_strong())

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -97,6 +97,7 @@ fn font_opts(app: &WeakEntity<AppView>, cx: &Context<SettingsView>) -> (Vec<Opt>
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Tab {
     General,
+    Notebooks,
     Appearance,
     Pdf,
     Markdown,
@@ -120,9 +121,14 @@ enum PwMode {
 /// that aren't already in its title.
 const SECTIONS: &[(Tab, &str, &str)] = &[
     (
-        Tab::General,
+        Tab::Notebooks,
+        "Notebooks",
+        "vault workspace switch add remove rename folder data set",
+    ),
+    (
+        Tab::Notebooks,
         "Data location",
-        "folder path database directory move attachments",
+        "folder path database directory move attachments notebook vault",
     ),
     (
         Tab::General,
@@ -263,6 +269,9 @@ pub struct SettingsView {
     sec_new: Entity<InputState>,
     sec_confirm: Entity<InputState>,
     security_status: Option<String>,
+    /// The Notebooks tab's rename dialog: its field, and the target's dir.
+    nb_rename_input: Entity<InputState>,
+    nb_rename_target: Option<String>,
     _subs: Vec<Subscription>,
 }
 
@@ -451,6 +460,8 @@ impl SettingsView {
             },
         ));
 
+        let nb_rename_input = cx.new(|cx| InputState::new(window, cx));
+
         Self {
             app,
             theme_select,
@@ -469,8 +480,263 @@ impl SettingsView {
             sec_new,
             sec_confirm,
             security_status: None,
+            nb_rename_input,
+            nb_rename_target: None,
             _subs: subs,
         }
+    }
+
+    /// Tell every note window the registry changed (chip + title refresh).
+    fn notify_app_notebooks(&self, cx: &mut Context<Self>) {
+        if let Some(app) = self.app.upgrade() {
+            app.update(cx, |a, cx| a.notebooks_changed(cx));
+        }
+    }
+
+    /// Confirm and relaunch into `nb` (Settings → Notebooks "Switch").
+    fn switch_notebook(
+        &mut self,
+        nb: crate::paths::Notebook,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if nb.is_active() {
+            return;
+        }
+        let fresh = !std::path::Path::new(&nb.dir).join("zorite.db").exists();
+        let (title, body): (&'static str, String) = if fresh {
+            (
+                "Create notebook",
+                format!(
+                    "Zorite will relaunch with a fresh, empty notebook “{}” in:\n{}",
+                    nb.name, nb.dir
+                ),
+            )
+        } else {
+            (
+                "Switch notebook",
+                format!("Zorite will relaunch into “{}”:\n{}", nb.name, nb.dir),
+            )
+        };
+        window.open_alert_dialog(cx, move |dialog, _window, _cx| {
+            let nb = nb.clone();
+            let body = body.clone();
+            dialog
+                .title(title)
+                .description(SharedString::from(body))
+                .button_props(
+                    DialogButtonProps::default()
+                        .ok_text("Relaunch")
+                        .cancel_text("Cancel")
+                        .show_cancel(true),
+                )
+                .on_ok(move |_, _window, cx| {
+                    match crate::paths::switch_notebook(&nb.dir) {
+                        Ok(()) => crate::app::relaunch(cx),
+                        Err(e) => log::error!("switch notebook failed: {e}"),
+                    }
+                    true
+                })
+        });
+    }
+
+    /// "Add notebook…": pick a folder — empty starts fresh, one holding a
+    /// `zorite.db` opens as-is — register it, and offer the relaunch.
+    fn add_notebook(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let rx = cx.prompt_for_paths(gpui::PathPromptOptions {
+            files: false,
+            directories: true,
+            multiple: false,
+            prompt: Some("Use folder".into()),
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            let Ok(Ok(Some(paths))) = rx.await else {
+                return;
+            };
+            let Some(dir) = paths.into_iter().next() else {
+                return;
+            };
+            let _ = this.update_in(cx, |this, window, cx| {
+                match crate::paths::register_dir(&dir) {
+                    Ok(nb) => {
+                        this.notify_app_notebooks(cx);
+                        cx.notify();
+                        this.switch_notebook(nb, window, cx);
+                    }
+                    Err(e) => this.alert("Can’t use that folder", e, window, cx),
+                }
+            });
+        })
+        .detach();
+    }
+
+    /// The row's Rename button: a small input dialog, committed to the
+    /// registry (and the notebook's own name sidecar).
+    fn rename_notebook(
+        &mut self,
+        nb: crate::paths::Notebook,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.nb_rename_target = Some(nb.dir.clone());
+        self.nb_rename_input
+            .update(cx, |s, cx| s.set_value(nb.name, window, cx));
+        let input = self.nb_rename_input.clone();
+        let weak = cx.entity().downgrade();
+        window.open_dialog(cx, move |dialog, _window, _cx| {
+            let input_body = input.clone();
+            let input_btn = input.clone();
+            let input_key = input.clone();
+            let weak_btn = weak.clone();
+            let weak_key = weak.clone();
+            dialog
+                .title("Rename notebook")
+                .w(px(420.0))
+                .child(Input::new(&input_body))
+                .footer(
+                    DialogFooter::new()
+                        .child(
+                            Button::new("nb-rn-cancel")
+                                .label("Cancel")
+                                .on_click(|_, window, cx| window.close_dialog(cx)),
+                        )
+                        .child(Button::new("nb-rn-ok").primary().label("Rename").on_click(
+                            move |_, window, cx| {
+                                let name = input_btn.read(cx).value().to_string();
+                                let _ =
+                                    weak_btn.update(cx, |this, cx| this.commit_nb_rename(name, cx));
+                                window.close_dialog(cx);
+                            },
+                        )),
+                )
+                .on_ok(move |_, _window, cx| {
+                    let name = input_key.read(cx).value().to_string();
+                    let _ = weak_key.update(cx, |this, cx| this.commit_nb_rename(name, cx));
+                    true
+                })
+                .on_cancel(|_, _window, _cx| true)
+        });
+        self.nb_rename_input.update(cx, |s, cx| s.focus(window, cx));
+    }
+
+    fn commit_nb_rename(&mut self, name: String, cx: &mut Context<Self>) {
+        let Some(dir) = self.nb_rename_target.take() else {
+            return;
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            return;
+        }
+        if let Err(e) = crate::paths::rename_notebook(&dir, name) {
+            log::error!("rename notebook: {e}");
+        }
+        self.notify_app_notebooks(cx);
+        cx.notify();
+    }
+
+    /// Remove from the list — never touches the notebook's files.
+    fn forget_notebook(&mut self, nb: crate::paths::Notebook, cx: &mut Context<Self>) {
+        if nb.is_active() {
+            return;
+        }
+        if let Err(e) = crate::paths::forget_notebook(&nb.dir) {
+            log::error!("forget notebook: {e}");
+        }
+        self.notify_app_notebooks(cx);
+        cx.notify();
+    }
+
+    /// One notebook in the Notebooks card: name + path on the left, its
+    /// actions on the right (the active row swaps Switch/Remove for a
+    /// "current" tag).
+    fn notebook_settings_row(
+        &self,
+        nb: crate::paths::Notebook,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let active = nb.is_active();
+        let name = nb.name.clone();
+        let dir = nb.dir.clone();
+        let nb_switch = nb.clone();
+        let nb_rename = nb.clone();
+        let nb_forget = nb.clone();
+        let reveal_dir = PathBuf::from(&nb.dir);
+        let mut actions = div().flex().flex_row().items_center().gap(px(6.0));
+        if active {
+            actions = actions.child(
+                div()
+                    .px(px(8.0))
+                    .py(px(3.0))
+                    .rounded(px(6.0))
+                    .bg(theme::accent_tint())
+                    .text_size(px(11.0))
+                    .text_color(theme::accent())
+                    .child("current"),
+            );
+        } else {
+            actions = actions.child(nb_button(
+                SharedString::from(format!("nb-switch:{}", nb.dir)),
+                "Switch",
+                cx,
+                move |this, window, cx| this.switch_notebook(nb_switch.clone(), window, cx),
+            ));
+        }
+        actions = actions
+            .child(nb_button(
+                SharedString::from(format!("nb-rename:{}", nb.dir)),
+                "Rename",
+                cx,
+                move |this, window, cx| this.rename_notebook(nb_rename.clone(), window, cx),
+            ))
+            .child(nb_button(
+                SharedString::from(format!("nb-reveal:{}", nb.dir)),
+                "Reveal",
+                cx,
+                move |_this, _window, _cx| {
+                    crate::app::AppView::reveal_folder(&reveal_dir);
+                },
+            ));
+        if !active {
+            actions = actions.child(nb_button(
+                SharedString::from(format!("nb-forget:{}", nb.dir)),
+                "Remove",
+                cx,
+                move |this, _window, cx| this.forget_notebook(nb_forget.clone(), cx),
+            ));
+        }
+        div()
+            .px(px(10.0))
+            .py(px(8.0))
+            .rounded(px(8.0))
+            .bg(theme::glass())
+            .border_1()
+            .border_color(theme::border_subtle())
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(10.0))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .flex()
+                    .flex_col()
+                    .gap(px(2.0))
+                    .child(
+                        div()
+                            .text_size(px(13.0))
+                            .text_color(theme::text_primary())
+                            .child(name),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(11.0))
+                            .text_color(theme::text_tertiary())
+                            .truncate()
+                            .child(dir),
+                    ),
+            )
+            .child(actions)
     }
 
     /// Re-run the update check now (Settings → Updates → "Check now").
@@ -820,10 +1086,11 @@ impl SettingsView {
     }
 
     /// Confirm a relocation to `target`, then record it and quit so the change
-    /// (and any pending move) applies on the next launch.
+    /// (and any pending move) applies on the next launch. Move-only: a folder
+    /// that already holds a database is a notebook — opening it belongs to the
+    /// sidebar switcher, not a silent repoint from here.
     fn confirm_relocation(&mut self, target: PathBuf, window: &mut Window, cx: &mut Context<Self>) {
         use crate::paths::Relocation;
-        let current = crate::paths::data_dir();
         let (title, body, ok): (&'static str, String, &'static str) =
             match crate::paths::plan_relocation(&target) {
                 Relocation::NoOp => return,
@@ -831,21 +1098,25 @@ impl SettingsView {
                     self.alert("Can’t use that folder", reason, window, cx);
                     return;
                 }
-                Relocation::Switch => (
-                    "Switch data location",
-                    format!(
-                        "“{}” already contains a Zorite database.\n\nZorite will use it the next \
-                         time it starts. Your current data stays where it is:\n{}",
-                        target.display(),
-                        current.display(),
-                    ),
-                    "Switch & Quit",
-                ),
+                Relocation::Switch => {
+                    self.alert(
+                        "That folder is already a notebook",
+                        format!(
+                            "“{}” already contains a Zorite database.\n\nAdd it from the \
+                             notebook switcher at the bottom of the sidebar, then switch to \
+                             it there.",
+                            target.display(),
+                        ),
+                        window,
+                        cx,
+                    );
+                    return;
+                }
                 Relocation::Move => (
                     "Move data location",
                     format!(
-                        "Zorite will move your notes, settings, and attachments to:\n{}\n\nThe \
-                         change takes effect the next time you open Zorite.",
+                        "Zorite will move this notebook's notes, settings, and attachments \
+                         to:\n{}\n\nThe change takes effect the next time you open Zorite.",
                         target.display(),
                     ),
                     "Move & Quit",
@@ -1003,6 +1274,14 @@ impl SettingsView {
                 Tab::General,
                 active,
                 !self.tab_has_matches(Tab::General),
+                cx,
+            ))
+            .child(nav_item(
+                "nav-notebooks",
+                "Notebooks",
+                Tab::Notebooks,
+                active,
+                !self.tab_has_matches(Tab::Notebooks),
                 cx,
             ))
             .child(nav_item(
@@ -1426,7 +1705,22 @@ impl Render for SettingsView {
                 }))
         };
 
-        // Data-location card body (General): the current path, then change /
+        // Notebooks card body: every registered notebook with per-row actions
+        // (switch / rename / reveal / remove), then "Add notebook…".
+        let notebooks_control = {
+            let mut col = div().flex().flex_col().gap(px(8.0));
+            for nb in crate::paths::notebooks() {
+                col = col.child(self.notebook_settings_row(nb, cx));
+            }
+            col.child(div().flex().flex_row().mt(px(2.0)).child(text_button(
+                "nb-add",
+                "Add notebook…",
+                cx,
+                |this, w, cx| this.add_notebook(w, cx),
+            )))
+        };
+
+        // Data-location card body (Notebooks): the current path, then move /
         // reveal / reset actions.
         let data_path = crate::paths::data_dir().display().to_string();
         let at_default = crate::paths::is_default_location();
@@ -1451,12 +1745,9 @@ impl Render for SettingsView {
                     .flex()
                     .flex_row()
                     .gap(px(8.0))
-                    .child(text_button(
-                        "data-change",
-                        "Change…",
-                        cx,
-                        |this, w, cx| this.choose_data_location(w, cx),
-                    ))
+                    .child(text_button("data-move", "Move…", cx, |this, w, cx| {
+                        this.choose_data_location(w, cx)
+                    }))
                     .child(text_button(
                         "data-reveal",
                         "Reveal",
@@ -1594,14 +1885,25 @@ impl Render for SettingsView {
                             .flex_col()
                             .gap(px(16.0));
                         match self.tab {
-                            Tab::General => content
+                            Tab::Notebooks => content
+                                .child(self.section_card(
+                                    "Notebooks",
+                                    "Each notebook is a self-contained folder — its own \
+                                         database, settings, and attachments. Switching \
+                                         relaunches Zorite into the picked notebook; \
+                                         removing one only forgets it here, never touching \
+                                         its files. The chip at the bottom of the sidebar is \
+                                         the quick switcher.",
+                                    notebooks_control,
+                                ))
                                 .child(self.section_card(
                                     "Data location",
-                                    "Where Zorite keeps your database, settings, and \
-                                         attachments. Changing it moves your data to the new \
-                                         folder, then reopens Zorite.",
+                                    "Where the current notebook keeps its database, \
+                                         settings, and attachments. Moving relocates the \
+                                         data to the new folder, then reopens Zorite.",
                                     location_control,
-                                ))
+                                )),
+                            Tab::General => content
                                 .child(self.section_card(
                                     "Remember window position",
                                     "Reopen Zorite with the size and position it had when \
@@ -2007,6 +2309,33 @@ fn fmt_size(bytes: u64) -> String {
     } else {
         format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
     }
+}
+
+/// [`text_button`]'s small sibling for the notebook rows: a dynamic id (one
+/// per notebook) and tighter padding.
+fn nb_button(
+    id: SharedString,
+    label: &'static str,
+    cx: &mut Context<SettingsView>,
+    on: impl Fn(&mut SettingsView, &mut Window, &mut Context<SettingsView>) + 'static,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .px(px(8.0))
+        .py(px(4.0))
+        .rounded(px(6.0))
+        .border_1()
+        .border_color(theme::border_subtle())
+        .bg(theme::glass())
+        .text_color(theme::text_secondary())
+        .text_size(px(12.0))
+        .cursor_pointer()
+        .hover(|h| {
+            h.bg(theme::glass_strong())
+                .text_color(theme::text_primary())
+        })
+        .child(label)
+        .on_click(cx.listener(move |this, _, window, cx| on(this, window, cx)))
 }
 
 fn text_button(

--- a/src/ui/graph.rs
+++ b/src/ui/graph.rs
@@ -16,6 +16,7 @@ use gpui::{
     PinchEvent, Pixels, Point, ScrollDelta, ScrollWheelEvent, SharedString, Size,
     StatefulInteractiveElement, Styled, TextRun, canvas, div, fill, point, px, size,
 };
+use gpui_component::Sizable;
 use gpui_component::input::{Input, InputState};
 use gpui_component::switch::Switch;
 
@@ -813,6 +814,7 @@ fn panel(
     let toggle = |id: &'static str, on: bool, set: fn(&mut GraphFilters, bool)| {
         let ent = cx.entity();
         Switch::new(id)
+            .small()
             .checked(on)
             .on_click(move |on: &bool, _w, cx| {
                 let mut nf = f;
@@ -879,7 +881,7 @@ fn panel(
                         .child(format!("{} shown", state.nodes.len())),
                 ),
         )
-        .children(search.map(|input| Input::new(&input).text_size(px(12.0))))
+        .children(search.map(|input| Input::new(&input).small().text_size(px(12.0))))
         .children(match_count.map(|n| {
             div()
                 .text_size(px(11.0))

--- a/src/ui/page_view.rs
+++ b/src/ui/page_view.rs
@@ -6,6 +6,7 @@ use gpui::{
     MouseDownEvent, ParentElement, StatefulInteractiveElement, Styled, div,
     prelude::FluentBuilder as _, px, relative,
 };
+use gpui_component::Sizable;
 use gpui_component::input::Input;
 
 use crate::app::{AppView, PageEditor, PageFind};
@@ -360,7 +361,7 @@ fn find_bar(pf: &PageFind, cx: &mut Context<AppView>) -> impl IntoElement {
             div()
                 .flex_1()
                 .min_w_0()
-                .child(Input::new(&pf.input).text_size(px(13.0))),
+                .child(Input::new(&pf.input).small().text_size(px(13.0))),
         )
         .child(
             div()

--- a/src/ui/properties_page.rs
+++ b/src/ui/properties_page.rs
@@ -8,6 +8,7 @@ use gpui::{
     AppContext, ClickEvent, Entity, InteractiveElement, IntoElement, ParentElement,
     StatefulInteractiveElement, Styled, Window, div, px, svg,
 };
+use gpui_component::Sizable;
 use gpui_component::input::{Input, InputEvent, InputState};
 use gpui_component::tooltip::Tooltip;
 
@@ -172,7 +173,11 @@ pub fn render(app: &AppView, cx: &mut gpui::Context<AppView>) -> impl IntoElemen
                 .text_color(theme::text_tertiary())
                 .child("Map a key before first use:"),
         )
-        .child(div().w(px(160.0)).child(Input::new(&state.new_key_input)))
+        .child(
+            div()
+                .w(px(160.0))
+                .child(Input::new(&state.new_key_input).small()),
+        )
         .child(icon_button(
             "props-add-icon",
             String::new(),
@@ -253,7 +258,11 @@ fn key_row(
             .flex()
             .items_center()
             .gap(px(4.0))
-            .child(div().flex_1().child(Input::new(&state.rename_input)))
+            .child(
+                div()
+                    .flex_1()
+                    .child(Input::new(&state.rename_input).small()),
+            )
             .child(action_chip(
                 ("props-rename-ok", i),
                 "OK",

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -7,8 +7,8 @@
 
 use gpui::{
     AnyElement, ClickEvent, Context, Div, FontWeight, InteractiveElement, IntoElement, MouseButton,
-    ParentElement, SharedString, Stateful, StatefulInteractiveElement, Styled, Window, div,
-    prelude::FluentBuilder as _, px, relative,
+    MouseDownEvent, ParentElement, SharedString, Stateful, StatefulInteractiveElement, Styled,
+    Window, deferred, div, prelude::FluentBuilder as _, px, relative,
 };
 use gpui_component::{
     Icon, IconName, Sizable, input::Input, menu::ContextMenuExt, tooltip::Tooltip,
@@ -195,6 +195,214 @@ fn expanded(app: &AppView, window: &mut Window, cx: &mut Context<AppView>) -> im
                         }),
                 ),
         )
+        .child(notebook_footer(app, cx))
+}
+
+/// The notebook switcher at the sidebar's bottom (user-picked spot): a quiet
+/// chip naming the active notebook; clicking opens a popover with the
+/// registered notebooks (switch = relaunch) and "Add notebook…". Shown even
+/// with a single notebook — it's the entry point for creating a second one.
+fn notebook_footer(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
+    let notebooks = crate::paths::notebooks();
+    let active = notebooks.iter().find(|n| n.is_active());
+    let name: SharedString = active.map_or("Main".to_string(), |n| n.name.clone()).into();
+    let dir: SharedString = active.map(|n| n.dir.clone()).unwrap_or_default().into();
+    let popover = app
+        .notebook_popover
+        .then(|| notebook_popover(&notebooks, cx));
+    div()
+        .flex_shrink_0()
+        .relative()
+        .p_2()
+        .border_t_1()
+        .border_color(theme::border_subtle())
+        .child(
+            div()
+                .id("notebook-chip")
+                .flex()
+                .items_center()
+                .gap_2()
+                .px_2()
+                .py_1p5()
+                .rounded(px(6.0))
+                .text_size(px(13.0))
+                .text_color(theme::text_secondary())
+                .cursor_pointer()
+                .hover(|h| h.bg(theme::hover()).text_color(theme::text_primary()))
+                .child(
+                    Icon::empty()
+                        .path("icons/book.svg")
+                        .size_4()
+                        .flex_shrink_0(),
+                )
+                .child(div().flex_1().truncate().child(name))
+                .child(
+                    Icon::new(IconName::ChevronUp)
+                        .with_size(px(12.0))
+                        .text_color(theme::text_tertiary())
+                        .flex_shrink_0(),
+                )
+                .tooltip(move |window, cx| Tooltip::new(dir.clone()).build(window, cx))
+                .on_click(
+                    cx.listener(|this: &mut AppView, _: &ClickEvent, _window, cx| {
+                        this.toggle_notebook_popover(cx);
+                    }),
+                ),
+        )
+        .children(popover)
+}
+
+/// The switcher popover, anchored above the chip: one row per registered
+/// notebook (✓ on the active one; right-click for rename / remove / reveal)
+/// and an "Add notebook…" row that picks a folder — empty = create fresh,
+/// holding a `zorite.db` = add existing.
+fn notebook_popover(notebooks: &[crate::paths::Notebook], cx: &mut Context<AppView>) -> AnyElement {
+    let rows: Vec<AnyElement> = notebooks
+        .iter()
+        .map(|nb| notebook_row(nb.clone(), cx))
+        .collect();
+    deferred(
+        div()
+            .absolute()
+            .bottom_full()
+            .left_0()
+            .mb(px(4.0))
+            .w(px(224.0))
+            .occlude()
+            .bg(theme::elevated())
+            .border_1()
+            .border_color(theme::divider())
+            .rounded(px(8.0))
+            .shadow_md()
+            .py_1()
+            .text_size(px(13.0))
+            .text_color(theme::text_primary())
+            .on_mouse_down_out(cx.listener(|this: &mut AppView, _, _window, cx| {
+                this.notebook_popover = false;
+                cx.notify();
+            }))
+            .children(rows)
+            .child(div().my_1().h(px(1.0)).bg(theme::divider()))
+            .child(
+                div()
+                    .id("nb-add")
+                    .mx_1()
+                    .px_2()
+                    .py_1p5()
+                    .rounded(px(6.0))
+                    .cursor_pointer()
+                    .text_color(theme::text_secondary())
+                    .hover(|h| h.bg(theme::hover()).text_color(theme::text_primary()))
+                    .child("Add notebook…")
+                    .on_click(
+                        cx.listener(|this: &mut AppView, _: &ClickEvent, window, cx| {
+                            this.add_notebook_via_picker(window, cx);
+                        }),
+                    ),
+            ),
+    )
+    .into_any_element()
+}
+
+/// One notebook row in the popover: the name (✓ tints the active row), then
+/// small inline buttons — rename (✎), reveal, and remove-from-list (✕, never
+/// on the active row; removing never deletes files). Inline buttons rather
+/// than a right-click menu: a nested context menu anchored inside this
+/// hand-rolled popover dies to its click-away dismissal.
+fn notebook_row(nb: crate::paths::Notebook, cx: &mut Context<AppView>) -> AnyElement {
+    let active = nb.is_active();
+    let name: SharedString = nb.name.clone().into();
+    let dir: SharedString = nb.dir.clone().into();
+    let nb_click = nb.clone();
+    let nb_rename = nb.clone();
+    let nb_reveal = nb.clone();
+    let nb_forget = nb.clone();
+    div()
+        .id(SharedString::from(format!("nb:{}", nb.dir)))
+        .flex()
+        .items_center()
+        .gap_1()
+        .mx_1()
+        .px_2()
+        .py_1p5()
+        .rounded(px(6.0))
+        .cursor_pointer()
+        .when(active, |d| d.bg(theme::accent_tint()))
+        .when(!active, |d| d.hover(|h| h.bg(theme::hover())))
+        .child(
+            // The folder-path tooltip sits on the NAME, not the whole row, so
+            // it can't flash while the pointer crosses the row's buttons
+            // (which carry their own tips).
+            div()
+                .id(SharedString::from(format!("nb-name:{}", nb.dir)))
+                .flex_1()
+                .truncate()
+                .when(active, |d| d.text_color(theme::accent()))
+                .child(name)
+                .tooltip(move |window, cx| Tooltip::new(dir.clone()).build(window, cx)),
+        )
+        .child(row_btn(
+            ("nb-rename", nb.dir.clone()),
+            Icon::empty()
+                .path("icons/pencil.svg")
+                .with_size(px(13.0))
+                .into_any_element(),
+            "Rename",
+            cx.listener(move |this: &mut AppView, _: &MouseDownEvent, window, cx| {
+                cx.stop_propagation();
+                this.rename_notebook_dialog(nb_rename.clone(), window, cx);
+            }),
+        ))
+        .child(row_btn(
+            ("nb-reveal", nb.dir.clone()),
+            Icon::empty()
+                .path("icons/folder.svg")
+                .with_size(px(13.0))
+                .into_any_element(),
+            "Reveal folder",
+            cx.listener(move |this: &mut AppView, _: &MouseDownEvent, _window, cx| {
+                cx.stop_propagation();
+                this.reveal_notebook(nb_reveal.clone(), cx);
+            }),
+        ))
+        .when(!active, |d| {
+            d.child(row_btn(
+                ("nb-forget", nb.dir.clone()),
+                div().text_size(px(12.0)).child("✕").into_any_element(),
+                "Remove from list (keeps the files)",
+                cx.listener(move |this: &mut AppView, _: &MouseDownEvent, _window, cx| {
+                    cx.stop_propagation();
+                    this.forget_notebook(nb_forget.clone(), cx);
+                }),
+            ))
+        })
+        .on_click(
+            cx.listener(move |this: &mut AppView, _: &ClickEvent, window, cx| {
+                this.switch_notebook(nb_click.clone(), window, cx);
+            }),
+        )
+        .into_any_element()
+}
+
+/// A small muted icon button inside a notebook row. Its handler runs on mouse
+/// down (stopping propagation) so the row's click-to-switch never also fires.
+fn row_btn(
+    id: (&'static str, String),
+    face: AnyElement,
+    tip: &'static str,
+    handler: impl Fn(&MouseDownEvent, &mut Window, &mut gpui::App) + 'static,
+) -> AnyElement {
+    div()
+        .id(SharedString::from(format!("{}:{}", id.0, id.1)))
+        .flex_shrink_0()
+        .p(px(3.0))
+        .rounded(px(4.0))
+        .text_color(theme::text_tertiary())
+        .hover(|h| h.bg(theme::hover()).text_color(theme::text_primary()))
+        .child(face)
+        .tooltip(move |window, cx| Tooltip::new(tip).build(window, cx))
+        .on_mouse_down(MouseButton::Left, handler)
+        .into_any_element()
 }
 
 /// The collapsed sidebar: a thin icon rail with the expand caret (`>`) at the

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -203,13 +203,15 @@ fn expanded(app: &AppView, window: &mut Window, cx: &mut Context<AppView>) -> im
 /// registered notebooks (switch = relaunch) and "Add notebook…". Shown even
 /// with a single notebook — it's the entry point for creating a second one.
 fn notebook_footer(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
-    let notebooks = crate::paths::notebooks();
+    // The app's cached registry (no pointer-file read per render); refreshed
+    // on popover open and after mutations.
+    let notebooks = &app.notebooks;
     let active = notebooks.iter().find(|n| n.is_active());
     let name: SharedString = active.map_or("Main".to_string(), |n| n.name.clone()).into();
     let dir: SharedString = active.map(|n| n.dir.clone()).unwrap_or_default().into();
     let popover = app
         .notebook_popover
-        .then(|| notebook_popover(&notebooks, cx));
+        .then(|| notebook_popover(notebooks, cx));
     div()
         .flex_shrink_0()
         .relative()

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -121,7 +121,7 @@ fn expanded(app: &AppView, window: &mut Window, cx: &mut Context<AppView>) -> im
                         ),
                 )
                 .child(
-                    Input::new(&app.search_input).prefix(
+                    Input::new(&app.search_input).small().prefix(
                         Icon::new(IconName::Search)
                             .size_4()
                             .text_color(theme::text_tertiary()),


### PR DESCRIPTION
Obsidian-style multiple data sets — **Notebooks** — each a self-contained folder (database + images/PDFs/themes/fonts), switched from a chip at the bottom of the sidebar or a new Settings → Notebooks tab.

## What's in it

- **Registry** in `data_location.json`: the existing `dir` stays the active pointer; a `notebooks: [{name, dir}]` list rides along. Serde-compatible both ways (tested) — old builds ignore it, and a registry-less file keeps the old byte shape. The active dir synthesizes as "Main" until the first registry write.
- **Sidebar chip switcher**: active notebook name + popover — the list (✓ on active, click to switch), per-row rename/reveal/remove buttons, and "Add notebook…" (the picked folder decides: empty = create fresh, holds a `zorite.db` = open existing).
- **Settings → Notebooks tab**: the same management as rows with buttons, plus the Data-location card moved in from General (Move-only now; a target already holding a database directs to the switcher instead of silently repointing).
- **Switch = confirm → pointer write → relaunch.** Not `cx.restart()`: gpui's macOS restart goes through `open`/LaunchServices, which pops a Terminal for a bare binary and drops the environment — the app respawns `current_exe` directly and quits.
- **Names travel**: a rename writes a `notebook-name` sidecar inside the notebook folder (read back on re-add, carried by data moves). Folder renaming is deliberately not offered (open-DB file locks).
- **Window title** shows "Zorite — <notebook>" once more than one is registered — the app's drawn TitleBar label (live-updating) plus the native title for Mission Control/taskbar.
- Removing a notebook only forgets the registry entry, never files. `ZORITE_DATA` keeps top precedence. An encrypted notebook lands on its unlock screen like any launch.

## Cross-platform notes for CI

The new surface is the respawn relaunch (`std::process::Command::new(current_exe)`) and pointer-file handling — worth a look on the Windows/Linux legs; macOS is live-tested end to end (registry round-trips, switch/create/rename/remove/reveal, sandboxed-HOME relaunch).

Phase 2 (restartless / side-by-side notebooks) stays in TODO.md, gated on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)