### PR TITLE
fix: the v0.7.0 UX-papercuts batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ log: <https://github.com/packetThrower/zorite/releases>.
 
 ### Added
 
+- **Right-click, everywhere** — one page menu on every surface a page shows
+  up: sidebar rows, the All Pages browser, search results, linked references,
+  and page tabs all offer open-in-new-tab/window, favorites, rename, delete,
+  export — plus **Copy link** (`[[Title]]`) and **Copy contents**. Selected
+  text gets a Cut/Copy/Paste menu (spelling suggestions stack on top on a
+  flagged word), and a property panel row offers Edit / Delete property.
 - **Notebooks** — keep more than one set of notes, each a self-contained
   folder (database, images, PDFs, themes), and switch between them from a
   chip at the bottom of the sidebar. Add a notebook by picking a folder — an
@@ -49,6 +55,28 @@ log: <https://github.com/packetThrower/zorite/releases>.
   case), and checkboxes/radios show their checked state (their
   state-dictionary appearances previously didn't draw at all). Signature and
   read-only fields stay inert; choice fields edit as free text for now.
+
+### Fixed
+
+- **Editing papercuts** — a sweep from a UX audit: Home on a list/task/quote
+  line lands on the text (a second press reaches the true start) instead of
+  revealing the hidden marker; Enter, Backspace, and Delete around a property
+  panel open its editor instead of splicing raw `key:: value` source;
+  finishing a property or formula at the very end of a note drops the caret
+  on a fresh line below; double- and triple-clicking a formula no longer
+  selects its hidden source; deleting a formula removes it whole, like an
+  image (its alignment marker too); ⌥-arrow word jumps treat formulas and
+  panels as objects; and selecting across a rendered block (math, diagram,
+  properties, code) reveals its source so what you see highlighted is exactly
+  what copies.
+- **Failures speak up** — renaming a page to a name that's taken now says so
+  (right in the rename dialog, which stays open), and errors from deleting
+  pages, exporting formulas, filling PDF form fields, and adding images to a
+  whiteboard all show a dialog instead of failing silently. A PDF that can't
+  be opened shows why instead of loading forever, and a page deleted in one
+  window closes its tabs in every window.
+- **Windows spell-check follows your system language** (it was fixed to
+  English), and the math editor renders sharp on non-Retina displays.
 
 ## [0.6.1] - 2026-07-07
 

--- a/TODO.md
+++ b/TODO.md
@@ -17,77 +17,40 @@ work is collected under [Completed](#completed) at the bottom.
 
 ## UX papercuts (v0.6.2 candidate)
 
-Found by the 2026-07-08 four-way UX audit (editor interaction paths,
-cross-view parity, app flows, known-gap mining), plus the overlapping items
-moved in from other sections. The spine for a possible **v0.6.2**.
+Found by the 2026-07-08 four-way UX audit; **ALL DONE 2026-07-09** (shipping
+in v0.7.0) except the two deferrals at the bottom. Kept briefly for the
+release notes; prune after 0.7.0 ships.
 
-**Editor interaction (gpui-editor):**
-- [ ] **Home lands before hidden markers** — on a list/task/quote line, Home
-  seats the caret at the raw line start (before the invisible `- [ ]` prefix),
-  so the caret looks wrong and typing lands inside the marker (`home()`)
-- [ ] **Enter inside a property panel breaks it** — `newline()` guards tables
-  (`caret_in_table`) but not property blocks, so Enter splices a raw newline
-  into `key:: value` source; should commit/step like the table path
-- [ ] **Double/triple-click on formulas bypass click-to-edit** — the construct
-  checks (math/property/image) run only at `click_count == 1`; double-click
-  word-selects inside `$x^2$` instead of opening the math editor, triple-click
-  selects the raw `$$` fences
-- [ ] **Backspace/Delete at a math boundary strips a `$`** and dumps raw
-  LaTeX — images delete atomically (Word-style); math wants the same guard
-- [ ] **Selections can include hidden markers** — shift-click, shift-arrows,
-  and drag extend into hidden `$$`/fence regions, so copied text contains
-  markers that were invisible on screen
-- [ ] Word-jump (⌥←/→) stops inside hidden constructs (`$x` splits as two
-  words) instead of hopping the whole formula
-
-**Cross-view parity:**
-- [ ] **`![](file.pdf)` file chips render only in WYSIWYG** — the reader has
-  no file-chip path at all (cross-view-rule violation); the same markdown
-  should read as the same chip in both views
-- [ ] VERIFY: **image resize inside an embed** may write the embedding page
-  instead of the target — editor embeds reuse the main image provider where
-  the reader has a separate read-only embed-image path
-- [ ] Reader opens bare URLs via `cx.open_url` directly, bypassing the host
-  hook the editor's `OpenLink` event goes through
-
-**App flows:**
-- [ ] **Unified right-click menu for page rows everywhere** — All Pages rows,
-  search results, backlink rows, and graph nodes are left-click-only today;
-  extract the sidebar's page menu (open in new tab/window, favorite, rename,
-  delete, export PDF, new sub-page) into one shared builder used by every
-  page-like surface (tabs included), and grow it with **copy/paste actions**:
-  Copy link (`[[Title]]`) and Copy contents (markdown) at minimum
-- [ ] **Error-dialog sweep** — user-facing operations that log failures
-  silently: page rename (dialog AND inline title — a duplicate name is a
-  silent no-op), alias save, notebook rename/forget, math PNG/SVG export
-  (`let _ = fs::write`), image import, PDF form-field writes. Surface each
-  through the existing `show_error_dialog` helper
-- [ ] **Deleting a page in one window leaves it open and editable in
-  others** — the cross-window sync (`apply_external_edit`) detects content
-  changes but not deletion; the ghost tab should close (or mark deleted)
-- [ ] Embeds: the box **height estimate undershoots** for image/math/mermaid-heavy
-  content (it's a line-count heuristic — `ensure_content_embeds`), so those boxes
-  scroll more than they should; measure or estimate rendered heights instead
-- [ ] Sidebar: remember the collapsed state across launches, and add a keyboard
-  shortcut to toggle it
-
-**PDF:**
-- [ ] **A failed load is silent and permanent** (2026-07-06 API audit) — an
-  unreadable/malformed PDF only `log::error!`s and `PdfView` sits on the
-  "Loading PDF…" placeholder forever, no error state, event, or retry; a
-  retry-unlock failing with `LoadError::Other` is likewise eventless, so the
-  password prompt gets no signal. Wants an explicit error state + `PdfEvent`
-  (overlaps the graceful-fallback item under Import & export)
-- [ ] `is_pdf` misses query-string refs (`report.pdf?v=2`) — it only checks
-  `ends_with(".pdf")` after trimming trailing whitespace (API audit)
-
-**Platform (from the crate audit):**
-- [ ] `os-spellcheck`: the Windows backend creates its checker for a
-  **hardcoded `en-US`** — follow the system UI language
-  (`GetUserDefaultLocaleName`), falling back gracefully when unsupported
-- [ ] `ratex-gpui`: `MathEditor` rasterizes at a **hard-coded `dpr: 2.0`**
-  (`view.rs` `with_root`) instead of the window's scale factor — slightly soft
-  on 1× displays, wasteful on 3×
+- [x] Editor interaction: smart Home; Enter/backspace-join/forward-delete
+  around property panels seat the form; block-editor exits at document end
+  create a line below; double/triple-click swallowed on $$/property blocks;
+  atomic formula deletion (incl. the `<!-- math:ALIGN -->` marker); ⌥←/→
+  word-jumps route into constructs; selections reveal the blocks they sweep
+- [x] App flows: error-dialog sweep (rename collisions report INLINE in the
+  rename dialog — a stacked dialog pops the first off the dialog stack; the
+  builder runs inside AppView's render, so dialog-read state goes through
+  `Rc<RefCell<…>>`); unified right-click (shared page menu on sidebar /
+  All Pages / search / backlinks / page tabs + Copy link / Copy contents;
+  editor text menu; property Edit/Delete; compact custom menus); ghost tabs
+  close after a cross-window delete
+- [x] PDF: terminal load failures render an error pane + emit
+  `PdfEvent::LoadFailed` (retry-unlock failing non-password stands the
+  prompt down); `is_pdf` sees through URL queries
+- [x] Platform: Windows spell-check follows the system UI language;
+  the math editor rasterizes at the window's real scale factor
+- [x] CLOSED AS FALSE POSITIVES (verified 2026-07-09): "reader lacks file
+  chips" — the host's `ImageRenderer` (src/ui/image.rs) classifies
+  `is_pdf` and renders chips in both the page and embed renderers, the
+  audit only searched gpui-markdown; "embed image-resize writes the wrong
+  page" — embeds use the deliberately grip-free `embed_renderer`
+- [ ] DEFERRED: **graph-node context menu** — nodes hit-test inside one
+  canvas element (`g.hit(position)`), so the shared page-menu builder
+  doesn't attach; needs the app's overlay-menu machinery (the reader
+  ctx-menu recipe)
+- [ ] DEFERRED: **PopupMenu density** — the pinned gpui-component rev has a
+  `Size::Small` branch for menus (20px rows vs 26px) but NO public setter;
+  upstream a `Sizable` impl for `PopupMenu` (or bump the pin when one
+  exists), then `.small()` the page menus to match the custom ones
 
 ## Notes & navigation
 - [ ] Aliases: offer a page's aliases as suggestions in `[[` autocomplete

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -2051,6 +2051,44 @@ impl EditorState {
         start..(range.end + 1).min(self.content.len())
     }
 
+    /// Route a landing offset into an atomic construct the way the plain
+    /// arrows do: an inline `$…$` span strictly containing it, or a `$$`
+    /// block / property-panel row, opens its in-place editor instead of
+    /// seating a raw caret (which would reveal hidden source). Returns true
+    /// when handled — word-jumps (⌥←/→) stop there.
+    fn enter_construct_at(&mut self, off: usize, at_end: bool, cx: &mut Context<Self>) -> bool {
+        if let Some((range, source)) = self.inline_math_span_at(off) {
+            cx.emit(EditorEvent::EditMath {
+                range,
+                source,
+                at_end,
+                inline: true,
+            });
+            return true;
+        }
+        let (row, _) = self.row_col(off);
+        if let Some((range, source)) = self.math_block_at(row) {
+            cx.emit(EditorEvent::EditMath {
+                range,
+                source,
+                at_end,
+                inline: false,
+            });
+            return true;
+        }
+        if let Some((range, source)) = self.property_block_at(row) {
+            let block_row = row - self.row_col(range.start).0;
+            cx.emit(EditorEvent::EditProperties {
+                range,
+                source,
+                at_end,
+                row: Some(block_row),
+            });
+            return true;
+        }
+        false
+    }
+
     /// If the caret sits inside a property block, ask the host to seat the
     /// in-place form there (focused on the caret's row; `at_end` = caret at
     /// the value's end) — the recovery for any edit that lands a raw caret in
@@ -2989,11 +3027,19 @@ impl EditorState {
     }
 
     fn word_left(&mut self, _: &WordLeft, _: &mut Window, cx: &mut Context<Self>) {
-        self.move_to(self.prev_word(self.cursor_offset()), cx);
+        let off = self.prev_word(self.cursor_offset());
+        if self.enter_construct_at(off, true, cx) {
+            return;
+        }
+        self.move_to(off, cx);
     }
 
     fn word_right(&mut self, _: &WordRight, _: &mut Window, cx: &mut Context<Self>) {
-        self.move_to(self.next_word(self.cursor_offset()), cx);
+        let off = self.next_word(self.cursor_offset());
+        if self.enter_construct_at(off, false, cx) {
+            return;
+        }
+        self.move_to(off, cx);
     }
 
     fn select_word_left(&mut self, _: &SelectWordLeft, _: &mut Window, cx: &mut Context<Self>) {
@@ -5052,13 +5098,33 @@ fn shape_document(
     let code_regions = md
         .map(|_| markdown_syntax::code_regions(content))
         .unwrap_or_default();
+    // Rows a (non-empty) selection touches. A selected block reveals its raw
+    // source just like the caret's block does, so what's highlighted is what a
+    // copy carries — the per-line pass below already reveals inline markers on
+    // selected lines; rendered BLOCKS (math, mermaid, panels, fences) need the
+    // same region-wide, or a sweep silently selects invisible `$$`/fence text.
+    let sel_rows: Option<Range<usize>> = (selection.0 != selection.1).then(|| {
+        let (a, b) = (
+            selection.0.min(selection.1).min(content.len()),
+            selection.0.max(selection.1).min(content.len()),
+        );
+        let row_of = |off: usize| content[..off].matches('\n').count();
+        row_of(a)..row_of(b) + 1
+    });
+    let sel_hits = |r: &Range<usize>| {
+        sel_rows
+            .as_ref()
+            .is_some_and(|s| s.start < r.end && r.start < s.end)
+    };
     // ```mermaid blocks ready to render as a diagram: the caret is outside the
     // block and the host has a rendered bitmap. The diagram paints on the block's
     // first line; the rest collapse. Caret inside / still rendering → raw code.
     let mermaid: Vec<(Range<usize>, BlockImg)> = match block_mermaid.filter(|_| md.is_some()) {
         Some(f) => markdown_syntax::mermaid_blocks(content)
             .into_iter()
-            .filter(|(range, _)| caret_row.is_none_or(|cr| !range.contains(&cr)))
+            .filter(|(range, _)| {
+                caret_row.is_none_or(|cr| !range.contains(&cr)) && !sel_hits(range)
+            })
             .filter_map(|(range, source)| {
                 // Sized by the provider's logical dimensions, like math below —
                 // never texture pixels ÷ window scale factor.
@@ -5088,7 +5154,7 @@ fn shape_document(
     let math: Vec<(Range<usize>, BlockImg)> = match block_math.filter(|_| md.is_some()) {
         Some(f) => markdown_syntax::math_regions(content)
             .into_iter()
-            .filter(|r| caret_row.is_none_or(|cr| !r.range.contains(&cr)))
+            .filter(|r| caret_row.is_none_or(|cr| !r.range.contains(&cr)) && !sel_hits(&r.range))
             .filter_map(|r| {
                 // Sized by the provider's logical dimensions — NOT texture pixels
                 // ÷ window scale factor (see [`BlockMathFn`]: the raster's density
@@ -5122,7 +5188,7 @@ fn shape_document(
     let props: Vec<(Range<usize>, PropPanel)> = match md {
         Some(st) => markdown_syntax::property_regions(content)
             .into_iter()
-            .filter(|r| caret_row.is_none_or(|cr| !r.contains(&cr)))
+            .filter(|r| caret_row.is_none_or(|cr| !r.contains(&cr)) && !sel_hits(r))
             .map(|r| {
                 let panel = build_prop_panel(
                     &lines,
@@ -5472,9 +5538,9 @@ fn shape_document(
         // its block — so a code block reads as just its boxed body (W6), with the
         // fences re-appearing while you edit inside it.
         let collapse_fence = is_fence
-            && !code_regions
-                .iter()
-                .any(|r| r.contains(&idx) && caret_row.is_some_and(|cr| r.contains(&cr)));
+            && !code_regions.iter().any(|r| {
+                r.contains(&idx) && (caret_row.is_some_and(|cr| r.contains(&cr)) || sel_hits(r))
+            });
         // A `<!-- table:STYLE -->` or `<!-- math:ALIGN -->` marker line collapses (hidden)
         // too, unless the caret lands on it — so the marker stays out of the way but editable.
         let collapse_marker = caret_row != Some(idx)

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -555,6 +555,9 @@ pub struct EditorState {
     /// The open image right-click menu, if any: the image's logical line + the
     /// menu's anchor (window space). Offers Word-style object actions (Delete).
     image_menu: Option<(usize, Point<Pixels>)>,
+    /// Right-clicked property-panel row: its source line + click position
+    /// (anchors the Edit/Delete property menu).
+    prop_menu: Option<(usize, Point<Pixels>)>,
     /// Supplies replacement suggestions for a flagged word, fetched lazily when
     /// the user right-clicks it. Set by the host via [`Self::on_suggest`];
     /// without it, the right-click menu has nothing to offer.
@@ -617,7 +620,9 @@ pub struct EditorState {
     /// Painted bounds of each property-panel row (from the last paint), so
     /// `on_mouse_move` repaints when the hovered row changes (the panel's hover
     /// border reads the live pointer during paint).
-    prop_row_rects: Vec<Bounds<Pixels>>,
+    /// Each painted property-panel row's bounds + its source line (for
+    /// hover borders and the right-click property menu).
+    prop_row_rects: Vec<(Bounds<Pixels>, usize)>,
     /// The property row the pointer was last over — drives `on_mouse_move`'s
     /// repaint-on-change (like the table hover).
     prop_hover_row: Option<usize>,
@@ -694,6 +699,7 @@ impl EditorState {
             table_menu: None,
             table_menu_scroll: ScrollHandle::new(),
             image_menu: None,
+            prop_menu: None,
             suggest: None,
             block_image: None,
             block_chip: None,
@@ -2140,6 +2146,7 @@ impl EditorState {
             self.menu = None;
             self.table_menu = None;
             self.image_menu = None;
+            self.prop_menu = None;
             cx.notify();
             return;
         }
@@ -2359,6 +2366,7 @@ impl EditorState {
         self.menu = None;
         self.table_menu = None;
         self.image_menu = None;
+        self.prop_menu = None;
         self.goal_x = None;
         self.last_edit = EditKind::Other;
         match event.click_count {
@@ -2491,7 +2499,7 @@ impl EditorState {
         let prow = self
             .prop_row_rects
             .iter()
-            .position(|b| b.contains(&event.position));
+            .position(|(b, _)| b.contains(&event.position));
         if prow != self.prop_hover_row {
             self.prop_hover_row = prow;
             cx.notify();
@@ -2563,6 +2571,18 @@ impl EditorState {
         Some(start..(end + 1).min(self.content.len()))
     }
 
+    /// Delete the `key:: value` line at `row` (+ its newline) — the panel's
+    /// right-click "Delete property". One undoable edit; deleting the last
+    /// property removes the panel.
+    fn delete_property_row(&mut self, row: usize, cx: &mut Context<Self>) {
+        let Some(&start) = self.line_starts().get(row) else {
+            return;
+        };
+        let end = (self.line_end(row) + 1).min(self.content.len());
+        self.replace_range(start..end, "", cx);
+        cx.emit(EditorEvent::Changed);
+    }
+
     /// Delete the image occupying logical line `row` — line + trailing newline,
     /// one undoable edit. Backs the right-click "Delete image" and the
     /// Word-style Backspace/Delete on an image row.
@@ -2596,6 +2616,21 @@ impl EditorState {
             self.table_menu = None;
             self.focus(window, cx);
             self.image_menu = Some((line, event.position));
+            cx.notify();
+            return;
+        }
+        // Right-click a property-panel row: Edit / Delete property menu — the
+        // panel renders as a widget, there's no text under the pointer.
+        if let Some(&(_, row)) = self
+            .prop_row_rects
+            .iter()
+            .find(|(rect, _)| rect.contains(&event.position))
+        {
+            self.menu = None;
+            self.table_menu = None;
+            self.image_menu = None;
+            self.focus(window, cx);
+            self.prop_menu = Some((row, event.position));
             cx.notify();
             return;
         }
@@ -2636,16 +2671,30 @@ impl EditorState {
         let offset = self.index_for_mouse_position(event.position);
         // Window-space — the popup renders on a `deferred`/`anchored` layer.
         let anchor = event.position;
-        let hit = self.diagnostic_at(offset).map(|d| d.range.clone());
-        self.menu = hit.and_then(|range| {
-            let word = self.content[range.clone()].to_string();
-            let suggestions = self.suggest.as_ref().map(|f| f(&word)).unwrap_or_default();
-            (!suggestions.is_empty()).then(|| DiagMenu {
-                anchor,
-                range,
-                suggestions: suggestions.into_iter().map(SharedString::from).collect(),
-                scroll: ScrollHandle::new(),
-            })
+        // A right-click outside the selection moves the caret there (so Paste
+        // lands under the pointer); inside it, the selection stays put — it's
+        // what Cut/Copy act on.
+        let sel = self.selected_range.clone();
+        let in_selection = !sel.is_empty() && offset >= sel.start && offset <= sel.end;
+        if !in_selection {
+            self.move_to(offset, cx);
+        }
+        self.focus(window, cx);
+        // Suggestions when the click lands on a flagged word; the clipboard
+        // verbs (Cut / Copy / Paste) ride along either way.
+        let (range, suggestions) = match self.diagnostic_at(offset).map(|d| d.range.clone()) {
+            Some(range) => {
+                let word = self.content[range.clone()].to_string();
+                let suggestions = self.suggest.as_ref().map(|f| f(&word)).unwrap_or_default();
+                (range, suggestions)
+            }
+            None => (offset..offset, Vec::new()),
+        };
+        self.menu = Some(DiagMenu {
+            anchor,
+            range,
+            suggestions: suggestions.into_iter().map(SharedString::from).collect(),
+            scroll: ScrollHandle::new(),
         });
         cx.notify();
     }
@@ -2662,6 +2711,7 @@ impl EditorState {
         if self.menu.take().is_some()
             || self.table_menu.take().is_some()
             || self.image_menu.take().is_some()
+            || self.prop_menu.take().is_some()
         {
             cx.notify();
         }
@@ -4029,8 +4079,8 @@ impl Render for EditorState {
                             // Don't let the scroll container's max-height squeeze
                             // the rows; they keep their height and overflow.
                             .flex_shrink_0()
-                            .px(px(12.))
-                            .py(px(5.))
+                            .px(px(10.))
+                            .py(px(3.))
                             // Highlight the row under the pointer.
                             .hover(move |s| s.bg(hover))
                             .child(sugg)
@@ -4054,7 +4104,7 @@ impl Render for EditorState {
                 // so the scroll affordance is visible. Sized from the row count
                 // (known now) and positioned from the live scroll offset — a
                 // wheel scroll calls window.refresh(), which re-renders this.
-                const ROW_H: f32 = 28.0;
+                const ROW_H: f32 = 24.0;
                 const PAD: f32 = 4.0;
                 const MAX_H: f32 = 180.0;
                 let rows_h = count as f32 * ROW_H;
@@ -4072,6 +4122,47 @@ impl Render for EditorState {
                         .rounded(px(3.))
                         .bg(thumb_c)
                 });
+
+                // Cut / Copy need a selection; Paste always applies (the caret
+                // was seated at the click when it landed outside the selection).
+                let has_sel = !self.selected_range.is_empty();
+                let clip_item = |id: &'static str, label: &'static str| {
+                    div()
+                        .id(id)
+                        .flex_shrink_0()
+                        .px(px(10.))
+                        .py(px(3.))
+                        .hover(move |s| s.bg(hover))
+                        .child(label)
+                };
+                let mut clipboard = div().flex().flex_col().py(px(4.));
+                if has_sel {
+                    clipboard = clipboard
+                        .child(clip_item("menu-cut", "Cut").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|editor, _: &MouseDownEvent, window, cx| {
+                                cx.stop_propagation();
+                                editor.menu = None;
+                                editor.cut(&Cut, window, cx);
+                            }),
+                        ))
+                        .child(clip_item("menu-copy", "Copy").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|editor, _: &MouseDownEvent, window, cx| {
+                                cx.stop_propagation();
+                                editor.menu = None;
+                                editor.copy(&Copy, window, cx);
+                            }),
+                        ));
+                }
+                let clipboard = clipboard.child(clip_item("menu-paste", "Paste").on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|editor, _: &MouseDownEvent, window, cx| {
+                        cx.stop_propagation();
+                        editor.menu = None;
+                        editor.paste(&Paste, window, cx);
+                    }),
+                ));
 
                 // Deferred + anchored to a window-space top layer with `.occlude()`,
                 // so it renders above the page chrome and captures the wheel — else a
@@ -4092,13 +4183,13 @@ impl Render for EditorState {
                             // Clip rows + thumb to the rounded box.
                             .overflow_hidden()
                             .text_color(menu_fg)
-                            .text_size(px(14.))
+                            .text_size(px(13.))
                             // A click anywhere outside the menu dismisses it.
                             .on_mouse_down_out(cx.listener(|editor, _: &MouseDownEvent, _, cx| {
                                 editor.menu = None;
                                 cx.notify();
                             }))
-                            .child(
+                            .children((count > 0).then(|| {
                                 // The scroll viewport: shows ~6 rows, the rest scroll.
                                 div()
                                     .id("suggestion-menu")
@@ -4108,8 +4199,10 @@ impl Render for EditorState {
                                     .flex()
                                     .flex_col()
                                     .py(px(PAD))
-                                    .children(rows),
-                            )
+                                    .children(rows)
+                            }))
+                            .children((count > 0).then(|| div().h(px(1.)).bg(menu_border)))
+                            .child(clipboard)
                             .children(thumb),
                     ),
                 )
@@ -4127,7 +4220,7 @@ impl Render for EditorState {
                 let divider = st.map_or(rgba(0xffffff2e).into(), |s| s.popover_divider);
                 let mut thumb_c = st.map_or(rgba(0xffffff66).into(), |s| s.marker);
                 thumb_c.a = 0.5;
-                const ROW_H: f32 = 28.0;
+                const ROW_H: f32 = 24.0;
                 const DIV_H: f32 = 9.0;
                 const PAD: f32 = 4.0;
                 const MAX_H: f32 = 240.0;
@@ -4150,8 +4243,8 @@ impl Render for EditorState {
                         div()
                             .id(("table-menu-row", i))
                             .flex_shrink_0()
-                            .px(px(12.))
-                            .py(px(5.))
+                            .px(px(10.))
+                            .py(px(3.))
                             .hover(move |s| s.bg(hover))
                             .child(SharedString::from(label))
                             .on_mouse_down(
@@ -4195,7 +4288,7 @@ impl Render for EditorState {
                             .rounded(px(6.))
                             .overflow_hidden()
                             .text_color(menu_fg)
-                            .text_size(px(14.))
+                            .text_size(px(13.))
                             .on_mouse_down_out(cx.listener(|editor, _: &MouseDownEvent, _, cx| {
                                 editor.table_menu = None;
                                 cx.notify();
@@ -4221,6 +4314,65 @@ impl Render for EditorState {
             }))
             // The image right-click menu: Word-style object actions on an inline
             // image (Delete), anchored at the click. Chrome matches the table menu.
+            .children(self.prop_menu.map(|(row, anchor)| {
+                let st = self.markdown_style.as_ref();
+                let menu_bg = st.map_or(rgb(0x26262b).into(), |s| s.popover_bg);
+                let menu_border = st.map_or(rgb(0x45454c).into(), |s| s.popover_border);
+                let menu_fg = st.map_or(rgb(0xe6e6e6).into(), |s| s.popover_fg);
+                let hover = st.map_or(rgba(0x2f6fd628).into(), |s| s.popover_hover);
+                let item = |id: &'static str, label: &'static str| {
+                    div()
+                        .id(id)
+                        .px(px(10.))
+                        .py(px(3.))
+                        .hover(move |s| s.bg(hover))
+                        .child(label)
+                };
+                gpui::deferred(
+                    gpui::anchored().position(anchor).snap_to_window().child(
+                        div()
+                            .occlude()
+                            .min_w(px(160.))
+                            .cursor(CursorStyle::Arrow)
+                            .bg(menu_bg)
+                            .border_1()
+                            .border_color(menu_border)
+                            .rounded(px(6.))
+                            .overflow_hidden()
+                            .text_color(menu_fg)
+                            .text_size(px(13.))
+                            .py(px(4.))
+                            .on_mouse_down_out(cx.listener(|editor, _: &MouseDownEvent, _, cx| {
+                                editor.prop_menu = None;
+                                cx.notify();
+                            }))
+                            .child(item("prop-menu-edit", "Edit properties").on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |editor, _: &MouseDownEvent, _, cx| {
+                                    cx.stop_propagation();
+                                    editor.prop_menu = None;
+                                    if let Some((range, source)) = editor.property_block_at(row) {
+                                        let block_row = row - editor.row_col(range.start).0;
+                                        cx.emit(EditorEvent::EditProperties {
+                                            range,
+                                            source,
+                                            at_end: false,
+                                            row: Some(block_row),
+                                        });
+                                    }
+                                }),
+                            ))
+                            .child(item("prop-menu-delete", "Delete property").on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |editor, _: &MouseDownEvent, _, cx| {
+                                    cx.stop_propagation();
+                                    editor.prop_menu = None;
+                                    editor.delete_property_row(row, cx);
+                                }),
+                            )),
+                    ),
+                )
+            }))
             .children(self.image_menu.map(|(line, anchor)| {
                 let st = self.markdown_style.as_ref();
                 let menu_bg = st.map_or(rgb(0x26262b).into(), |s| s.popover_bg);
@@ -4239,7 +4391,7 @@ impl Render for EditorState {
                             .rounded(px(6.))
                             .overflow_hidden()
                             .text_color(menu_fg)
-                            .text_size(px(14.))
+                            .text_size(px(13.))
                             .py(px(4.))
                             .on_mouse_down_out(cx.listener(|editor, _: &MouseDownEvent, _, cx| {
                                 editor.image_menu = None;
@@ -4248,8 +4400,8 @@ impl Render for EditorState {
                             .child(
                                 div()
                                     .id("image-menu-delete")
-                                    .px(px(12.))
-                                    .py(px(5.))
+                                    .px(px(10.))
+                                    .py(px(3.))
                                     .hover(move |s| s.bg(hover))
                                     .child("Delete image")
                                     .on_mouse_down(
@@ -5996,7 +6148,8 @@ fn paint_prop_panel(
     window: &mut Window,
     cx: &mut App,
     pill_rects: &mut Vec<(Bounds<Pixels>, gpui_markdown::syntax::LinkHit)>,
-    row_rects: &mut Vec<Bounds<Pixels>>,
+    row_rects: &mut Vec<(Bounds<Pixels>, usize)>,
+    base_row: usize,
 ) {
     let line_h = font_size * LINE_HEIGHT_RATIO;
     let pad = px(10.);
@@ -6004,7 +6157,7 @@ fn paint_prop_panel(
     for (ri, (key, icon, segs)) in p.rows.iter().enumerate() {
         let row_top = origin.y + p.row_h * ri as f32;
         let row_bounds = Bounds::new(point(origin.x, row_top), size(p.width, p.row_h));
-        row_rects.push(row_bounds);
+        row_rects.push((row_bounds, base_row + ri));
         // Whole-row hover border (Obsidian-style).
         if row_bounds.contains(&mouse) {
             window.paint_quad(PaintQuad {
@@ -7478,7 +7631,7 @@ impl Element for EditorElement {
         // Property-panel pill bounds + targets (click-to-open) and row bounds
         // (hover change-detection), committed for the next frame's handlers.
         let mut prop_pill_rects: Vec<(Bounds<Pixels>, gpui_markdown::syntax::LinkHit)> = Vec::new();
-        let mut prop_row_rects: Vec<Bounds<Pixels>> = Vec::new();
+        let mut prop_row_rects: Vec<(Bounds<Pixels>, usize)> = Vec::new();
         // The span being structurally edited (if any): skip painting its raster — the seated
         // editor overlays its spot.
         let editing_inline = self
@@ -7883,6 +8036,7 @@ impl Element for EditorElement {
                     cx,
                     &mut prop_pill_rects,
                     &mut prop_row_rects,
+                    i,
                 );
             } else {
                 // Code blocks + gutter marks inset their text (kept in sync with

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1480,9 +1480,37 @@ impl EditorState {
     }
 
     fn home(&mut self, _: &Home, _: &mut Window, cx: &mut Context<Self>) {
-        let (row, _) = self.row_col(self.cursor_offset());
+        let (row, col) = self.row_col(self.cursor_offset());
         let starts = self.line_starts();
-        self.move_to(starts[row], cx);
+        // Smart Home on a gutter line (list/task/quote): the marker is hidden
+        // behind a painted bullet, so land on the first content character —
+        // the raw line start would reveal the marker and let typing break it.
+        // A second Home (at or inside the prefix) goes to the true start.
+        let plen = self.hidden_prefix_len(row);
+        let target = if plen > 0 && col > plen {
+            starts[row] + plen
+        } else {
+            starts[row]
+        };
+        self.move_to(target, cx);
+    }
+
+    /// The hidden marker prefix length of logical `row` — list/task/quote
+    /// lines draw their marker as a painted gutter and hide the source chars.
+    /// 0 when the line has no gutter or markdown styling is off.
+    fn hidden_prefix_len(&self, row: usize) -> usize {
+        if self.markdown_style.is_none() {
+            return 0;
+        }
+        let Some(&start) = self.line_starts().get(row) else {
+            return 0;
+        };
+        let line = &self.content[start..self.line_end(row)];
+        markdown_syntax::task_prefix(line)
+            .map(|(l, ..)| l)
+            .or_else(|| markdown_syntax::list_prefix(line).map(|(l, ..)| l))
+            .or_else(|| markdown_syntax::blockquote_prefix(line))
+            .unwrap_or(0)
     }
 
     fn end(&mut self, _: &End, _: &mut Window, cx: &mut Context<Self>) {
@@ -1498,7 +1526,8 @@ impl EditorState {
             // the start of the line just below one — remove the whole picture
             // (line + newline) as one edit, never stepping into its hidden
             // markdown character by character.
-            let (row, col) = self.row_col(self.cursor_offset());
+            let off = self.cursor_offset();
+            let (row, col) = self.row_col(off);
             if let Some(range) = self.image_row_range(row).or_else(|| {
                 (col == 0 && row > 0)
                     .then(|| self.image_row_range(row - 1))
@@ -1508,11 +1537,48 @@ impl EditorState {
                 cx.emit(EditorEvent::Changed);
                 return;
             }
-            let prev = self.previous_boundary(self.cursor_offset());
-            if self.cursor_offset() == prev {
+            // The same Word-style treatment for math: backspacing onto an
+            // inline formula's closing `$` removes the whole formula, and at
+            // the start of the line below a `$$` block removes the whole
+            // block — never stripping one hidden delimiter and dumping raw
+            // LaTeX. A caret strictly INSIDE a span (revealed source) still
+            // edits character-wise.
+            if let Some((range, _)) = self
+                .inline_math_span_at(self.previous_boundary(off))
+                .filter(|(r, _)| off == r.end)
+            {
+                self.replace_range(range, "", cx);
+                cx.emit(EditorEvent::Changed);
+                return;
+            }
+            if col == 0
+                && row > 0
+                && self.math_block_at(row).is_none() // inside = raw editing
+                && let Some((range, _)) = self.math_block_at(row - 1)
+            {
+                let range = self.math_delete_range(range);
+                self.replace_range(range, "", cx);
+                cx.emit(EditorEvent::Changed);
+                return;
+            }
+            // Backspacing from the line below a property panel joins as
+            // usual — but the caret would land inside the panel and reveal
+            // its raw `key:: value` source. Seat the in-place form after the
+            // join instead (the same landing as arrowing in from below).
+            let join_into_props = col == 0
+                && row > 0
+                && self.property_block_at(row).is_none()
+                && self.property_block_at(row - 1).is_some();
+            let prev = self.previous_boundary(off);
+            if off == prev {
                 return;
             }
             self.select_to(prev, cx);
+            self.replace_text_in_range(None, "", window, cx);
+            if join_into_props {
+                self.edit_properties_at_caret(true, cx);
+            }
+            return;
         }
         self.replace_text_in_range(None, "", window, cx);
     }
@@ -1532,11 +1598,41 @@ impl EditorState {
                 cx.emit(EditorEvent::Changed);
                 return;
             }
-            let next = self.next_boundary(self.cursor_offset());
-            if self.cursor_offset() == next {
+            // Math mirrors of the backspace guards: deleting onto an inline
+            // formula's opening `$` removes the whole formula; at the end of
+            // the line above a `$$` block removes the whole block.
+            if let Some((range, _)) = self
+                .inline_math_span_at(self.next_boundary(off))
+                .filter(|(r, _)| off == r.start)
+            {
+                self.replace_range(range, "", cx);
+                cx.emit(EditorEvent::Changed);
+                return;
+            }
+            if off == self.line_end(row)
+                && self.math_block_at(row).is_none() // inside = raw editing
+                && let Some((range, _)) = self.math_block_at(row + 1)
+            {
+                let range = self.math_delete_range(range);
+                self.replace_range(range, "", cx);
+                cx.emit(EditorEvent::Changed);
+                return;
+            }
+            // Mirroring backspace's property join: pulling the panel's first
+            // line up would seat a raw caret in the block — open the form.
+            let join_into_props = off == self.line_end(row)
+                && self.property_block_at(row).is_none()
+                && self.property_block_at(row + 1).is_some();
+            let next = self.next_boundary(off);
+            if off == next {
                 return;
             }
             self.select_to(next, cx);
+            self.replace_text_in_range(None, "", window, cx);
+            if join_into_props {
+                self.edit_properties_at_caret(false, cx);
+            }
+            return;
         }
         self.replace_text_in_range(None, "", window, cx);
     }
@@ -1572,6 +1668,16 @@ impl EditorState {
             self.selected_range = end..end;
             self.replace_text_in_range(None, "\n", window, cx);
             return;
+        }
+        // Inside a property panel a raw newline would split a `key:: value`
+        // line. Enter opens the panel's editor instead — the same route as a
+        // click or arrow-in (the form's own Enter then commits).
+        if self.selected_range.is_empty() {
+            let (row, _) = self.row_col(self.cursor_offset());
+            if self.property_block_at(row).is_some() {
+                self.edit_properties_at_caret(false, cx);
+                return;
+            }
         }
         // List auto-continuation: Enter on a list/task item opens the next item
         // (same marker + indent; ordered numbers increment); Enter on an *empty*
@@ -1923,6 +2029,39 @@ impl EditorState {
             .map(|(r, source)| (starts[r.start]..self.line_end(r.end - 1), source.into()))
     }
 
+    /// A `$$` block's byte range grown for deletion: takes in the
+    /// `<!-- math:ALIGN -->` marker line directly above (removing the block
+    /// alone would orphan it) and the trailing newline.
+    fn math_delete_range(&self, range: Range<usize>) -> Range<usize> {
+        let mut start = range.start;
+        let (row, _) = self.row_col(range.start);
+        if row > 0 {
+            let prev_start = self.line_starts()[row - 1];
+            let prev = &self.content[prev_start..self.line_end(row - 1)];
+            if markdown_syntax::math_align_marker(prev).is_some() {
+                start = prev_start;
+            }
+        }
+        start..(range.end + 1).min(self.content.len())
+    }
+
+    /// If the caret sits inside a property block, ask the host to seat the
+    /// in-place form there (focused on the caret's row; `at_end` = caret at
+    /// the value's end) — the recovery for any edit that lands a raw caret in
+    /// the panel, mirroring what arrows and clicks do on entry.
+    fn edit_properties_at_caret(&mut self, at_end: bool, cx: &mut Context<Self>) {
+        let (row, _) = self.row_col(self.cursor_offset());
+        if let Some((range, source)) = self.property_block_at(row) {
+            let block_row = row - self.row_col(range.start).0;
+            cx.emit(EditorEvent::EditProperties {
+                range,
+                source,
+                at_end,
+                row: Some(block_row),
+            });
+        }
+    }
+
     /// The property block whose lines cover `row`, as an absolute byte range +
     /// source — so a click or an arrow into the panel opens the property editor
     /// instead of landing in (and revealing) the raw `key:: value` lines.
@@ -2223,18 +2362,28 @@ impl EditorState {
         self.goal_x = None;
         self.last_edit = EditKind::Other;
         match event.click_count {
-            // Double-click selects the word under the cursor; a $$…$$ block already
-            // opened the structural editor on the first (single) click.
+            // Double-click selects the word under the cursor. On a $$…$$ block
+            // or property panel the FIRST click of the pair already opened the
+            // in-place editor — word-selecting the hidden source underneath
+            // would fight the seated editor, so those clicks are swallowed.
             2 => {
+                let (row, _) = self.row_col(offset);
+                if self.math_block_at(row).is_some() || self.property_block_at(row).is_some() {
+                    return;
+                }
                 self.is_selecting = false;
                 self.selected_range = self.word_range_at(offset).unwrap_or(offset..offset);
                 self.selection_reversed = false;
                 cx.notify();
             }
-            // Triple-click (or more): select the whole logical line.
+            // Triple-click (or more): select the whole logical line — except on
+            // a block construct, where it would select the raw hidden fences.
             n if n >= 3 => {
-                self.is_selecting = false;
                 let (row, _) = self.row_col(offset);
+                if self.math_block_at(row).is_some() || self.property_block_at(row).is_some() {
+                    return;
+                }
+                self.is_selecting = false;
                 let start = self.line_starts()[row];
                 self.selected_range = start..self.line_end(row);
                 self.selection_reversed = false;
@@ -2558,10 +2707,18 @@ impl EditorState {
         self.focus(window, cx);
         let target = if after {
             let (end_row, _) = self.row_col(block.end.saturating_sub(1));
-            self.line_starts()
-                .get(end_row + 1)
-                .copied()
-                .unwrap_or(self.content.len())
+            match self.line_starts().get(end_row + 1).copied() {
+                Some(start) => start,
+                // The block ends the document: give the caret a fresh line
+                // below. Landing at content-end would park it ON the block's
+                // last row, revealing the raw source it just committed.
+                None => {
+                    let end = self.content.len();
+                    self.replace_range(end..end, "\n", cx);
+                    cx.emit(EditorEvent::Changed);
+                    self.content.len()
+                }
+            }
         } else {
             let (start_row, _) = self.row_col(block.start);
             if start_row > 0 {

--- a/crates/gpui-pdf/API.md
+++ b/crates/gpui-pdf/API.md
@@ -28,17 +28,18 @@ public. Items in the **Feature** column require that Cargo feature (`search` imp
 | [`parse_with_password`](#parse_with_password) | fn | — | `fn parse_with_password(bytes: Arc<Vec<u8>>, password: &str) -> Result<Arc<Document>, LoadError>` | Parse an encrypted PDF |
 | [`page_dims`](#page_dims) | fn | — | `fn page_dims(doc: &Document) -> Vec<(f32, f32)>` | Per-page `(w, h)` in points, no rasterization |
 | [`render_page`](#render_page) | fn | — | `fn render_page(doc: &Document, idx: usize, scale: f32) -> Result<Arc<RenderImage>, String>` | Rasterize one page to a BGRA bitmap |
-| [`is_pdf`](#is_pdf) | fn | — | `fn is_pdf(src: &str) -> bool` | `.pdf` extension check |
+| [`is_pdf`](#is_pdf) | fn | — | `fn is_pdf(src: &str) -> bool` | `.pdf` extension check (sees through `?query`) |
 | [`PAGE_WIDTH`](#const-page_width) | const | — | `const PAGE_WIDTH: f32 = 820.0` | Base on-screen page width at zoom 1.0 |
 | [`keep_window`](#keep_window) | fn | — | `fn keep_window(dims: &[(f32, f32)], page_width: f32, scroll_y: f32, viewport_h: f32) -> (usize, usize)` | Which pages to keep rasterized |
 | [`PdfStyle`](#struct-pdfstyle) | struct | — | 6 `pub Hsla` fields; `impl Default` | Colors for the viewer chrome |
 | [`PdfStyleFn`](#type-pdfstylefn) | type alias | — | `Rc<dyn Fn() -> PdfStyle>` | Live style source, read at paint time |
 | [`PdfQualityFn`](#type-pdfqualityfn) | type alias | — | `Rc<dyn Fn() -> f32>` | Live render-quality source |
-| [`PdfEvent`](#enum-pdfevent) | enum | — | `LockChanged` | Emitted on lock-state transitions |
+| [`PdfEvent`](#enum-pdfevent) | enum | — | `LockChanged`, `LoadFailed` | Lock transitions + terminal load failures |
 | [`PdfView`](#struct-pdfview) | struct | — | `impl Render + EventEmitter<PdfEvent>` | The ready-made page-virtualized viewer |
 | [`PdfView::new`](#pdfviewnew) | constructor | — | `fn new(path: PathBuf, style: PdfStyleFn, quality: PdfQualityFn, cx: &mut Context<Self>) -> Self` | Create a viewer; loads off-thread |
 | [`PdfView::is_locked`](#pdfviewis_locked) | method | — | `fn is_locked(&self) -> bool` | Encrypted and awaiting a password |
 | [`PdfView::unlock_failed`](#pdfviewunlock_failed) | method | — | `fn unlock_failed(&self) -> bool` | Last unlock used a wrong password |
+| [`PdfView::load_error`](#pdfviewload_error) | method | — | `fn load_error(&self) -> Option<&SharedString>` | Terminal read/parse failure message |
 | [`PdfView::unlock`](#pdfviewunlock) | method | — | `fn unlock(&mut self, password: String, cx: &mut Context<Self>)` | Retry an encrypted PDF with a password |
 | [`PdfView::release`](#pdfviewrelease) | method | — | `fn release(&mut self, window: &mut Window, cx: &mut Context<Self>)` | Free all bitmaps + GPU textures before drop |
 | [`PdfView::detach_textures`](#pdfviewdetach_textures) | method | — | `fn detach_textures(&mut self, window: &mut Window, cx: &mut Context<Self>)` | Free GPU textures, keep bitmaps (window move) |
@@ -486,8 +487,10 @@ True if a link/image `src` points at a PDF.
 | --- | --- | --- |
 | `src` | `&str` | A path or URL string. |
 
-**Returns** — `bool`: whether `src`, lowercased and with trailing whitespace
-trimmed, ends with `.pdf`.
+**Returns** — `bool`: whether `src` — lowercased, trailing whitespace trimmed,
+and with any `?query` suffix ignored (`report.pdf?v=2` counts) — ends with
+`.pdf`. A `#fragment` is NOT stripped: for PDF refs it's the page-jump anchor
+(`file.pdf#p3`), handled by callers.
 
 **Guarantees & edge cases**
 
@@ -602,15 +605,19 @@ there is no `set_quality` method.
 ```rust
 pub enum PdfEvent {
     LockChanged,
+    LoadFailed,
 }
 ```
 
-Emitted (via `impl EventEmitter<PdfEvent> for PdfView`) when the view's lock state
-transitions: the load discovered an encrypted file, an [`unlock`](#pdfviewunlock)
-succeeded, or an unlock failed with a wrong password. Fired only on these
-transitions — not on every redraw. A host rendering a password prompt around the
-viewer subscribes to know when to re-render (see
-[`PdfView::is_locked`](#pdfviewis_locked)).
+Emitted (via `impl EventEmitter<PdfEvent> for PdfView`). `LockChanged` fires when
+the view's lock state transitions: the load discovered an encrypted file, an
+[`unlock`](#pdfviewunlock) succeeded, or an unlock failed with a wrong password.
+`LoadFailed` fires when the file can't be read or parsed — terminal for the view,
+which renders the failure message (see [`PdfView::load_error`](#pdfviewload_error))
+in place of the loading placeholder; it also fires when a retry-unlock fails with
+a non-password error (e.g. an unsupported encryption handler), so a password
+prompt knows to stand down. Fired only on these transitions — not on every
+redraw.
 
 ---
 
@@ -718,6 +725,17 @@ pub fn unlock_failed(&self) -> bool
 Whether the most recent [`unlock`](#pdfviewunlock) used a wrong password — drives
 the prompt's "incorrect password" message. Cleared at the start of the next
 attempt (and on success). **Parameters** — none (`&self`).
+
+### `PdfView::load_error`
+
+```rust
+pub fn load_error(&self) -> Option<&SharedString>
+```
+
+The terminal read/parse failure, if any — the viewer renders this message in
+place of the loading placeholder, and [`PdfEvent::LoadFailed`](#enum-pdfevent)
+fired when it was set. `None` while loading and after a successful parse.
+**Parameters** — none (`&self`).
 
 ### `PdfView::unlock`
 

--- a/crates/gpui-pdf/src/lib.rs
+++ b/crates/gpui-pdf/src/lib.rs
@@ -176,7 +176,11 @@ pub fn render_page(doc: &Document, idx: usize, scale: f32) -> Result<Arc<RenderI
 
 /// True if a link/image `src` points at a PDF (by extension, case-insensitive).
 pub fn is_pdf(src: &str) -> bool {
-    src.to_lowercase().trim_end().ends_with(".pdf")
+    let src = src.trim_end();
+    // A URL query (`report.pdf?v=2`) doesn't change what the file is; `#`
+    // stays — it's the page-jump anchor (`file.pdf#p3`), stripped by callers.
+    let path = src.split('?').next().unwrap_or(src);
+    path.to_lowercase().ends_with(".pdf")
 }
 
 // ─────────────────────────────── Viewport virtualization ───────────────────────────────
@@ -449,6 +453,12 @@ struct SearchMatch {
 /// re-render. (Fired only on these transitions, not on every redraw.)
 pub enum PdfEvent {
     LockChanged,
+    /// The file couldn't be read or parsed (see [`PdfView::load_error`]) —
+    /// terminal for this view; the viewer shows the message in place of the
+    /// loading placeholder. Also fired when a retry-unlock fails with a
+    /// non-password error (e.g. an unsupported encryption handler discovered
+    /// at unlock time), so a password prompt knows to stand down.
+    LoadFailed,
     /// A form-field widget was clicked (`forms` feature): the field's
     /// description and its current window-space bounds — everything a host
     /// needs to toggle a checkbox or seat a text input right over the widget,
@@ -481,6 +491,9 @@ pub struct PdfView {
     /// The most recent [`PdfView::unlock`] used a wrong password — drives the
     /// prompt's "incorrect password" message; cleared on the next attempt.
     unlock_failed: bool,
+    /// A terminal read/parse failure — the viewer renders this message
+    /// instead of sitting on "Loading PDF…" forever.
+    load_error: Option<SharedString>,
     /// `(width, height)` in points per page — drives page-slot sizing.
     dims: Vec<(f32, f32)>,
     /// Per-page render state; only pages near the viewport hold a bitmap.
@@ -595,6 +608,9 @@ impl PdfView {
                 Ok(x) => x,
                 Err(e) => {
                     log::error!("read pdf: {e}");
+                    let _ = this.update(cx, |this, cx| {
+                        this.fail_load(format!("Couldn’t read the file: {e}"), cx);
+                    });
                     return;
                 }
             };
@@ -608,7 +624,10 @@ impl PdfView {
                         cx.emit(PdfEvent::LockChanged);
                         cx.notify();
                     }
-                    Err(LoadError::Other(e)) => log::error!("parse pdf: {e}"),
+                    Err(LoadError::Other(e)) => {
+                        log::error!("parse pdf: {e}");
+                        this.fail_load(format!("Couldn’t open the PDF: {e}"), cx);
+                    }
                 }
             });
         })
@@ -623,6 +642,7 @@ impl PdfView {
             bytes: None,
             locked: false,
             unlock_failed: false,
+            load_error: None,
             dims: Vec::new(),
             pages: Vec::new(),
             scroll: ScrollHandle::new(),
@@ -848,10 +868,31 @@ impl PdfView {
                     cx.emit(PdfEvent::LockChanged);
                     cx.notify();
                 }
-                Err(LoadError::Other(e)) => log::error!("unlock pdf: {e}"),
+                Err(LoadError::Other(e)) => {
+                    // Not a wrong password — e.g. an unsupported encryption
+                    // handler discovered at unlock time. Terminal: swap the
+                    // prompt for the error pane.
+                    log::error!("unlock pdf: {e}");
+                    this.locked = false;
+                    this.fail_load(format!("Couldn’t open the PDF: {e}"), cx);
+                    cx.emit(PdfEvent::LockChanged);
+                }
             });
         })
         .detach();
+    }
+
+    /// Record a terminal load failure (the message renders in the viewer) and
+    /// tell the host.
+    fn fail_load(&mut self, msg: String, cx: &mut Context<Self>) {
+        self.load_error = Some(msg.into());
+        cx.emit(PdfEvent::LoadFailed);
+        cx.notify();
+    }
+
+    /// The terminal read/parse failure shown in place of the viewer, if any.
+    pub fn load_error(&self) -> Option<&SharedString> {
+        self.load_error.as_ref()
     }
 
     /// Set the highlights to draw — the host derives these from its own store (e.g.
@@ -1547,6 +1588,9 @@ impl Render for PdfView {
         self.ensure_window(window, cx);
         let style = (self.style)();
 
+        if let Some(err) = &self.load_error {
+            return load_failed(style, err.clone()).into_any_element();
+        }
         if self.dims.is_empty() {
             return loading(style).into_any_element();
         }
@@ -2405,6 +2449,31 @@ impl Render for PdfView {
     }
 }
 
+/// The terminal-failure pane: the file name stays in the tab; the pane says
+/// why the viewer is empty (instead of an eternal "Loading PDF…").
+fn load_failed(style: PdfStyle, err: SharedString) -> impl IntoElement {
+    div()
+        .size_full()
+        .flex()
+        .flex_col()
+        .gap(px(6.))
+        .items_center()
+        .justify_center()
+        .bg(style.bg)
+        .child(
+            div()
+                .text_color(style.placeholder_fg)
+                .child("This PDF couldn’t be opened"),
+        )
+        .child(
+            div()
+                .text_size(px(12.))
+                .text_color(style.placeholder_fg)
+                .max_w(px(520.))
+                .child(err),
+        )
+}
+
 fn loading(style: PdfStyle) -> impl IntoElement {
     div()
         .size_full()
@@ -2447,6 +2516,15 @@ impl Render for Tip {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn is_pdf_sees_through_url_queries() {
+        assert!(super::is_pdf("report.pdf"));
+        assert!(super::is_pdf("Report.PDF "));
+        assert!(super::is_pdf("https://x.test/report.pdf?v=2"));
+        assert!(!super::is_pdf("report.pdf.png"));
+        assert!(!super::is_pdf("a.png?name=report.pdf"));
+    }
+
     use super::*;
 
     #[test]

--- a/crates/os-spellcheck/src/windows.rs
+++ b/crates/os-spellcheck/src/windows.rs
@@ -7,7 +7,9 @@
 //! `check` (detection) collects the error spans; `suggestions` asks the checker
 //! for replacements for one word, lazily — mirroring the macOS split.
 
-use windows::Win32::Globalization::{ISpellChecker, ISpellCheckerFactory, SpellCheckerFactory};
+use windows::Win32::Globalization::{
+    GetUserDefaultLocaleName, ISpellChecker, ISpellCheckerFactory, SpellCheckerFactory,
+};
 use windows::Win32::System::Com::{CLSCTX_INPROC_SERVER, CoCreateInstance, CoTaskMemFree};
 use windows::core::{HSTRING, PWSTR};
 
@@ -90,13 +92,29 @@ impl Backend {
     }
 }
 
-/// Create the system spell checker for the UI language. `None` on any failure
-/// (COM not initialized, language unsupported) — the caller treats that as
-/// "spell-check unavailable".
+/// Create the system spell checker for the user's UI language
+/// (`GetUserDefaultLocaleName`, e.g. "de-DE"), falling back to `en-US` when
+/// the lookup fails or that language has no checker installed. `None` on any
+/// failure (COM not initialized, no language supported) — the caller treats
+/// that as "spell-check unavailable".
 fn connect() -> Option<ISpellChecker> {
     unsafe {
         let factory: ISpellCheckerFactory =
             CoCreateInstance(&SpellCheckerFactory, None, CLSCTX_INPROC_SERVER).ok()?;
+        // 85 = LOCALE_NAME_MAX_LENGTH; the returned count includes the NUL.
+        let mut buf = [0u16; 85];
+        let n = GetUserDefaultLocaleName(&mut buf);
+        if n > 1 {
+            let lang = HSTRING::from(String::from_utf16_lossy(&buf[..(n - 1) as usize]));
+            if factory
+                .IsSupported(&lang)
+                .map(|b| b.as_bool())
+                .unwrap_or(false)
+                && let Ok(sc) = factory.CreateSpellChecker(&lang)
+            {
+                return Some(sc);
+            }
+        }
         let lang = HSTRING::from("en-US");
         factory.CreateSpellChecker(&lang).ok()
     }

--- a/crates/ratex-gpui/src/editor/view.rs
+++ b/crates/ratex-gpui/src/editor/view.rs
@@ -205,6 +205,7 @@ impl MathEditor {
             anchor: None,
             focus: cx.focus_handle(),
             font_size,
+            // Corrected to the window's scale factor on first render.
             dpr: 2.0,
             align,
             theme,
@@ -775,7 +776,16 @@ impl MathEditor {
 }
 
 impl Render for MathEditor {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // Rasterize at the window's real pixel density — the construction
+        // default (2.0) is only right on a 2× display; a 1× screen rendered
+        // soft and a 3× wasted texture. Guarded, so this settles in one
+        // extra frame after a display change.
+        let dpr = window.scale_factor().max(1.0);
+        if (dpr - self.dpr).abs() > f32::EPSILON {
+            self.dpr = dpr;
+            self.rerender(window, cx);
+        }
         let theme = self.theme;
         let (w, h) = self
             .rendered

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -62,7 +62,11 @@ actions!(
         // The custom property editor's Tab / Shift+Tab field stepping (bound in
         // its own key context so they override the default focus traversal).
         PropNextField,
-        PropPrevField
+        PropPrevField,
+        // The shared page context menu's copy verbs (`[[Title]]` / markdown
+        // body to the clipboard); no keybindings.
+        CopyPageLink,
+        CopyPageContents
     ]
 );
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -595,9 +595,14 @@ pub struct AppView {
     /// Shared cross-window save signal (see [`DocSignal`]): this window emits on
     /// save and reloads stale content on other windows' saves (live multi-window).
     doc_signal: Entity<DocSignal>,
-    /// The rename dialog's text field, and the page being renamed.
+    /// The rename dialog's text field, the page being renamed, and the
+    /// failure line shown inside the dialog (collision / DB error). The error
+    /// is an `Rc<RefCell<…>>`, NOT a plain field: the dialog builder runs
+    /// inside this view's own render (`Root::render_dialog_layer`), where
+    /// reading the AppView entity would double-borrow and panic.
     rename_input: Entity<InputState>,
     rename_target: Option<i64>,
+    rename_error: Rc<RefCell<Option<SharedString>>>,
     /// The text field for the password prompt shown when an encrypted PDF tab is
     /// locked (one field shared across PDF tabs — only the active one prompts).
     pdf_password_input: Entity<InputState>,
@@ -841,6 +846,7 @@ impl AppView {
             doc_signal,
             rename_input: cx.new(|cx| InputState::new(window, cx)),
             rename_target: None,
+            rename_error: Rc::new(RefCell::new(None)),
             pdf_password_input,
             db_error,
             db_error_shown: false,
@@ -3048,12 +3054,16 @@ impl AppView {
         };
         cx.notify();
         let rx = cx.prompt_for_new_path(crate::paths::desktop_dir().as_path(), Some("formula.png"));
-        cx.spawn_in(window, async move |_this, _cx| {
+        cx.spawn_in(window, async move |this, cx| {
             let Ok(Ok(Some(path))) = rx.await else { return };
-            let Some(png) = ratex_gpui::render::render_latex_to_png(&source, 48.0, 4.0) else {
-                return;
-            };
-            let _ = std::fs::write(path, png);
+            let result = ratex_gpui::render::render_latex_to_png(&source, 48.0, 4.0)
+                .ok_or_else(|| "the formula didn’t render".to_string())
+                .and_then(|png| std::fs::write(&path, png).map_err(|e| e.to_string()));
+            if let Err(e) = result {
+                let _ = this.update_in(cx, |this, window, cx| {
+                    this.show_error_dialog("Export failed", e, window, cx);
+                });
+            }
         })
         .detach();
     }
@@ -3064,12 +3074,16 @@ impl AppView {
         };
         cx.notify();
         let rx = cx.prompt_for_new_path(crate::paths::desktop_dir().as_path(), Some("formula.svg"));
-        cx.spawn_in(window, async move |_this, _cx| {
+        cx.spawn_in(window, async move |this, cx| {
             let Ok(Ok(Some(path))) = rx.await else { return };
-            let Some(svg) = ratex_gpui::render::render_latex_to_svg(&source, 48.0) else {
-                return;
-            };
-            let _ = std::fs::write(path, svg);
+            let result = ratex_gpui::render::render_latex_to_svg(&source, 48.0)
+                .ok_or_else(|| "the formula didn’t render".to_string())
+                .and_then(|svg| std::fs::write(&path, svg).map_err(|e| e.to_string()));
+            if let Err(e) = result {
+                let _ = this.update_in(cx, |this, window, cx| {
+                    this.show_error_dialog("Export failed", e, window, cx);
+                });
+            }
         })
         .detach();
     }
@@ -3774,7 +3788,7 @@ impl AppView {
                     on
                 };
                 if new != field.value {
-                    self.write_pdf_field(&path, &field.name, &new, cx);
+                    self.write_pdf_field(&path, &field.name, &new, window, cx);
                 }
             }
             FieldKind::Text | FieldKind::Choice => {
@@ -3840,7 +3854,7 @@ impl AppView {
         };
         let value = edit.input.read(cx).value().trim_end().to_string();
         if value != edit.field.value {
-            self.write_pdf_field(&edit.path, &edit.field.name, &value, cx);
+            self.write_pdf_field(&edit.path, &edit.field.name, &value, window, cx);
         }
         let Some(view) = self.pdf_views.get(&edit.path).cloned() else {
             cx.notify();
@@ -3896,13 +3910,13 @@ impl AppView {
 
     /// Commit the seated PDF field input (Enter / click-away): write the value
     /// if it changed, then drop the seat.
-    pub(crate) fn commit_pdf_field_edit(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+    pub(crate) fn commit_pdf_field_edit(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let Some(edit) = self.pdf_field_edit.take() else {
             return;
         };
         let value = edit.input.read(cx).value().trim_end().to_string();
         if value != edit.field.value {
-            self.write_pdf_field(&edit.path, &edit.field.name, &value, cx);
+            self.write_pdf_field(&edit.path, &edit.field.name, &value, window, cx);
         }
         cx.notify();
     }
@@ -3910,20 +3924,45 @@ impl AppView {
     /// Write one form field: read the stored PDF, rewrite it through
     /// `set_form_value` (value + regenerated appearance), save it back, and
     /// hot-swap the open viewer's document (scroll/zoom preserved).
-    fn write_pdf_field(&mut self, path: &PathBuf, name: &str, value: &str, cx: &mut Context<Self>) {
+    fn write_pdf_field(
+        &mut self,
+        path: &PathBuf,
+        name: &str,
+        value: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let bytes = match std::fs::read(path) {
             Ok(b) => b,
             Err(e) => {
                 log::error!("read pdf for form write: {e}");
+                self.show_error_dialog(
+                    "Couldn’t save the field",
+                    format!("Reading the PDF failed: {e}"),
+                    window,
+                    cx,
+                );
                 return;
             }
         };
         let Some(new) = gpui_pdf::set_form_value(&bytes, name, value) else {
             log::error!("form write refused: field {name:?}");
+            self.show_error_dialog(
+                "Couldn’t save the field",
+                format!("The PDF rejected a write to “{name}” (it may be read-only)."),
+                window,
+                cx,
+            );
             return;
         };
         if let Err(e) = std::fs::write(path, &new) {
             log::error!("save pdf form write: {e}");
+            self.show_error_dialog(
+                "Couldn’t save the field",
+                format!("Writing the PDF failed: {e}"),
+                window,
+                cx,
+            );
             return;
         }
         if let Some(view) = self.pdf_views.get(path) {
@@ -4515,9 +4554,11 @@ impl AppView {
             }));
             // Files dropped on the canvas → import the images, place at the drop.
             let w = weak.clone();
-            v.set_on_drop_files(Rc::new(move |paths, x, y, _window, cx| {
+            v.set_on_drop_files(Rc::new(move |paths, x, y, window, cx| {
                 if let Some(app) = w.upgrade() {
-                    app.update(cx, |a, cx| a.drop_files_on_board(id, paths, x, y, cx));
+                    app.update(cx, |a, cx| {
+                        a.drop_files_on_board(id, paths, x, y, window, cx)
+                    });
                 }
             }));
             // ⌘C / ⌘X → put the serialized selection on the system clipboard,
@@ -4669,8 +4710,8 @@ impl AppView {
             let Some(path) = paths.into_iter().next() else {
                 return;
             };
-            let _ = this.update(cx, |this, cx| {
-                this.place_image_file_on_board(board_id, path, x, y, cx);
+            let _ = this.update_in(cx, |this, window, cx| {
+                this.place_image_file_on_board(board_id, path, x, y, window, cx);
             });
         })
         .detach();
@@ -4684,12 +4725,20 @@ impl AppView {
         paths: Vec<PathBuf>,
         x: f32,
         y: f32,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let mut n = 0.0;
         for path in paths {
             if crate::images::is_supported(&path) {
-                self.place_image_file_on_board(board_id, path, x + n * 16.0, y + n * 16.0, cx);
+                self.place_image_file_on_board(
+                    board_id,
+                    path,
+                    x + n * 16.0,
+                    y + n * 16.0,
+                    window,
+                    cx,
+                );
                 n += 1.0;
             }
         }
@@ -4702,11 +4751,20 @@ impl AppView {
         path: PathBuf,
         x: f32,
         y: f32,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         match crate::images::import_file(&path) {
             Ok(rel) => self.add_image_to_board(board_id, rel.into(), x, y, cx),
-            Err(e) => log::error!("import image {}: {e}", path.display()),
+            Err(e) => {
+                log::error!("import image {}: {e}", path.display());
+                self.show_error_dialog(
+                    "Couldn’t add the image",
+                    format!("Importing {} failed: {e}", path.display()),
+                    window,
+                    cx,
+                );
+            }
         }
     }
 
@@ -6894,6 +6952,31 @@ impl AppView {
 
     /// Delete a named page and refresh the UI. Journals are never deleted
     /// (the DB guards this too). Any tabs showing the page are closed.
+    /// A one-button error dialog — the voice for user-initiated operations
+    /// (rename, delete, export, form writes) whose failures used to be
+    /// log-only. NOTE: `feat/notebooks` adds an identical helper; drop one
+    /// copy when the branches merge.
+    fn show_error_dialog(
+        &mut self,
+        title: &'static str,
+        body: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.open_alert_dialog(cx, move |dialog, _window, _cx| {
+            let body = body.clone();
+            dialog
+                .title(title)
+                .description(SharedString::from(body))
+                .button_props(
+                    DialogButtonProps::default()
+                        .ok_text("OK")
+                        .show_cancel(false),
+                )
+                .on_ok(|_, _window, _cx| true)
+        });
+    }
+
     fn delete_page(&mut self, id: i64, window: &mut Window, cx: &mut Context<Self>) {
         match self.db.delete_page(id) {
             Ok(true) => {
@@ -6920,7 +7003,10 @@ impl AppView {
                 self.activate_tab(self.active, window, cx);
             }
             Ok(false) => {}
-            Err(e) => log::error!("delete page {id}: {e}"),
+            Err(e) => {
+                log::error!("delete page {id}: {e}");
+                self.show_error_dialog("Couldn’t delete the page", e.to_string(), window, cx);
+            }
         }
     }
 
@@ -7496,6 +7582,7 @@ impl AppView {
             return;
         };
         self.rename_target = Some(id);
+        *self.rename_error.borrow_mut() = None;
         self.rename_input
             .update(cx, |s, cx| s.set_value(title.to_string(), window, cx));
 
@@ -7504,6 +7591,7 @@ impl AppView {
         // a child) with a footer we build ourselves. Enter/Escape are wired
         // via on_ok/on_cancel.
         let input = self.rename_input.clone();
+        let err = self.rename_error.clone();
         let weak = cx.entity().downgrade();
         window.open_dialog(cx, move |dialog, _window, _cx| {
             let input_body = input.clone();
@@ -7511,10 +7599,21 @@ impl AppView {
             let input_key = input.clone();
             let weak_btn = weak.clone();
             let weak_key = weak.clone();
+            // A failed rename (collision, DB error) reports INSIDE this dialog
+            // and keeps it open — a second dialog on top would pop this one off
+            // the dialog stack and read as "nothing happened".
+            let error = err.borrow().clone();
             dialog
                 .title("Rename page")
                 .w(px(420.0))
                 .child(Input::new(&input_body))
+                .children(error.map(|e| {
+                    div()
+                        .mt(px(6.0))
+                        .text_size(px(12.0))
+                        .text_color(gpui::rgb(0xE5484D))
+                        .child(e)
+                }))
                 .footer(
                     DialogFooter::new()
                         .child(
@@ -7525,16 +7624,20 @@ impl AppView {
                         .child(Button::new("rename-ok").primary().label("Rename").on_click(
                             move |_, window, cx| {
                                 let title = input_btn.read(cx).value().to_string();
-                                let _ = weak_btn
-                                    .update(cx, |this, cx| this.commit_rename(title, window, cx));
-                                window.close_dialog(cx);
+                                let done = weak_btn
+                                    .update(cx, |this, cx| this.commit_rename(title, window, cx))
+                                    .unwrap_or(true);
+                                if done {
+                                    window.close_dialog(cx);
+                                }
                             },
                         )),
                 )
                 .on_ok(move |_, window, cx| {
                     let title = input_key.read(cx).value().to_string();
-                    let _ = weak_key.update(cx, |this, cx| this.commit_rename(title, window, cx));
-                    true
+                    weak_key
+                        .update(cx, |this, cx| this.commit_rename(title, window, cx))
+                        .unwrap_or(true)
                 })
                 .on_cancel(|_, _window, _cx| true)
         });
@@ -7543,12 +7646,22 @@ impl AppView {
 
     /// Apply a confirmed rename: rewrite `[[links]]`, refresh the sidebar,
     /// and update any open tab titles for the page.
-    fn commit_rename(&mut self, new_title: String, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(id) = self.rename_target.take() else {
-            return;
+    /// Returns whether the rename dialog should close: a success or a
+    /// cancel-like no-op (empty/unchanged name) closes; a collision or DB
+    /// error keeps it open showing `rename_error` inline.
+    fn commit_rename(
+        &mut self,
+        new_title: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(id) = self.rename_target else {
+            return true;
         };
         match self.db.rename_page(id, &new_title) {
             Ok(true) => {
+                self.rename_target = None;
+                *self.rename_error.borrow_mut() = None;
                 let title: SharedString = new_title.trim().to_string().into();
                 for tab in &mut self.tabs {
                     if matches!(tab.kind, TabKind::Page(pid) if pid == id) {
@@ -7559,10 +7672,39 @@ impl AppView {
                 self.reload_day_editors(window, cx);
                 self.signal_doc_changed(cx);
                 self.activate_tab(self.active, window, cx);
+                true
             }
-            Ok(false) => {}
-            Err(e) => log::error!("rename page {id}: {e}"),
+            Ok(false) => {
+                // Only a collision needs a voice — an empty or unchanged name
+                // reads as cancelling the dialog.
+                let t = new_title.trim().to_string();
+                if !t.is_empty() && self.title_collides(id, &t) {
+                    *self.rename_error.borrow_mut() =
+                        Some(format!("A page named “{t}” already exists.").into());
+                    cx.notify();
+                    false
+                } else {
+                    self.rename_target = None;
+                    true
+                }
+            }
+            Err(e) => {
+                log::error!("rename page {id}: {e}");
+                *self.rename_error.borrow_mut() = Some(format!("Rename failed: {e}").into());
+                cx.notify();
+                false
+            }
         }
+    }
+
+    /// Whether another page already owns `title` (the silent-no-op reason a
+    /// rename most often fails).
+    fn title_collides(&self, id: i64, title: &str) -> bool {
+        self.db
+            .get_page_by_title(title)
+            .ok()
+            .flatten()
+            .is_some_and(|p| p.id != id)
     }
 
     /// Rename the open page from its inline title field. Updates state in
@@ -7607,11 +7749,25 @@ impl AppView {
                 cx.notify();
             }
             Ok(false) => {
-                // Empty, duplicate, or journal — revert the field.
+                // Empty, duplicate, or journal — revert the field, and say
+                // why when it was a collision (the only surprising case).
+                let t = new_title.trim().to_string();
                 title_state.update(cx, |s, cx| s.set_value(current, window, cx));
+                if !t.is_empty() && self.title_collides(id, &t) {
+                    self.show_error_dialog(
+                        "Can’t rename",
+                        format!("A page named “{t}” already exists."),
+                        window,
+                        cx,
+                    );
+                }
                 cx.notify();
             }
-            Err(e) => log::error!("rename page {id} (inline): {e}"),
+            Err(e) => {
+                log::error!("rename page {id} (inline): {e}");
+                title_state.update(cx, |s, cx| s.set_value(current, window, cx));
+                self.show_error_dialog("Rename failed", e.to_string(), window, cx);
+            }
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -33,10 +33,11 @@ use gpui_component::{
 use gpui_editor::{Diagnostic, EditorEvent, EditorState};
 
 use crate::actions::{
-    CloseTab, DeletePage, ExportActivePdf, ExportNotebook, ExportPdf, FindInPage, FitImages,
-    GlobalSearch, ImportLogseq, ImportObsidian, InsertTab, NewPage, NewSubPage, NewWhiteboard,
-    NextTab, OpenInNewTab, OpenInNewWindow, OpenSettings, Outdent, PasteImage, PrevTab, RenamePage,
-    SlashCancel, SlashConfirm, SlashDown, SlashUp, ToggleFavorite,
+    CloseTab, CopyPageContents, CopyPageLink, DeletePage, ExportActivePdf, ExportNotebook,
+    ExportPdf, FindInPage, FitImages, GlobalSearch, ImportLogseq, ImportObsidian, InsertTab,
+    NewPage, NewSubPage, NewWhiteboard, NextTab, OpenInNewTab, OpenInNewWindow, OpenSettings,
+    Outdent, PasteImage, PrevTab, RenamePage, SlashCancel, SlashConfirm, SlashDown, SlashUp,
+    ToggleFavorite,
 };
 use crate::db::Db;
 use crate::images::ImageSeed;
@@ -6952,6 +6953,33 @@ impl AppView {
 
     /// Delete a named page and refresh the UI. Journals are never deleted
     /// (the DB guards this too). Any tabs showing the page are closed.
+    /// Shared page-menu "Copy link": put `[[Title]]` on the clipboard.
+    fn on_copy_page_link(&mut self, _: &CopyPageLink, _: &mut Window, cx: &mut Context<Self>) {
+        if let Some((_, title)) = self.context_page.take() {
+            cx.write_to_clipboard(ClipboardItem::new_string(format!("[[{title}]]")));
+        }
+    }
+
+    /// Shared page-menu "Copy contents": the page's markdown body.
+    fn on_copy_page_contents(
+        &mut self,
+        _: &CopyPageContents,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((id, _)) = self.context_page.take() else {
+            return;
+        };
+        match self.db.get_page(id) {
+            Ok(Some(p)) => cx.write_to_clipboard(ClipboardItem::new_string(p.content)),
+            Ok(None) => {}
+            Err(e) => {
+                log::error!("copy page {id} contents: {e}");
+                self.show_error_dialog("Couldn’t copy", e.to_string(), window, cx);
+            }
+        }
+    }
+
     /// A one-button error dialog — the voice for user-initiated operations
     /// (rename, delete, export, form writes) whose failures used to be
     /// log-only. NOTE: `feat/notebooks` adds an identical helper; drop one
@@ -8089,9 +8117,9 @@ impl Render for AppView {
                 rows = rows.child(
                     div()
                         .id(("ctx-menu-row", action_id))
-                        .px(px(12.0))
-                        .py(px(5.0))
-                        .text_size(px(14.0))
+                        .px(px(10.0))
+                        .py(px(3.0))
+                        .text_size(px(13.0))
                         .cursor_pointer()
                         .hover(|s| s.bg(theme::accent_tint()))
                         .on_mouse_down(
@@ -8246,6 +8274,8 @@ impl Render for AppView {
             .on_action(cx.listener(Self::on_export_pdf))
             .on_action(cx.listener(Self::on_export_active_pdf))
             .on_action(cx.listener(Self::on_rename_page))
+            .on_action(cx.listener(Self::on_copy_page_link))
+            .on_action(cx.listener(Self::on_copy_page_contents))
             .on_action(cx.listener(Self::on_toggle_favorite))
             .on_action(cx.listener(Self::on_new_page))
             .on_action(cx.listener(Self::on_new_sub_page))

--- a/src/app.rs
+++ b/src/app.rs
@@ -3768,6 +3768,9 @@ impl AppView {
                     }
                     cx.notify();
                 }
+                // Terminal load failure — the viewer renders the message
+                // itself; just repaint the chrome around it.
+                crate::pdf::PdfEvent::LoadFailed => cx.notify(),
                 crate::pdf::PdfEvent::FieldClicked { field, bounds } => {
                     this.on_pdf_field_clicked(
                         event_path.clone(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1206,6 +1206,29 @@ impl AppView {
                 self.load_page_editor(id, window, cx);
             }
         }
+        // A page deleted in another window closes its tabs here too — its
+        // ghost would otherwise stay open and editable, saving into a row
+        // that no longer exists. Only a definite `Ok(None)` counts; a DB
+        // error must not eat tabs. (The pinned Journal at 0 is never a page.)
+        let mut removed = false;
+        let mut i = self.tabs.len();
+        while i > 1 {
+            i -= 1;
+            if let TabKind::Page(pid) = self.tabs[i].kind
+                && matches!(self.db.get_page(pid), Ok(None))
+            {
+                self.tabs.remove(i);
+                if self.active > i {
+                    self.active -= 1;
+                } else if self.active == i {
+                    self.active = self.active.min(self.tabs.len() - 1);
+                }
+                removed = true;
+            }
+        }
+        if removed {
+            self.activate_tab(self.active, window, cx);
+        }
         // Refresh the active page's backlinks (another window may have edited a
         // page that links here) and the sidebar list (a page may have been
         // created / renamed / deleted elsewhere).

--- a/src/ui/all_pages.rs
+++ b/src/ui/all_pages.rs
@@ -5,7 +5,7 @@
 //! and thousands of day rows would swamp the list.
 
 use gpui::{
-    ClickEvent, Context, InteractiveElement, IntoElement, ParentElement,
+    ClickEvent, Context, InteractiveElement, IntoElement, ParentElement, SharedString,
     StatefulInteractiveElement, Styled, div, px,
 };
 
@@ -28,8 +28,8 @@ pub enum KindFilter {
 /// What a row is — and, for a PDF, where it lives.
 #[derive(Clone)]
 enum Row {
-    Page,
-    Board,
+    Page(i64),
+    Board(i64),
     Pdf(std::path::PathBuf),
 }
 
@@ -55,7 +55,7 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
         rows.extend(app.pages().iter().map(|p| {
             (
                 p.title.clone(),
-                Row::Page,
+                Row::Page(p.id),
                 local_date(&p.created_at),
                 local_date(&p.updated_at),
             )
@@ -65,7 +65,7 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
         rows.extend(app.whiteboards().iter().map(|w| {
             (
                 w.title.clone(),
-                Row::Board,
+                Row::Board(w.id),
                 local_date(&w.created_at),
                 local_date(&w.updated_at),
             )
@@ -164,56 +164,64 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
         let open_title = title.clone();
         let open_row = row.clone();
         let badge = match &row {
-            Row::Page => "Page",
-            Row::Board => "Whiteboard",
+            Row::Page(_) => "Page",
+            Row::Board(_) => "Whiteboard",
             Row::Pdf(_) => "PDF",
         };
-        list = list.child(
-            div()
-                .id(("all-pages-row", i))
-                .flex()
-                .flex_row()
-                .items_center()
-                .gap(px(12.0))
-                .px(px(10.0))
-                .py(px(6.0))
-                .rounded(px(6.0))
-                .cursor_pointer()
-                .hover(|s| s.bg(theme::hover()))
-                .on_click(
-                    cx.listener(move |this: &mut AppView, _: &ClickEvent, window, cx| {
-                        // Pages/boards route like a wiki-link (boards open
-                        // their canvas); a PDF opens its viewer directly.
-                        match &open_row {
-                            Row::Pdf(path) => this.open_pdf(path.clone(), window, cx),
-                            _ => this.open_page_title(&open_title, window, cx),
-                        }
-                    }),
-                )
-                .child(
+        let menu_target = match &row {
+            Row::Page(id) | Row::Board(id) => Some(*id),
+            Row::Pdf(_) => None,
+        };
+        let menu_title: SharedString = title.clone().into();
+        let row_el = div()
+            .id(("all-pages-row", i))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(12.0))
+            .px(px(10.0))
+            .py(px(6.0))
+            .rounded(px(6.0))
+            .cursor_pointer()
+            .hover(|s| s.bg(theme::hover()))
+            .on_click(
+                cx.listener(move |this: &mut AppView, _: &ClickEvent, window, cx| {
+                    // Pages/boards route like a wiki-link (boards open
+                    // their canvas); a PDF opens its viewer directly.
+                    match &open_row {
+                        Row::Pdf(path) => this.open_pdf(path.clone(), window, cx),
+                        _ => this.open_page_title(&open_title, window, cx),
+                    }
+                }),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .truncate()
+                    .text_size(px(14.0))
+                    .text_color(theme::text_primary())
+                    .child(title),
+            )
+            .child(date_cell(created))
+            .child(date_cell(updated))
+            .child(
+                div().w(px(92.0)).flex_shrink_0().flex().flex_row().child(
                     div()
-                        .flex_1()
-                        .min_w_0()
-                        .truncate()
-                        .text_size(px(14.0))
-                        .text_color(theme::text_primary())
-                        .child(title),
-                )
-                .child(date_cell(created))
-                .child(date_cell(updated))
-                .child(
-                    div().w(px(92.0)).flex_shrink_0().flex().flex_row().child(
-                        div()
-                            .px(px(8.0))
-                            .py(px(1.0))
-                            .rounded(px(10.0))
-                            .bg(theme::glass())
-                            .text_size(px(11.0))
-                            .text_color(theme::text_secondary())
-                            .child(badge),
-                    ),
+                        .px(px(8.0))
+                        .py(px(1.0))
+                        .rounded(px(10.0))
+                        .bg(theme::glass())
+                        .text_size(px(11.0))
+                        .text_color(theme::text_secondary())
+                        .child(badge),
                 ),
-        );
+            );
+        list = list.child(match menu_target {
+            // Pages and boards carry the shared page menu; PDFs are files.
+            Some(id) => super::with_page_menu(row_el, id, menu_title, app.is_favorite(id), cx),
+            None => row_el.into_any_element(),
+        });
     }
     if count == 0 {
         list = list.child(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,3 +20,54 @@ pub mod sidebar;
 pub mod slash_menu;
 pub mod tab_bar;
 pub mod table_picker;
+
+use gpui::{
+    AnyElement, Context, Div, InteractiveElement, IntoElement, MouseButton, SharedString, Stateful,
+};
+use gpui_component::menu::ContextMenuExt;
+
+use crate::actions::{
+    CopyPageContents, CopyPageLink, DeletePage, ExportPdf, NewSubPage, OpenInNewTab,
+    OpenInNewWindow, RenamePage, ToggleFavorite,
+};
+use crate::app::AppView;
+
+/// Attach THE page context menu to a row — one menu for every page-like
+/// surface (sidebar rows, All Pages, search results, backlinks), so the same
+/// actions are reachable wherever a page shows up. Right-click stores the
+/// target (`set_context_page`); the items dispatch the page actions.
+pub(crate) fn with_page_menu(
+    row: Stateful<Div>,
+    id: i64,
+    title: SharedString,
+    is_fav: bool,
+    cx: &mut Context<AppView>,
+) -> AnyElement {
+    let fav_label = if is_fav {
+        "Remove from favorites"
+    } else {
+        "Add to favorites"
+    };
+    row.on_mouse_down(
+        MouseButton::Right,
+        cx.listener(move |this: &mut AppView, _, _window, _cx| {
+            this.set_context_page(id, title.clone());
+        }),
+    )
+    .context_menu(move |menu, _window, _cx| {
+        menu.menu(fav_label, Box::new(ToggleFavorite))
+            .separator()
+            .menu("Open in new tab", Box::new(OpenInNewTab))
+            .menu("Open in new window", Box::new(OpenInNewWindow))
+            .separator()
+            .menu("Copy link", Box::new(CopyPageLink))
+            .menu("Copy contents", Box::new(CopyPageContents))
+            .separator()
+            .menu("Export as PDF…", Box::new(ExportPdf))
+            .separator()
+            .menu("New sub-page", Box::new(NewSubPage))
+            .menu("Rename page", Box::new(RenamePage))
+            .menu("Delete page", Box::new(DeletePage))
+    })
+    .into_any_element()
+}

--- a/src/ui/page_view.rs
+++ b/src/ui/page_view.rs
@@ -93,7 +93,7 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
                             this.child(sub_pages_section(&pe.title, &children, cx))
                         })
                         .when(!pe.backlinks.is_empty(), |this| {
-                            this.child(backlinks_section(&pe.backlinks, cx))
+                            this.child(backlinks_section(&pe.backlinks, app, cx))
                         })
                         .when(!pe.unlinked.is_empty(), |this| {
                             this.child(unlinked_section(&pe.unlinked, cx))
@@ -511,7 +511,11 @@ fn sub_page_item(
         })
 }
 
-fn backlinks_section(backlinks: &[Backlink], cx: &mut Context<AppView>) -> impl IntoElement {
+fn backlinks_section(
+    backlinks: &[Backlink],
+    app: &AppView,
+    cx: &mut Context<AppView>,
+) -> impl IntoElement {
     div()
         .mt(px(28.0))
         .pt_4()
@@ -531,7 +535,7 @@ fn backlinks_section(backlinks: &[Backlink], cx: &mut Context<AppView>) -> impl 
             backlinks
                 .iter()
                 .enumerate()
-                .map(|(i, bl)| backlink_row(i, bl, cx).into_any_element())
+                .map(|(i, bl)| backlink_row(i, bl, app, cx))
                 .collect::<Vec<_>>(),
         )
 }
@@ -624,9 +628,14 @@ fn unlinked_row(i: usize, bl: &Backlink, cx: &mut Context<AppView>) -> impl Into
         )
 }
 
-fn backlink_row(i: usize, bl: &Backlink, cx: &mut Context<AppView>) -> impl IntoElement {
+fn backlink_row(
+    i: usize,
+    bl: &Backlink,
+    app: &AppView,
+    cx: &mut Context<AppView>,
+) -> gpui::AnyElement {
     let page_id = bl.source_page_id;
-    div()
+    let row = div()
         .id(("bl", i))
         .px_3()
         .py_2()
@@ -653,5 +662,13 @@ fn backlink_row(i: usize, bl: &Backlink, cx: &mut Context<AppView>) -> impl Into
             cx.listener(move |this: &mut AppView, _: &ClickEvent, window, cx| {
                 this.open_page_id(page_id, window, cx);
             }),
-        )
+        );
+    // The linked-reference rows carry the shared page menu too.
+    super::with_page_menu(
+        row,
+        page_id,
+        bl.source_page_title.clone().into(),
+        app.is_favorite(page_id),
+        cx,
+    )
 }

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -8,7 +8,7 @@ use gpui::{
 };
 
 use crate::app::AppView;
-use crate::search::{Filter, Hit, Kind};
+use crate::search::{Filter, Hit, Kind, Target};
 use crate::theme;
 
 pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
@@ -16,7 +16,7 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
     let rows: Vec<_> = hits
         .iter()
         .enumerate()
-        .map(|(i, hit)| hit_row(i, hit, cx).into_any_element())
+        .map(|(i, hit)| hit_row(i, hit, app, cx))
         .collect();
 
     div()
@@ -121,7 +121,7 @@ fn chip_id(filter: Filter) -> &'static str {
     }
 }
 
-fn hit_row(i: usize, hit: &Hit, cx: &mut Context<AppView>) -> impl IntoElement {
+fn hit_row(i: usize, hit: &Hit, app: &AppView, cx: &mut Context<AppView>) -> gpui::AnyElement {
     let target = hit.target.clone();
     // Flat marker for boards (matches the chip); the colored file/image emoji
     // are dropped — the subtitle already names the kind ("PDF · in …").
@@ -129,7 +129,7 @@ fn hit_row(i: usize, hit: &Hit, cx: &mut Context<AppView>) -> impl IntoElement {
         Kind::Whiteboard => "▦",
         Kind::Page | Kind::Pdf | Kind::Image => "",
     };
-    div()
+    let row = div()
         .id(("hit", i))
         .px_3()
         .py_2()
@@ -167,5 +167,12 @@ fn hit_row(i: usize, hit: &Hit, cx: &mut Context<AppView>) -> impl IntoElement {
             cx.listener(move |this: &mut AppView, _: &ClickEvent, window, cx| {
                 this.open_search_hit(target.clone(), window, cx);
             }),
-        )
+        );
+    // Page-like hits carry the shared page menu; file hits are files.
+    match (&hit.kind, &hit.target) {
+        (Kind::Page | Kind::Whiteboard, Target::Page(id)) => {
+            super::with_page_menu(row, *id, hit.title.clone().into(), app.is_favorite(*id), cx)
+        }
+        _ => row.into_any_element(),
+    }
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -14,10 +14,7 @@ use gpui_component::{
     Icon, IconName, Sizable, input::Input, menu::ContextMenuExt, tooltip::Tooltip,
 };
 
-use crate::actions::{
-    DeletePage, ExportPdf, NewPage, NewSubPage, OpenInNewTab, OpenInNewWindow, RenamePage,
-    ToggleFavorite,
-};
+use crate::actions::NewPage;
 use crate::app::AppView;
 use crate::hierarchy::{self, PageNode};
 use crate::models::Page;
@@ -452,7 +449,7 @@ fn tree_row(
         row = row.child(chevron(full_path.clone(), collapsed, row_indent(depth), cx));
     }
     match node.id {
-        Some(id) => with_page_menu(row, id, full_path, is_fav, cx),
+        Some(id) => super::with_page_menu(row, id, full_path, is_fav, cx),
         None => row.into_any_element(),
     }
 }
@@ -487,7 +484,7 @@ fn favorite_row(
         let full = title.clone();
         row = row.tooltip(move |window, cx| Tooltip::new(full.clone()).build(window, cx));
     }
-    with_page_menu(row, page.id, title, true, cx)
+    super::with_page_menu(row, page.id, title, true, cx)
 }
 
 /// A "Whiteboards" section row: a board shown by its full title, opened by id
@@ -518,7 +515,7 @@ fn whiteboard_row(
         let full = title.clone();
         row = row.tooltip(move |window, cx| Tooltip::new(full.clone()).build(window, cx));
     }
-    with_page_menu(row, page.id, title, app.is_favorite(page.id), cx)
+    super::with_page_menu(row, page.id, title, app.is_favorite(page.id), cx)
 }
 
 /// The "new whiteboard" button in the sidebar's top toolbar — the Lucide
@@ -614,41 +611,6 @@ fn chevron(
                 this.toggle_collapsed(&toggle_path, cx);
             }),
         )
-}
-
-/// Attach the page right-click menu (favorite toggle / open elsewhere / rename /
-/// delete) to a built row. Shared by recent and favorite rows.
-fn with_page_menu(
-    row: Stateful<Div>,
-    id: i64,
-    full_path: SharedString,
-    is_fav: bool,
-    cx: &mut Context<AppView>,
-) -> AnyElement {
-    let fav_label = if is_fav {
-        "Remove from favorites"
-    } else {
-        "Add to favorites"
-    };
-    row.on_mouse_down(
-        MouseButton::Right,
-        cx.listener(move |this: &mut AppView, _, _window, _cx| {
-            this.set_context_page(id, full_path.clone());
-        }),
-    )
-    .context_menu(move |menu, _window, _cx| {
-        menu.menu(fav_label, Box::new(ToggleFavorite))
-            .separator()
-            .menu("Open in new tab", Box::new(OpenInNewTab))
-            .menu("Open in new window", Box::new(OpenInNewWindow))
-            .separator()
-            .menu("Export as PDF…", Box::new(ExportPdf))
-            .separator()
-            .menu("New sub-page", Box::new(NewSubPage))
-            .menu("Rename page", Box::new(RenamePage))
-            .menu("Delete page", Box::new(DeletePage))
-    })
-    .into_any_element()
 }
 
 /// A collapsible section header: the uppercase title, a hairline rule, and a

--- a/src/ui/tab_bar.rs
+++ b/src/ui/tab_bar.rs
@@ -10,8 +10,11 @@ use gpui_component::menu::ContextMenuExt;
 use gpui_component::tab::{Tab, TabBar};
 use gpui_component::tooltip::Tooltip;
 
-use crate::actions::OpenInNewWindow;
-use crate::app::{AppView, DraggingTab, GlobalDraggingTab, TabDrag};
+use crate::actions::{
+    CopyPageContents, CopyPageLink, DeletePage, NewSubPage, OpenInNewWindow, RenamePage,
+    ToggleFavorite,
+};
+use crate::app::{AppView, DraggingTab, GlobalDraggingTab, TabDrag, TabKind};
 use crate::theme;
 
 pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
@@ -23,6 +26,12 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
     for (i, tab) in app.tabs.iter().enumerate() {
         let kind = tab.kind.clone();
         let title = tab.title.clone();
+        let menu_title = title.clone();
+        let is_page = matches!(tab.kind, TabKind::Page(_));
+        let fav_label = match &tab.kind {
+            TabKind::Page(pid) if app.is_favorite(*pid) => "Remove from favorites",
+            _ => "Add to favorites",
+        };
         // Cap the label: a long name (e.g. a PDF filename) is ellipsized, with the
         // full title in a tooltip. A "(highlights)" tab keeps that suffix visible.
         let (display, truncated) = tab_label(&title);
@@ -44,6 +53,11 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
                 MouseButton::Right,
                 cx.listener(move |this: &mut AppView, _ev, _window, _cx| {
                     this.set_context_target(kind.clone());
+                    // A page tab also arms the shared page actions (copy /
+                    // favorite / rename / delete) with its page.
+                    if let TabKind::Page(pid) = kind {
+                        this.set_context_page(pid, menu_title.clone());
+                    }
                 }),
             );
         if truncated {
@@ -51,9 +65,24 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
             overlay =
                 overlay.tooltip(move |window, cx| Tooltip::new(full.clone()).build(window, cx));
         }
-        let overlay = overlay.context_menu(|menu, _window, _cx| {
-            menu.menu("Open in new window", Box::new(OpenInNewWindow))
-                .menu("Export as PDF…", Box::new(crate::actions::ExportPdf))
+        let overlay = overlay.context_menu(move |menu, _window, _cx| {
+            let menu = menu
+                .menu("Open in new window", Box::new(OpenInNewWindow))
+                .menu("Export as PDF…", Box::new(crate::actions::ExportPdf));
+            // Page tabs grow the shared page verbs; the pinned Journal and
+            // PDF tabs keep the slim menu.
+            if !is_page {
+                return menu;
+            }
+            menu.separator()
+                .menu("Copy link", Box::new(CopyPageLink))
+                .menu("Copy contents", Box::new(CopyPageContents))
+                .separator()
+                .menu(fav_label, Box::new(ToggleFavorite))
+                .separator()
+                .menu("New sub-page", Box::new(NewSubPage))
+                .menu("Rename page", Box::new(RenamePage))
+                .menu("Delete page", Box::new(DeletePage))
         });
         let mut t = Tab::new()
             .label(display)


### PR DESCRIPTION
The UX-papercuts batch from the 2026-07-08 four-way audit (editor interaction paths, cross-view parity, app flows, known-gap mining) — every item on the list, all live-tested on macOS.

## Editor (gpui-editor)
- Smart Home on list/task/quote lines (content start first; second press = true start)
- Enter / backspace-join / forward-delete around property panels seat the in-place form instead of revealing raw `key:: value` source; exiting a block editor at the end of the note creates a fresh line below (the old fallback parked the caret ON the block, un-rendering it)
- Double/triple-click on `$$` blocks and property panels no longer word/line-select the hidden source under the seated editor
- Backspace/Delete at a formula boundary removes the whole formula atomically (like images), including a `<!-- math:ALIGN -->` marker line
- ⌥←/→ word-jumps route into constructs the way plain arrows do
- A selection swept across a rendered block (math, mermaid, property panel, code fence) reveals its source region-wide, so what's highlighted is what a copy carries

## App
- Error-dialog sweep: rename collisions report inline in the rename dialog (a stacked dialog pops the first off gpui-component's dialog stack), inline-title collisions alert, and delete/math-export/PDF-form-write/image-import failures all speak
- Unified right-click: one shared page menu (sidebar, All Pages, search results, backlinks, page tabs) + Copy link / Copy contents; editor text menu (Cut/Copy/Paste + spelling suggestions in one menu); property panels get Edit/Delete property; all custom menus compacted to match the small-chrome convention
- A page deleted in one window closes its ghost tabs in every window

## Crates
- gpui-pdf: terminal load failures render an error pane + emit `PdfEvent::LoadFailed` (no more eternal "Loading PDF…"); `is_pdf` sees through URL queries; API.md synced
- os-spellcheck: Windows follows the system UI language (`GetUserDefaultLocaleName` + `IsSupported`, en-US fallback) — **the Windows CI leg is the real compile check here**
- ratex-gpui: the math editor rasterizes at the window's real scale factor instead of a hard-coded 2.0

Two audit items closed as false positives during verification: the reader already renders PDF chips (host-side `ImageRenderer` classifies them), and embed image-resize can't write the wrong page (embeds use the grip-free `embed_renderer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)