### PR TITLE
UX bug fixes — slash menu scroll, math export alignment, chip parity, dead controls

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,6 +53,10 @@ release notes; prune after 0.7.0 ships.
   exists), then `.small()` the page menus to match the custom ones
 
 ## Notes & navigation
+- [ ] **Find in the journal feed** — a real `⌘F` find bar on the Journal tab
+  (today it routes to the global search): match + step across every loaded
+  day's rendered text, reusing `gpui-markdown`'s `find_matches`/`search` like
+  the page find bar, but with per-day match bookkeeping and feed scrolling
 - [ ] Aliases: offer a page's aliases as suggestions in `[[` autocomplete
 - [ ] Block references: **"Copy block link"** — auto-generate a ` ^id` on a line
   (right-click / command) and put `[[Page#^id]]` on the clipboard, so linking to

--- a/crates/gpui-editor/API.md
+++ b/crates/gpui-editor/API.md
@@ -17,6 +17,7 @@ crate root; nothing from `gpui-markdown` is re-exported.)
 | [`bind_keys`](#fn-bind_keys) | fn | `fn bind_keys(cx: &mut App)` | Bind the editing keys (once, at startup) |
 | [`LINE_HEIGHT_RATIO`](#const-line_height_ratio) | const | `const LINE_HEIGHT_RATIO: f32 = 1.45` | Row height as a multiple of the font size |
 | [`mermaid_sources`](#fn-mermaid_sources) | fn | `fn mermaid_sources(content: &str) -> Vec<SharedString>` | Every ` ```mermaid ` block's source, for pre-rendering |
+| [`paint_doc_icon`](#fn-paint_doc_icon) | fn | `fn paint_doc_icon(x, y, w, h: Pixels, color: Hsla, window: &mut Window)` | The file chips' line-art document glyph |
 | [`math_sources`](#fn-math_sources) | fn | `fn math_sources(content: &str) -> Vec<SharedString>` | Every `$$…$$` block's LaTeX, for pre-rendering |
 | [`inline_math_sources`](#fn-inline_math_sources) | fn | `fn inline_math_sources(content: &str) -> Vec<SharedString>` | Every inline `$…$` formula's LaTeX, for pre-rendering |
 | [`EditorState`](#struct-editorstate) | struct | — | The editor entity (text, caret, undo, layout) |
@@ -117,6 +118,21 @@ height from its **own** font (not the ambient `window.line_height()`, which
 tracks the host's UI text style and would leave caret and rows mismatched
 against differently-sized editor text). Public so a host's scroll math (e.g.
 click-to-edit caret prediction) can mirror the editor's row heights exactly.
+
+---
+
+## `fn paint_doc_icon`
+
+```rust
+pub fn paint_doc_icon(x: Pixels, y: Pixels, w: Pixels, h: Pixels, color: Hsla, window: &mut Window)
+```
+
+Paint the flat, line-art document glyph (a page with a folded top-right corner
+and two text lines) the editor draws on its file chips, in `color` at the
+given bounds. Stroke-drawn — not a font emoji — so it reads flat and on-theme
+at any text size. Public so a host's read-only view can draw the identical
+icon on its own file chips (cross-view parity); the editor sizes it
+`h = font_size × 0.92`, `w = h × 0.74`.
 
 ---
 

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -6145,7 +6145,10 @@ fn build_prop_panel(
         rows.push((SharedString::from(k.to_string()), icon, segs));
     }
     let key_w = key_indent + key_w + px(20.);
-    let width = key_w + val_w + px(10.);
+    // 10px inner padding on BOTH sides: values start at key_w + 10 (see
+    // `paint_prop_panel`), so the width needs 10 + val_w + 10 past key_w or
+    // the hover border sits flush against the last value character.
+    let width = key_w + val_w + px(20.);
     let row_h = font_size * LINE_HEIGHT_RATIO + px(8.);
     let height = row_h * rows.len() as f32;
     PropPanel {

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -6413,8 +6413,17 @@ fn paint_chip(
 
 /// Paint a flat, line-art document glyph (a page with a folded top-right corner +
 /// two text lines) in `color`, the chip's file icon. Drawn with strokes — not a
-/// font emoji — so it reads flat and on-theme at the text's size.
-fn paint_doc_icon(x: Pixels, y: Pixels, w: Pixels, h: Pixels, color: Hsla, window: &mut Window) {
+/// font emoji — so it reads flat and on-theme at the text's size. Public so a
+/// host's read-only view can draw the identical icon on its own file chips
+/// (cross-view parity).
+pub fn paint_doc_icon(
+    x: Pixels,
+    y: Pixels,
+    w: Pixels,
+    h: Pixels,
+    color: Hsla,
+    window: &mut Window,
+) {
     let f = w * 0.33; // folded-corner size
     // Page silhouette, with the top-right corner cut away for the fold.
     let mut outline = PathBuilder::stroke(px(1.3));

--- a/src/app.rs
+++ b/src/app.rs
@@ -8554,15 +8554,14 @@ impl Render for AppView {
             )
             .on_action(
                 cx.listener(|this: &mut AppView, _: &FindInPage, window, cx| {
-                    // ⌘F: find in the active page's rendered text. Only on a Page tab —
-                    // PDFs handle ⌘F in the viewer; the journal feed uses ⌘⇧F.
-                    if matches!(
-                        this.tabs.get(this.active).map(|t| &t.kind),
-                        Some(TabKind::Page(_))
-                    ) {
-                        this.open_page_find(window, cx);
-                    } else {
-                        cx.propagate();
+                    // ⌘F: find in the active page's rendered text on a Page tab.
+                    // On the Journal it routes to the global search — the feed's
+                    // find (silently eating the key made the menu item look
+                    // broken). PDFs handle ⌘F in the viewer.
+                    match this.tabs.get(this.active).map(|t| &t.kind) {
+                        Some(TabKind::Page(_)) => this.open_page_find(window, cx),
+                        Some(TabKind::Journal) => this.focus_global_search(window, cx),
+                        _ => cx.propagate(),
                     }
                 }),
             )

--- a/src/export.rs
+++ b/src/export.rs
@@ -82,6 +82,10 @@ struct Pdf {
     y: f64,
     /// Unique names for embedded images (the crate keys them by name).
     image_n: usize,
+    /// Horizontal alignment (0 left, 0.5 center, 1 right) set by the last
+    /// `<!-- math:ALIGN -->` marker, consumed by the formula that follows.
+    /// Center absent a marker — the app's and LaTeX's default.
+    math_align: f64,
 }
 
 impl Pdf {
@@ -93,6 +97,7 @@ impl Pdf {
             page: Page::new(PAGE_W, PAGE_H),
             y: PAGE_H - MARGIN,
             image_n: 0,
+            math_align: 0.5,
         }
     }
 
@@ -141,7 +146,8 @@ impl Pdf {
                     && let Some(png) =
                         ratex_gpui::render::render_latex_to_png(&m.value, MATH_PT as f32, MATH_DPR)
                 {
-                    self.png(png, MATH_DPR as f64, indent);
+                    let align = std::mem::replace(&mut self.math_align, 0.5);
+                    self.png_aligned(png, MATH_DPR as f64, indent, align);
                     return;
                 }
                 // Standalone images render as images; everything else flows.
@@ -205,7 +211,21 @@ impl Pdf {
             // Comments never print — they carry the app's control markers
             // (`<!-- math:left -->` alignment, table styles) and are invisible
             // in every view. Other raw HTML prints literally, like the reader.
-            mdast::Node::Html(h) if h.value.trim_start().starts_with("<!--") => {}
+            mdast::Node::Html(h) if h.value.trim_start().starts_with("<!--") => {
+                // …but a math-alignment marker steers the formula below it.
+                if let Some(inner) = h
+                    .value
+                    .trim()
+                    .strip_prefix("<!--")
+                    .and_then(|v| v.strip_suffix("-->"))
+                {
+                    self.math_align = match inner.trim() {
+                        "math:left" => 0.0,
+                        "math:right" => 1.0,
+                        _ => self.math_align,
+                    };
+                }
+            }
             mdast::Node::Html(h) => {
                 let runs = vec![(h.value.clone(), Style::default())];
                 self.runs(&runs, BODY_SIZE, indent);
@@ -214,8 +234,9 @@ impl Pdf {
             mdast::Node::Math(m) => {
                 // Typeset like the reader (RaTeX → PNG); the LaTeX source in
                 // monospace only if typesetting fails.
+                let align = std::mem::replace(&mut self.math_align, 0.5);
                 match ratex_gpui::render::render_latex_to_png(&m.value, MATH_PT as f32, MATH_DPR) {
-                    Some(png) => self.png(png, MATH_DPR as f64, indent),
+                    Some(png) => self.png_aligned(png, MATH_DPR as f64, indent, align),
                     None => self.code_block(&format!("$$ {} $$", m.value), indent),
                 }
             }
@@ -682,6 +703,12 @@ impl Pdf {
     /// Embed pre-rendered PNG bytes at `1/oversample` of their pixel size
     /// (96dpi px → pt), capped to the content width.
     fn png(&mut self, png: Vec<u8>, oversample: f64, indent: f64) {
+        self.png_aligned(png, oversample, indent, 0.0);
+    }
+
+    /// Like [`png`](Self::png), placed at `align` across the content width
+    /// (0 left, 0.5 center, 1 right) — display math carries an alignment.
+    fn png_aligned(&mut self, png: Vec<u8>, oversample: f64, indent: f64, align: f64) {
         let Ok(img) = Image::from_png_data(png) else {
             return;
         };
@@ -697,9 +724,8 @@ impl Pdf {
         self.image_n += 1;
         let name = format!("img{}", self.image_n);
         self.page.add_image(&name, img);
-        let _ = self
-            .page
-            .draw_image(&name, MARGIN + indent, self.y - h, w, h);
+        let x = MARGIN + indent + (CONTENT_W - indent - w) * align;
+        let _ = self.page.draw_image(&name, x, self.y - h, w, h);
         self.gap(h + BODY_SIZE * 0.5);
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -78,13 +78,22 @@ fn theme_opts(app: &WeakEntity<AppView>, cx: &Context<SettingsView>) -> (Vec<Opt
     }
 }
 
-/// Font-dropdown choices: Default, then every installed family (including the
-/// user-added ones registered at startup / via "Add font file…").
+/// Font-dropdown choices: Default (named for what it resolves to — the active
+/// theme's font, else the system face), then every installed family (including
+/// the user-added ones registered at startup / via "Add font file…").
 fn font_opts(app: &WeakEntity<AppView>, cx: &Context<SettingsView>) -> (Vec<Opt>, String) {
     let mut names = cx.text_system().all_font_names();
     names.sort();
     names.dedup();
-    let mut opts = vec![Opt::new("", "Default")];
+    let default_font = app.upgrade().and_then(|a| {
+        let a = a.read(cx);
+        a.skins()
+            .iter()
+            .find(|s| s.id == a.active_skin_id())
+            .and_then(|s| s.font.clone())
+    });
+    let default_label = format!("Default ({})", default_font.as_deref().unwrap_or("System"));
+    let mut opts = vec![Opt::new("", &default_label)];
     opts.extend(names.iter().map(|n| Opt::new(n, n)));
     let current = app
         .upgrade()

--- a/src/ui/image.rs
+++ b/src/ui/image.rs
@@ -221,38 +221,59 @@ fn build(
 
 /// A `![](file.pdf)` reference renders as a clickable chip that opens the PDF in
 /// its own viewer tab (keeping the note light — the pages live in the viewer).
+/// Styled to pixel-match the WYSIWYG editor's file chip (`paint_chip` in
+/// gpui-editor): same tokens, geometry, and line-art document glyph.
 fn pdf_chip(info: &ImageInfo, weak: WeakEntity<AppView>) -> AnyElement {
     let src = info.src.clone();
     let label = crate::pdf::resolve_path(&src)
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
         .unwrap_or_else(|| src.to_string());
-    div()
+    // The reader's body text size; chip metrics mirror the editor's
+    // (row height ratio, 10px x-pad, 7px icon gap, font-scaled icon).
+    let fs = px(16.0);
+    let icon_h = fs * 0.92;
+    let icon_w = icon_h * 0.74;
+    let icon_color = theme::accent();
+    let icon = canvas(
+        |_, _, _| (),
+        move |bounds, _, window, _| {
+            gpui_editor::paint_doc_icon(
+                bounds.origin.x,
+                bounds.origin.y,
+                bounds.size.width,
+                bounds.size.height,
+                icon_color,
+                window,
+            );
+        },
+    )
+    .w(icon_w)
+    .h(icon_h);
+    let chip = div()
         .id(SharedString::from(format!("pdf-chip:{src}")))
         .my(px(4.0))
-        .px_3()
-        .py_2()
+        .h(fs * gpui_editor::LINE_HEIGHT_RATIO + px(10.0))
+        .px(px(10.0))
         .rounded(px(6.0))
         .border_1()
-        .border_color(theme::border_subtle())
+        .border_color(theme::text_tertiary())
         .bg(theme::glass())
         .cursor_pointer()
         .hover(|h| h.bg(theme::glass_strong()))
         .flex()
         .flex_row()
         .items_center()
-        .gap_2()
-        .child("📄")
-        .child(
-            div()
-                .text_color(theme::accent())
-                .child(format!("{label} — open")),
-        )
+        .gap(px(7.0))
+        .child(icon)
+        .child(div().text_size(fs).text_color(theme::accent()).child(label))
         .on_click(move |_ev, window, cx| {
             if let Some(path) = crate::pdf::resolve_path(&src) {
                 let _ = weak.update(cx, |this, cx| this.open_pdf(path, window, cx));
             }
-        })
-        .into_any_element()
+        });
+    // A row wrapper so the chip hugs its content (a bare block child would
+    // stretch to the column width) — the editor's chip hugs too.
+    div().flex().child(chip).into_any_element()
 }
 
 /// Outcome of resolving a local image through the downscaling store.

--- a/src/ui/slash_menu.rs
+++ b/src/ui/slash_menu.rs
@@ -11,11 +11,15 @@ use crate::app::AppView;
 use crate::slash::{ItemKind, Slash, Trigger};
 use crate::theme;
 
-/// Row height (px) + the height cap, shared with `AppView::scroll_slash_into_view` so the
-/// keyboard scroll-into-view and the scrollbar thumb agree on the menu's geometry.
-pub const ITEM_H: f32 = 25.0;
-pub const MAX_H: f32 = 280.0;
+/// Fixed row height (px) — rows are exactly this tall (`.h(ITEM_H)`), so the
+/// keyboard scroll-into-view (`AppView::scroll_slash_into_view`) and the
+/// scrollbar thumb below always agree with the painted list. (They drifted
+/// ~4px/row when rows sized themselves from text + padding.)
+pub const ITEM_H: f32 = 28.0;
 const PAD: f32 = 4.0;
+/// Height cap = an exact number of rows, so the bottom row is never
+/// half-clipped and arrow-key scrolling advances by whole rows.
+pub const MAX_H: f32 = 2.0 * PAD + 10.0 * ITEM_H;
 /// Scrollable viewport height (the cap minus top/bottom padding).
 pub const VIEW_H: f32 = MAX_H - 2.0 * PAD;
 
@@ -61,7 +65,8 @@ pub fn render(
             col = col.child(
                 div()
                     .px_3()
-                    .py_1()
+                    .h(px(ITEM_H))
+                    .flex_none()
                     .text_size(px(13.0))
                     .flex()
                     .flex_row()

--- a/src/ui/tab_bar.rs
+++ b/src/ui/tab_bar.rs
@@ -18,10 +18,18 @@ use crate::app::{AppView, DraggingTab, GlobalDraggingTab, TabDrag, TabKind};
 use crate::theme;
 
 pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
+    let weak = cx.entity().downgrade();
     let mut bar = TabBar::new("tabs")
         .menu(true)
         .track_scroll(&app.tab_scroll)
-        .selected_index(app.active);
+        .selected_index(app.active)
+        // The overflow dropdown (and only it) reports picks through the
+        // bar-level handler — the per-`Tab` on_click below never fires for
+        // menu items, so without this an overflow pick did nothing.
+        .on_click(move |ix: &usize, window, cx| {
+            let ix = *ix;
+            let _ = weak.update(cx, |this, cx| this.activate_tab(ix, window, cx));
+        });
 
     for (i, tab) in app.tabs.iter().enumerate() {
         let kind = tab.kind.clone();


### PR DESCRIPTION
## What

Seven small user-reported fixes, one commit each:

- **Slash menu** — rows sized themselves from text + padding (~29px) while the scroll math assumed 25px, so arrow-key scrolling kicked in a line late, the thumb drifted, and the height cap clipped the bottom row. Rows are now a fixed 28px and the cap is an exact ten rows: whole-line scrolling exactly when the selection would leave view.
- **Property rows (WYSIWYG)** — the hover box had zero right padding; now 10px both sides.
- **PDF export** — display math honors `<!-- math:left/right -->` and centers by default, matching the reader (it always drew left).
- **Settings → Font** — "Default" names what it resolves to: "Default (theme font)" / "Default (System)".
- **Find in Page** — silently ate ⌘F on the Journal tab, which made the Edit-menu item look broken; it now routes to the global search there (the feed's find). Page tabs keep the existing find bar. A true in-feed find bar is tracked in TODO.
- **Tab overflow menu** — picks now activate the tab (gpui-component reports them through the bar-level `on_click`, which was never wired).
- **Reader PDF chip** — pixel-matches the WYSIWYG pill: shared line-art glyph (`gpui_editor::paint_doc_icon` is now public, API.md updated), same tokens/geometry, no "— open", hugs content.

## Testing

All seven live-verified on macOS; `fmt` / `clippy -D warnings` / `test --workspace` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)