### PR TITLE
PDF viewer: area highlights, fit zoom modes, failure hand-off, choice dropdowns

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -93,7 +93,7 @@ per-notebook settings sync.
 ## Import & export
 - [ ] Logseq import follow-ups: an in-progress indicator with real progress (it's a bare "may take a minute" dialog today); surface imported pages in the sidebar right away (a fresh DB shows "No recent pages" until things are visited)
 - [ ] PDF: **fit-width / fit-page** zoom modes (zoom is free-scale only today)
-- [ ] PDF: **area (image-region) highlights** — only text-anchored highlights exist so far; a box-drag over a scanned region would cover figures / pages with no text layer
+- [x] PDF: **area (image-region) highlights** — the `⬚` tool beside the pen: a box-drag marks a page region (figures / scans, no text layer needed), stored on the highlights page as an `@area(x,y,w,h)` quote token (same colors, jump-links, and flash); `Highlight.region` + `toggle_area_mode`/`CreateAreaFn` in gpui-pdf. See `crates/gpui-pdf/src/lib.rs`, `src/pdf.rs`
 - [ ] PDF: **garbled quotes from decorative fonts** — some heading fonts decode to shifted/garbled unicode (e.g. a −29 glyph shift), so a highlight on them stores garbled text (it still re-locates, since garbled matches garbled); body text is correct. Upstream hayro limitation
 - [ ] PDF: **graceful fallback for unsupported files** — encrypted PDFs now open behind a password prompt (RC4 / AES-128 / AES-256), but hayro can still fail on an *unsupported* encryption algorithm (e.g. a public-key / certificate handler) or exotic transparency / blend modes; on such a load/parse failure, show an "Open in default app" affordance (hand off to the OS viewer) instead of a blank pane
 - [ ] PDF forms, follow-ups — the AcroForm feature SHIPPED 2026-07-06 (see

--- a/TODO.md
+++ b/TODO.md
@@ -95,7 +95,7 @@ per-notebook settings sync.
 - [x] PDF: **fit-width / fit-page** zoom modes — sticky `↔`/`⤢` header controls (re-fit on viewport resize; any manual zoom takes over); `PdfView::fit_width`/`fit_page` in gpui-pdf
 - [x] PDF: **area (image-region) highlights** — the `⬚` tool beside the pen: a box-drag marks a page region (figures / scans, no text layer needed), stored on the highlights page as an `@area(x,y,w,h)` quote token (same colors, jump-links, and flash); `Highlight.region` + `toggle_area_mode`/`CreateAreaFn` in gpui-pdf. See `crates/gpui-pdf/src/lib.rs`, `src/pdf.rs`
 - [ ] PDF: **garbled quotes from decorative fonts** — some heading fonts decode to shifted/garbled unicode (e.g. a −29 glyph shift), so a highlight on them stores garbled text (it still re-locates, since garbled matches garbled); body text is correct. Upstream hayro limitation
-- [ ] PDF: **graceful fallback for unsupported files** — encrypted PDFs now open behind a password prompt (RC4 / AES-128 / AES-256), but hayro can still fail on an *unsupported* encryption algorithm (e.g. a public-key / certificate handler) or exotic transparency / blend modes; on such a load/parse failure, show an "Open in default app" affordance (hand off to the OS viewer) instead of a blank pane
+- [x] PDF: **graceful fallback for unsupported files** — the load-failure pane now offers **"Open in system viewer"** (host launches the OS default app via `open`/`start`/`xdg-open`); `PdfView::set_on_open_external` keeps the crate host-agnostic
 - [ ] PDF forms, follow-ups — the AcroForm feature SHIPPED 2026-07-06 (see
   Completed): remaining niceties are **choice-field dropdowns** (Ch fields
   edit as free text today; `FormField::options` already carries `/Opt`),

--- a/TODO.md
+++ b/TODO.md
@@ -97,8 +97,8 @@ per-notebook settings sync.
 - [ ] PDF: **garbled quotes from decorative fonts** — some heading fonts decode to shifted/garbled unicode (e.g. a −29 glyph shift), so a highlight on them stores garbled text (it still re-locates, since garbled matches garbled); body text is correct. Upstream hayro limitation
 - [x] PDF: **graceful fallback for unsupported files** — the load-failure pane now offers **"Open in system viewer"** (host launches the OS default app via `open`/`start`/`xdg-open`); `PdfView::set_on_open_external` keeps the crate host-agnostic
 - [ ] PDF forms, follow-ups — the AcroForm feature SHIPPED 2026-07-06 (see
-  Completed): remaining niceties are **choice-field dropdowns** (Ch fields
-  edit as free text today; `FormField::options` already carries `/Opt`),
+  Completed): choice-field dropdowns DONE (the seat editor lists /Opt
+  entries — click commits, typing still covers editable combos); remaining:
   synthesized-appearance fidelity (`/DA` fonts, `/Q` quadding, comb fields,
   multiline), and **filing the two hayro gaps upstream** (state-dict `/AP /N`
   selected by `/AS`; `NeedAppearances` synthesis) so the lopdf normalization

--- a/TODO.md
+++ b/TODO.md
@@ -92,7 +92,7 @@ per-notebook settings sync.
 
 ## Import & export
 - [ ] Logseq import follow-ups: an in-progress indicator with real progress (it's a bare "may take a minute" dialog today); surface imported pages in the sidebar right away (a fresh DB shows "No recent pages" until things are visited)
-- [ ] PDF: **fit-width / fit-page** zoom modes (zoom is free-scale only today)
+- [x] PDF: **fit-width / fit-page** zoom modes — sticky `↔`/`⤢` header controls (re-fit on viewport resize; any manual zoom takes over); `PdfView::fit_width`/`fit_page` in gpui-pdf
 - [x] PDF: **area (image-region) highlights** — the `⬚` tool beside the pen: a box-drag marks a page region (figures / scans, no text layer needed), stored on the highlights page as an `@area(x,y,w,h)` quote token (same colors, jump-links, and flash); `Highlight.region` + `toggle_area_mode`/`CreateAreaFn` in gpui-pdf. See `crates/gpui-pdf/src/lib.rs`, `src/pdf.rs`
 - [ ] PDF: **garbled quotes from decorative fonts** — some heading fonts decode to shifted/garbled unicode (e.g. a −29 glyph shift), so a highlight on them stores garbled text (it still re-locates, since garbled matches garbled); body text is correct. Upstream hayro limitation
 - [ ] PDF: **graceful fallback for unsupported files** — encrypted PDFs now open behind a password prompt (RC4 / AES-128 / AES-256), but hayro can still fail on an *unsupported* encryption algorithm (e.g. a public-key / certificate handler) or exotic transparency / blend modes; on such a load/parse failure, show an "Open in default app" affordance (hand off to the OS viewer) instead of a blank pane

--- a/crates/gpui-pdf/API.md
+++ b/crates/gpui-pdf/API.md
@@ -56,6 +56,8 @@ public. Items in the **Feature** column require that Cargo feature (`search` imp
 | [`PdfView::set_on_highlight`](#pdfviewset_on_highlight) | method | markup | `fn set_on_highlight(&mut self, handler: HighlightClickFn)` | Click handler for a highlight |
 | [`PdfView::set_on_create_highlight`](#pdfviewset_on_create_highlight) | method | markup | `fn set_on_create_highlight(&mut self, handler: CreateHighlightFn)` | Handler for a finished drag-selection |
 | [`PdfView::toggle_select_mode`](#pdfviewtoggle_select_mode) | method | markup | `fn toggle_select_mode(&mut self, cx: &mut Context<Self>)` | Toggle drag-to-highlight mode |
+| [`PdfView::toggle_area_mode`](#pdfviewtoggle_area_mode) | method | markup | `fn toggle_area_mode(&mut self, cx: &mut Context<Self>)` | Toggle drag-a-box area mode |
+| [`PdfView::set_on_create_area`](#pdfviewset_on_create_area) | method | markup | `fn set_on_create_area(&mut self, handler: CreateAreaFn, cx: &mut Context<Self>)` | Handler for a finished area drag |
 | [`PdfView::set_highlight_palette`](#pdfviewset_highlight_palette) | method | markup | `fn set_highlight_palette(&mut self, palette: Vec<(SharedString, Hsla)>, cx: &mut Context<Self>)` | Colors for the picker |
 | [`PdfView::reveal_highlight`](#pdfviewreveal_highlight) | method | markup | `fn reveal_highlight(&mut self, page: usize, cx: &mut Context<Self>)` | Scroll to a page's highlight and flash it |
 | [`PdfView::toggle_search`](#pdfviewtoggle_search) | method | search | `fn toggle_search(&mut self, cx: &mut Context<Self>)` | Open/close the find bar |
@@ -70,6 +72,7 @@ public. Items in the **Feature** column require that Cargo feature (`search` imp
 | [`Highlight`](#struct-highlight) | struct | markup | `{ id: u64, page: usize, quote: String, occurrence: usize, color: Hsla }` | A quote-anchored highlight to draw |
 | [`HighlightClickFn`](#type-highlightclickfn) | type alias | markup | `Rc<dyn Fn(u64, &mut Window, &mut App)>` | Highlight click callback |
 | [`CreateHighlightFn`](#type-createhighlightfn) | type alias | markup | `Rc<dyn Fn(usize, String, usize, SharedString, &mut Window, &mut App)>` | Drag-selection-finished callback |
+| [`CreateAreaFn`](#type-createareafn) | type alias | markup | `Rc<dyn Fn(usize, NormRect, SharedString, &mut Window, &mut App)>` | Area-drag-finished callback |
 | [`NormRect`](#struct-normrect) | struct | markup | `{ x, y, w, h: f32 }` | Rect in normalized (0..1) page coords |
 | [`NormPoint`](#struct-normpoint) | struct | markup | `{ x, y: f32 }` | Point in normalized page coords |
 | [`Selection`](#struct-selection) | struct | markup | `{ quote: String, occurrence: usize, rects: Vec<NormRect> }` | A resolved drag selection |
@@ -972,6 +975,46 @@ cancels any in-progress selection and hides the picker. While on, every visible
 page extracts its text layer so drags can select anywhere. Also bound to ⌘⇧H.
 **Parameters** — `cx` only.
 
+### `PdfView::toggle_area_mode`
+
+*(`markup` feature)*
+
+```rust
+pub fn toggle_area_mode(&mut self, cx: &mut Context<Self>)
+```
+
+Toggle "area mode": like highlight mode, but a drag marks a rectangular page
+*region* (a figure, a scanned paragraph) instead of selecting text, firing
+[`CreateAreaFn`](#type-createareafn) on release — no text layer involved, so it
+works on pages with none. The header shows it as the `⬚` tool beside the pen;
+they share the color picker, and turning either mode on turns the other off.
+**Parameters** — `cx` only.
+
+### `PdfView::set_on_create_area`
+
+*(`markup` feature)*
+
+```rust
+pub fn set_on_create_area(&mut self, handler: CreateAreaFn, cx: &mut Context<Self>)
+```
+
+Set the handler invoked when an area (box) drag finishes. Without one, the drag
+draws feedback but nothing is stored.
+
+**Parameters**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `handler` | [`CreateAreaFn`](#type-createareafn) | Receives `(page, rect, color_label, &mut Window, &mut App)`; `rect` is normalized page coords. |
+| `cx` | `&mut Context<Self>` | — |
+
+**Guarantees & edge cases**
+
+- The same minimum-drag threshold as text highlights applies (a bare click never
+  creates one).
+- The rect is normalized against the page the drag *started* on; a drag that
+  leaves the page clamps to the last position over it.
+
 ### `PdfView::set_highlight_palette`
 
 *(`markup` feature)*
@@ -1191,18 +1234,22 @@ walk; no rasterization. Pure and thread-safe.
 
 ```rust
 pub struct Highlight {
-    pub id: u64,           // host identifier, echoed back on click
-    pub page: usize,       // 0-based page the quote is on
-    pub quote: String,     // the text to locate (case-/whitespace-insensitive)
-    pub occurrence: usize, // which occurrence on the page (0-based)
-    pub color: Hsla,       // fill color; drawn translucent (alpha overridden)
+    pub id: u64,                  // host identifier, echoed back on click
+    pub page: usize,              // 0-based page the quote is on
+    pub quote: String,            // the text to locate (case-/whitespace-insensitive)
+    pub occurrence: usize,        // which occurrence on the page (0-based)
+    pub color: Hsla,              // fill color; drawn translucent (alpha overridden)
+    pub region: Option<NormRect>, // area highlight: drawn at this rect, no text layer
 }
 ```
 
-A highlight to draw on the PDF, located by its quote. Hand these to
-[`PdfView::set_highlights`](#pdfviewset_highlights); the viewer finds the quote via
-the text layer and draws a translucent box over each line it spans (`color` at
-alpha 0.35 normally, 0.6 while flashing). `Clone`.
+A highlight to draw on the PDF. Hand these to
+[`PdfView::set_highlights`](#pdfviewset_highlights). A quote highlight
+(`region: None`) is located via the text layer and draws a translucent box over
+each line it spans; an **area highlight** (`region: Some(rect)`) draws one box at
+its stored rect directly — no text layer, so it works on scans and figures, and
+`quote`/`occurrence` are not used for locating. Both draw `color` at alpha 0.35
+normally, 0.6 while flashing. `Clone`.
 
 ---
 
@@ -1234,6 +1281,21 @@ one-line quote, which occurrence of it on the page (so it re-locates
 unambiguously), and the label of the picked palette color (the opaque tag from
 [`set_highlight_palette`](#pdfviewset_highlight_palette), for the host to store).
 Install via [`PdfView::set_on_create_highlight`](#pdfviewset_on_create_highlight).
+
+---
+
+## `type CreateAreaFn`
+
+*(`markup` feature)*
+
+```rust
+pub type CreateAreaFn = Rc<dyn Fn(usize, NormRect, SharedString, &mut Window, &mut App)>;
+```
+
+Invoked when a box-drag finishes in area mode: the page (0-based), the dragged
+rect in normalized page coordinates, and the active palette color's label. The
+host stores it and hands it back as a [`Highlight`](#struct-highlight) with
+`region` set.
 
 ---
 

--- a/crates/gpui-pdf/API.md
+++ b/crates/gpui-pdf/API.md
@@ -24,6 +24,8 @@ public. Items in the **Feature** column require that Cargo feature (`search` imp
 | [`PdfView::form_fields`](#pdfviewform_fields) | method | `forms` | `fn form_fields(&self) -> &[FormField]` | The loaded document's fields (Tab order) |
 | [`PdfView::reveal_field`](#pdfviewreveal_field) | method | `forms` | `fn reveal_field(&mut self, field: &FormField, cx) -> Option<Bounds<Pixels>>` | Scroll a field on-screen, return its window bounds |
 | [`PdfView::replace_bytes`](#pdfviewreplace_bytes) | method | — | `fn replace_bytes(&mut self, bytes: Vec<u8>, cx)` | Hot-swap the document (scroll/zoom kept, no blanking) |
+| [`PdfView::set_on_open_external`](#pdfviewset_on_open_external) | method | — | `fn set_on_open_external(&mut self, f: OpenExternalFn)` | Button on the failure pane → host opens the OS viewer |
+| [`OpenExternalFn`](#type-openexternalfn) | type alias | — | `Rc<dyn Fn(&mut Window, &mut App)>` | The failure pane's hand-off callback |
 | `PdfEvent::FieldClicked` | event variant | `forms` | `{ field: FormField, bounds: Bounds<Pixels> }` | A form widget was clicked — toggle or seat an input |
 | [`parse_with_password`](#parse_with_password) | fn | — | `fn parse_with_password(bytes: Arc<Vec<u8>>, password: &str) -> Result<Arc<Document>, LoadError>` | Parse an encrypted PDF |
 | [`page_dims`](#page_dims) | fn | — | `fn page_dims(doc: &Document) -> Vec<(f32, f32)>` | Per-page `(w, h)` in points, no rasterization |
@@ -743,6 +745,24 @@ place of the loading placeholder, and [`PdfEvent::LoadFailed`](#enum-pdfevent)
 fired when it was set. `None` while loading and after a successful parse.
 **Parameters** — none (`&self`).
 
+### `PdfView::set_on_open_external`
+
+```rust
+pub fn set_on_open_external(&mut self, f: OpenExternalFn)
+```
+
+Set the handler behind the failure pane's **"Open in system viewer"** button —
+a graceful hand-off for files hayro can't parse (an unsupported encryption
+handler such as a public-key/certificate scheme, exotic transparency/blend
+features). The viewer stays host-agnostic: the host does the actual OS launch.
+Without a handler the pane shows only the error text.
+
+**Parameters**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `f` | [`OpenExternalFn`](#type-openexternalfn) | Called from the button with `(&mut Window, &mut App)`. |
+
 ### `PdfView::unlock`
 
 ```rust
@@ -1252,6 +1272,17 @@ an empty vec (the outer vec always has exactly one entry per page).
 
 **Cost & threading** — one pass over each page's annotation array plus a page-tree
 walk; no rasterization. Pure and thread-safe.
+
+---
+
+## `type OpenExternalFn`
+
+```rust
+pub type OpenExternalFn = Rc<dyn Fn(&mut Window, &mut gpui::App)>;
+```
+
+Invoked from the load-failure pane's "Open in system viewer" button (see
+[`set_on_open_external`](#pdfviewset_on_open_external)).
 
 ---
 

--- a/crates/gpui-pdf/API.md
+++ b/crates/gpui-pdf/API.md
@@ -47,6 +47,9 @@ public. Items in the **Feature** column require that Cargo feature (`search` imp
 | [`PdfView::zoom_in`](#pdfviewzoom_in--zoom_out--reset_zoom) | method | — | `fn zoom_in(&mut self, cx: &mut Context<Self>)` | Zoom in one step (×1.25) |
 | [`PdfView::zoom_out`](#pdfviewzoom_in--zoom_out--reset_zoom) | method | — | `fn zoom_out(&mut self, cx: &mut Context<Self>)` | Zoom out one step (÷1.25) |
 | [`PdfView::reset_zoom`](#pdfviewzoom_in--zoom_out--reset_zoom) | method | — | `fn reset_zoom(&mut self, cx: &mut Context<Self>)` | Back to 100% |
+| [`PdfView::fit_width`](#pdfviewfit_width) | method | — | `fn fit_width(&mut self, cx: &mut Context<Self>)` | Sticky fit-to-width zoom (toggles) |
+| [`PdfView::fit_page`](#pdfviewfit_page) | method | — | `fn fit_page(&mut self, cx: &mut Context<Self>)` | Sticky whole-page fit zoom (toggles) |
+| [`FitMode`](#enum-fitmode) | enum | — | `Width \| Page` | The two zoom-to-fit modes |
 | [`PdfView::go_to_page`](#pdfviewgo_to_page) | method | — | `fn go_to_page(&mut self, index: usize, cx: &mut Context<Self>)` | Scroll a page to the viewport top |
 | [`PdfView::next_page`](#pdfviewnext_page--prev_page) | method | — | `fn next_page(&mut self, cx: &mut Context<Self>)` | Go to the next page |
 | [`PdfView::prev_page`](#pdfviewnext_page--prev_page) | method | — | `fn prev_page(&mut self, cx: &mut Context<Self>)` | Go to the previous page |
@@ -841,6 +844,30 @@ One multiplicative step (×1.25 / ÷1.25) or back to 100% — all delegate to
 [`set_zoom`](#pdfviewset_zoom) (same clamping and no-blank behavior).
 **Parameters** — `cx` only.
 
+### `PdfView::fit_width`
+
+```rust
+pub fn fit_width(&mut self, cx: &mut Context<Self>)
+```
+
+Fit the page column to the viewport width. **Sticky**: the zoom re-computes on
+every viewport resize (window/sidebar changes) until a manual zoom — the ± / %
+controls, ⌘±/⌘0, or [`set_zoom`](#pdfviewset_zoom) — takes over. Calling it
+while already active toggles the mode off. The header shows it as the `↔`
+control, highlighted while active. **Parameters** — `cx` only.
+
+### `PdfView::fit_page`
+
+```rust
+pub fn fit_page(&mut self, cx: &mut Context<Self>)
+```
+
+Fit the whole *current* page inside the viewport, both axes — the fit uses that
+page's aspect ratio, so mixed-size documents re-fit for the page current at the
+time of (re-)fitting, not per scrolled page. Sticky and toggling like
+[`fit_width`](#pdfviewfit_width); the `⤢` header control.
+**Parameters** — `cx` only.
+
 ### `PdfView::go_to_page`
 
 ```rust
@@ -1225,6 +1252,17 @@ an empty vec (the outer vec always has exactly one entry per page).
 
 **Cost & threading** — one pass over each page's annotation array plus a page-tree
 walk; no rasterization. Pure and thread-safe.
+
+---
+
+## `enum FitMode`
+
+```rust
+pub enum FitMode { Width, Page }
+```
+
+The two zoom-to-fit modes (see [`fit_width`](#pdfviewfit_width) /
+[`fit_page`](#pdfviewfit_page)). `Copy`, `Clone`, `PartialEq`, `Eq`, `Debug`.
 
 ---
 

--- a/crates/gpui-pdf/src/lib.rs
+++ b/crates/gpui-pdf/src/lib.rs
@@ -318,6 +318,15 @@ fn render_scale(page_width: f32, scale_factor: f32, quality: f32, page_pt_width:
 
 // ─────────────────────────────── Component: PdfView ───────────────────────────────
 
+/// Automatic zoom-to-fit modes — see [`PdfView::fit_width`] / [`PdfView::fit_page`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FitMode {
+    /// The page column fills the viewport width.
+    Width,
+    /// The whole current page fits inside the viewport.
+    Page,
+}
+
 /// Smallest / largest zoom the viewer allows.
 const MIN_ZOOM: f32 = 0.5;
 const MAX_ZOOM: f32 = 3.0;
@@ -526,6 +535,11 @@ pub struct PdfView {
     /// from the thumb's top at grab time, so the thumb tracks the cursor. `None` when
     /// not dragging the scrollbar.
     scrollbar_drag: Option<f32>,
+    /// Active zoom-to-fit mode: re-fits on every viewport resize until a
+    /// manual zoom clears it.
+    fit: Option<FitMode>,
+    /// Viewport size the fit was last computed for (so a resize re-fits once).
+    fit_viewport: (f32, f32),
     /// On-screen zoom factor (1.0 = base width). Affects layout and render scale.
     zoom: f32,
     /// The quality multiplier the pages were last rendered at; compared against the
@@ -675,6 +689,8 @@ impl PdfView {
             pages: Vec::new(),
             scroll: ScrollHandle::new(),
             scrollbar_drag: None,
+            fit: None,
+            fit_viewport: (0.0, 0.0),
             zoom: 1.0,
             last_quality,
             generation: 0,
@@ -1338,6 +1354,12 @@ impl PdfView {
     /// re-render crisp at the new scale; their current bitmaps stay on screen
     /// (rescaled) until the fresh ones land, so nothing blanks.
     pub fn set_zoom(&mut self, zoom: f32, cx: &mut Context<Self>) {
+        // A manual zoom takes over from any active fit mode.
+        self.fit = None;
+        self.apply_zoom(zoom, cx);
+    }
+
+    fn apply_zoom(&mut self, zoom: f32, cx: &mut Context<Self>) {
         let z = zoom.clamp(MIN_ZOOM, MAX_ZOOM);
         if (z - self.zoom).abs() < 0.001 {
             return;
@@ -1347,6 +1369,63 @@ impl PdfView {
         self.generation = self.generation.wrapping_add(1);
         self.go_to_page(anchor, cx);
         cx.notify();
+    }
+
+    /// Fit the page column to the viewport width. Sticky: re-fits as the
+    /// viewer resizes, until a manual zoom (buttons, ⌘±/⌘0, [`set_zoom`])
+    /// takes over. Toggles off if already active.
+    ///
+    /// [`set_zoom`]: Self::set_zoom
+    pub fn fit_width(&mut self, cx: &mut Context<Self>) {
+        self.toggle_fit(FitMode::Width, cx);
+    }
+
+    /// Fit the whole current page inside the viewport (both axes). Sticky
+    /// like [`fit_width`](Self::fit_width); toggles off if already active.
+    pub fn fit_page(&mut self, cx: &mut Context<Self>) {
+        self.toggle_fit(FitMode::Page, cx);
+    }
+
+    fn toggle_fit(&mut self, mode: FitMode, cx: &mut Context<Self>) {
+        self.fit = if self.fit == Some(mode) {
+            None
+        } else {
+            Some(mode)
+        };
+        self.apply_fit(cx);
+        cx.notify();
+    }
+
+    /// Compute + apply the zoom for the active fit mode against the current
+    /// viewport. No-op before first layout (render re-applies once bounds are
+    /// known) or with no fit active.
+    fn apply_fit(&mut self, cx: &mut Context<Self>) {
+        let Some(mode) = self.fit else {
+            return;
+        };
+        let vp = self.scroll.bounds().size;
+        let (vw, vh) = (f32::from(vp.width), f32::from(vp.height));
+        if vw <= 1.0 || vh <= 1.0 {
+            return;
+        }
+        self.fit_viewport = (vw, vh);
+        // Chrome around the page column: the overlay scrollbar plus the page
+        // slots' 1px borders and a hair of breathing room.
+        let avail_w = (vw - SCROLLBAR_W - 6.0).max(50.0);
+        let zoom = match mode {
+            FitMode::Width => avail_w / PAGE_WIDTH,
+            FitMode::Page => {
+                let (pw, ph) = self
+                    .dims
+                    .get(self.current_page_index())
+                    .copied()
+                    .filter(|(w, h)| *w > 0.0 && *h > 0.0)
+                    .unwrap_or((612.0, 792.0));
+                let avail_h = (vh - 2.0 * PAGE_PAD_Y).max(50.0);
+                (avail_h / (PAGE_WIDTH * (ph / pw))).min(avail_w / PAGE_WIDTH)
+            }
+        };
+        self.apply_zoom(zoom, cx);
     }
 
     /// Zoom in one step.
@@ -1639,6 +1718,15 @@ impl EventEmitter<PdfEvent> for PdfView {}
 
 impl Render for PdfView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // A sticky fit mode re-fits when the viewport size changes (window or
+        // sidebar resize) — and computes the first real fit once layout exists.
+        if self.fit.is_some() {
+            let vp = self.scroll.bounds().size;
+            let (vw, vh) = (f32::from(vp.width), f32::from(vp.height));
+            if (vw - self.fit_viewport.0).abs() > 1.0 || (vh - self.fit_viewport.1).abs() > 1.0 {
+                self.apply_fit(cx);
+            }
+        }
         // Keep only the on-screen pages rasterized for the current scroll position.
         self.ensure_window(window, cx);
         let style = (self.style)();
@@ -1958,7 +2046,28 @@ impl Render for PdfView {
                 self.control("pdf-zoom-in", "+")
                     .on_click(cx.listener(|this, _, _window, cx| this.zoom_in(cx)))
                     .tooltip(self.tip("Zoom in (⌘+)")),
-            );
+            )
+            .child(div().w(px(1.0)).h(px(14.0)).mx(px(4.0)).bg(style.border))
+            .child({
+                let mut c = self
+                    .control("pdf-fit-width", "↔")
+                    .on_click(cx.listener(|this, _, _window, cx| this.fit_width(cx)))
+                    .tooltip(self.tip("Fit width"));
+                if self.fit == Some(FitMode::Width) {
+                    c = c.bg(style.placeholder_bg);
+                }
+                c
+            })
+            .child({
+                let mut c = self
+                    .control("pdf-fit-page", "⤢")
+                    .on_click(cx.listener(|this, _, _window, cx| this.fit_page(cx)))
+                    .tooltip(self.tip("Fit page"));
+                if self.fit == Some(FitMode::Page) {
+                    c = c.bg(style.placeholder_bg);
+                }
+                c
+            });
 
         // Highlight-mode toggle + color picker (markup): the pen turns drag-to-select
         // on and pops a palette down; the active color shows as a chip beneath it.

--- a/crates/gpui-pdf/src/lib.rs
+++ b/crates/gpui-pdf/src/lib.rs
@@ -405,6 +405,10 @@ pub struct Highlight {
     pub occurrence: usize,
     /// Fill color; drawn translucent.
     pub color: Hsla,
+    /// An **area (image-region) highlight**: a normalized page rect drawn
+    /// directly — no text layer involved, so it works on scans and figures.
+    /// When set, `quote`/`occurrence` are not used for locating.
+    pub region: Option<NormRect>,
 }
 
 /// Invoked with a [`Highlight`]'s `id` when the user clicks it. (`markup` feature.)
@@ -418,6 +422,25 @@ pub type HighlightClickFn = Rc<dyn Fn(u64, &mut Window, &mut gpui::App)>;
 #[cfg(feature = "markup")]
 pub type CreateHighlightFn =
     Rc<dyn Fn(usize, String, usize, SharedString, &mut Window, &mut gpui::App)>;
+
+/// Invoked when the user finishes a box-drag in "area mode": the page (0-based), the
+/// dragged rect in normalized page coordinates, and the label of the picked color.
+/// The host stores it and hands it back as a [`Highlight`] with `region` set.
+/// (`markup` feature.)
+#[cfg(feature = "markup")]
+pub type CreateAreaFn = Rc<dyn Fn(usize, NormRect, SharedString, &mut Window, &mut gpui::App)>;
+
+/// The normalized rect spanned by two drag endpoints, in either direction.
+/// (`markup` feature.)
+#[cfg(feature = "markup")]
+fn norm_rect_between(a: NormPoint, b: NormPoint) -> NormRect {
+    NormRect {
+        x: a.x.min(b.x),
+        y: a.y.min(b.y),
+        w: (a.x - b.x).abs(),
+        h: (a.y - b.y).abs(),
+    }
+}
 
 /// Cache state for a page's extracted text layer. (`markup` feature.)
 #[cfg(feature = "markup")]
@@ -540,6 +563,11 @@ pub struct PdfView {
     /// Click handler for a highlight (markup).
     #[cfg(feature = "markup")]
     on_highlight: Option<HighlightClickFn>,
+    /// "Area mode" (only meaningful while `selecting`): a drag marks a page
+    /// region instead of selecting text (markup).
+    area_mode: bool,
+    /// Called when an area drag finishes, so the host stores it (markup).
+    on_create_area: Option<CreateAreaFn>,
     /// "Highlight mode": dragging over text selects + creates a highlight (markup).
     #[cfg(feature = "markup")]
     selecting: bool,
@@ -666,6 +694,8 @@ impl PdfView {
             on_highlight: None,
             #[cfg(feature = "markup")]
             selecting: false,
+            area_mode: false,
+            on_create_area: None,
             #[cfg(feature = "markup")]
             sel_drag: None,
             #[cfg(feature = "markup")]
@@ -923,10 +953,34 @@ impl PdfView {
     #[cfg(feature = "markup")]
     pub fn toggle_select_mode(&mut self, cx: &mut Context<Self>) {
         self.selecting = !self.selecting;
+        self.area_mode = false;
         self.sel_drag = None;
         // Turning highlight mode on pops the color picker down; off hides it.
         self.palette_open = self.selecting && !self.palette.is_empty();
         cx.notify();
+    }
+
+    /// Toggle "area mode": like highlight mode, but a drag marks a page *region*
+    /// (an image/figure box) instead of selecting text, firing [`CreateAreaFn`]
+    /// on release. Turning it on turns text-highlight mode's selection off (they
+    /// share the pen state); turning either mode off clears the other.
+    /// (`markup` feature.)
+    pub fn toggle_area_mode(&mut self, cx: &mut Context<Self>) {
+        if self.selecting && self.area_mode {
+            self.selecting = false;
+            self.area_mode = false;
+        } else {
+            self.selecting = true;
+            self.area_mode = true;
+        }
+        self.sel_drag = None;
+        self.palette_open = self.selecting && !self.palette.is_empty();
+        cx.notify();
+    }
+
+    /// Set the handler invoked when an area (box) drag finishes. (`markup` feature.)
+    pub fn set_on_create_area(&mut self, f: CreateAreaFn, _cx: &mut Context<Self>) {
+        self.on_create_area = Some(f);
     }
 
     /// Set the highlight colors the picker offers, as `(label, fill)` pairs. The label
@@ -1448,10 +1502,11 @@ impl PdfView {
             let mut pages: Vec<usize> = self
                 .highlights
                 .iter()
+                .filter(|h| h.region.is_none())
                 .map(|h| h.page)
                 .filter(|p| (start..=end).contains(p))
                 .collect();
-            if self.selecting {
+            if self.selecting && !self.area_mode {
                 pages.extend(start..=end);
             }
             pages.sort_unstable();
@@ -1643,49 +1698,64 @@ impl Render for PdfView {
             #[cfg(feature = "markup")]
             let slot = {
                 let mut slot = slot;
-                if let Some(TextSlot::Ready(pt)) = self.page_text.get(&i) {
-                    // Brighten + outline the page's highlights briefly after a jump from
-                    // a note, so the clicked one is easy to spot.
-                    let flashing = self.flash == Some(i);
-                    for h in self.highlights.iter().filter(|h| h.page == i) {
-                        let fill = Hsla {
-                            a: if flashing { 0.6 } else { 0.35 },
-                            ..h.color
-                        };
-                        for (ri, r) in pt.locate(&h.quote, h.occurrence).into_iter().enumerate() {
-                            let id = h.id;
-                            let mut hl = div()
-                                .id(gpui::SharedString::from(format!(
-                                    "pdf-hl-{i}-{}-{ri}",
-                                    h.id
-                                )))
-                                .absolute()
-                                .left(px(r.x * page_width))
-                                .top(px(r.y * disp_h))
-                                .w(px(r.w * page_width))
-                                .h(px(r.h * disp_h))
-                                .rounded(px(1.0))
-                                .bg(fill)
-                                .cursor_pointer()
-                                .on_click(cx.listener(move |this, _, window, cx| {
-                                    if let Some(cb) = this.on_highlight.clone() {
-                                        cb(id, window, cx);
-                                    }
-                                }));
-                            if flashing {
-                                hl = hl.border_1().border_color(Hsla { a: 0.95, ..h.color });
-                            }
-                            slot = slot.child(hl);
+                // Brighten + outline the page's highlights briefly after a jump from
+                // a note, so the clicked one is easy to spot.
+                let flashing = self.flash == Some(i);
+                for h in self.highlights.iter().filter(|h| h.page == i) {
+                    let fill = Hsla {
+                        a: if flashing { 0.6 } else { 0.35 },
+                        ..h.color
+                    };
+                    // An area highlight is its stored rect; a quote highlight is
+                    // one rect per located line (needs the page's text layer).
+                    let rects: Vec<NormRect> = match h.region {
+                        Some(r) => vec![r],
+                        None => match self.page_text.get(&i) {
+                            Some(TextSlot::Ready(pt)) => pt.locate(&h.quote, h.occurrence),
+                            _ => Vec::new(),
+                        },
+                    };
+                    for (ri, r) in rects.into_iter().enumerate() {
+                        let id = h.id;
+                        let mut hl = div()
+                            .id(gpui::SharedString::from(format!(
+                                "pdf-hl-{i}-{}-{ri}",
+                                h.id
+                            )))
+                            .absolute()
+                            .left(px(r.x * page_width))
+                            .top(px(r.y * disp_h))
+                            .w(px(r.w * page_width))
+                            .h(px(r.h * disp_h))
+                            .rounded(px(1.0))
+                            .bg(fill)
+                            .cursor_pointer()
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                if let Some(cb) = this.on_highlight.clone() {
+                                    cb(id, window, cx);
+                                }
+                            }));
+                        if flashing {
+                            hl = hl.border_1().border_color(Hsla { a: 0.95, ..h.color });
                         }
+                        slot = slot.child(hl);
                     }
                 }
-                // Live drag-selection feedback (highlight mode).
+                // Live drag feedback: the raw box in area mode, the text
+                // selection's line rects in highlight mode.
                 if let Some((pg, a, b)) = self.sel_drag
                     && pg == i
-                    && let Some(TextSlot::Ready(pt)) = self.page_text.get(&i)
-                    && let Some(sel) = pt.select(a, b)
                 {
-                    for r in sel.rects {
+                    let rects: Vec<NormRect> = if self.area_mode {
+                        vec![norm_rect_between(a, b)]
+                    } else if let Some(TextSlot::Ready(pt)) = self.page_text.get(&i)
+                        && let Some(sel) = pt.select(a, b)
+                    {
+                        sel.rects
+                    } else {
+                        Vec::new()
+                    };
+                    for r in rects {
                         slot = slot.child(
                             div()
                                 .absolute()
@@ -1919,6 +1989,32 @@ impl Render for PdfView {
                 .child(div().w(px(12.0)).h(px(2.0)).rounded(px(1.0)).bg(active))
                 .on_click(cx.listener(|this, _, _window, cx| this.toggle_select_mode(cx)))
                 .tooltip(self.tip("Highlight — pick a color (⌘⇧H)"));
+            // The area (box) tool: same pen state + palette, but a drag marks a
+            // page region instead of selecting text — for figures and scans.
+            let area_bg = if self.selecting && self.area_mode {
+                style.placeholder_bg
+            } else {
+                Hsla { a: 0.0, ..style.bg }
+            };
+            let area = div()
+                .id("pdf-area")
+                .flex()
+                .flex_col()
+                .items_center()
+                .justify_center()
+                .gap(px(1.0))
+                .min_w(px(20.0))
+                .px(px(6.0))
+                .py(px(1.0))
+                .rounded(px(4.0))
+                .cursor_pointer()
+                .text_color(style.header_fg)
+                .bg(area_bg)
+                .hover(|s| s.bg(style.placeholder_bg))
+                .child("⬚")
+                .child(div().w(px(12.0)).h(px(2.0)).rounded(px(1.0)).bg(active))
+                .on_click(cx.listener(|this, _, _window, cx| this.toggle_area_mode(cx)))
+                .tooltip(self.tip("Area highlight — drag a box over a region"));
 
             // Color-picker dropdown, deferred so it paints over the page area below.
             let dropdown = if self.palette_open && !self.palette.is_empty() {
@@ -1965,7 +2061,16 @@ impl Render for PdfView {
                 None
             };
 
-            header.child(div().relative().child(pen).children(dropdown))
+            header.child(
+                div()
+                    .relative()
+                    .flex()
+                    .flex_row()
+                    .gap(px(2.0))
+                    .child(pen)
+                    .child(area)
+                    .children(dropdown),
+            )
         };
 
         // Find toggle (search): a magnifier that opens the find bar.
@@ -2149,6 +2254,14 @@ impl Render for PdfView {
                     // highlight. Threshold is in normalized page coords (~a few pixels).
                     const MIN_DRAG: f32 = 0.005;
                     if (a.x - b.x).abs() < MIN_DRAG && (a.y - b.y).abs() < MIN_DRAG {
+                        cx.notify();
+                        return;
+                    }
+                    if this.area_mode {
+                        if let Some(cb) = this.on_create_area.clone() {
+                            let color = this.active_color_name();
+                            cb(pg, norm_rect_between(a, b), color, window, cx);
+                        }
                         cx.notify();
                         return;
                     }

--- a/crates/gpui-pdf/src/lib.rs
+++ b/crates/gpui-pdf/src/lib.rs
@@ -451,6 +451,12 @@ fn norm_rect_between(a: NormPoint, b: NormPoint) -> NormRect {
     }
 }
 
+/// Invoked from the load-failure pane's "Open in system viewer" button, so the
+/// host can hand the file to the OS default app — the viewer itself stays
+/// host-agnostic (no process spawning). Set via [`PdfView::set_on_open_external`];
+/// without it the pane shows no button.
+pub type OpenExternalFn = Rc<dyn Fn(&mut Window, &mut gpui::App)>;
+
 /// Cache state for a page's extracted text layer. (`markup` feature.)
 #[cfg(feature = "markup")]
 enum TextSlot {
@@ -526,6 +532,8 @@ pub struct PdfView {
     /// A terminal read/parse failure — the viewer renders this message
     /// instead of sitting on "Loading PDF…" forever.
     load_error: Option<SharedString>,
+    /// Handler behind the failure pane's "Open in system viewer" button.
+    on_open_external: Option<OpenExternalFn>,
     /// `(width, height)` in points per page — drives page-slot sizing.
     dims: Vec<(f32, f32)>,
     /// Per-page render state; only pages near the viewport hold a bitmap.
@@ -685,6 +693,7 @@ impl PdfView {
             locked: false,
             unlock_failed: false,
             load_error: None,
+            on_open_external: None,
             dims: Vec::new(),
             pages: Vec::new(),
             scroll: ScrollHandle::new(),
@@ -939,6 +948,14 @@ impl PdfView {
     /// The terminal read/parse failure shown in place of the viewer, if any.
     pub fn load_error(&self) -> Option<&SharedString> {
         self.load_error.as_ref()
+    }
+
+    /// Set the handler behind the failure pane's "Open in system viewer"
+    /// button — a graceful hand-off for files hayro can't parse (unsupported
+    /// encryption handlers, exotic features). Without one, the pane shows
+    /// only the error text.
+    pub fn set_on_open_external(&mut self, f: OpenExternalFn) {
+        self.on_open_external = Some(f);
     }
 
     /// Set the highlights to draw — the host derives these from its own store (e.g.
@@ -1732,7 +1749,8 @@ impl Render for PdfView {
         let style = (self.style)();
 
         if let Some(err) = &self.load_error {
-            return load_failed(style, err.clone()).into_any_element();
+            return load_failed(style, err.clone(), self.on_open_external.clone())
+                .into_any_element();
         }
         if self.dims.is_empty() {
             return loading(style).into_any_element();
@@ -2673,7 +2691,11 @@ impl Render for PdfView {
 
 /// The terminal-failure pane: the file name stays in the tab; the pane says
 /// why the viewer is empty (instead of an eternal "Loading PDF…").
-fn load_failed(style: PdfStyle, err: SharedString) -> impl IntoElement {
+fn load_failed(
+    style: PdfStyle,
+    err: SharedString,
+    open_external: Option<OpenExternalFn>,
+) -> impl IntoElement {
     div()
         .size_full()
         .flex()
@@ -2694,6 +2716,24 @@ fn load_failed(style: PdfStyle, err: SharedString) -> impl IntoElement {
                 .max_w(px(520.))
                 .child(err),
         )
+        // Graceful hand-off: the file may still open fine in the OS viewer
+        // (unsupported encryption handler, exotic features).
+        .children(open_external.map(|handler| {
+            div()
+                .id("pdf-open-external")
+                .mt(px(8.))
+                .px(px(10.))
+                .py(px(4.))
+                .rounded(px(5.))
+                .border_1()
+                .border_color(style.border)
+                .text_size(px(12.))
+                .text_color(style.header_fg)
+                .cursor_pointer()
+                .hover(|s| s.bg(style.placeholder_bg))
+                .child("Open in system viewer")
+                .on_click(move |_, window, cx| handler(window, cx))
+        }))
 }
 
 fn loading(style: PdfStyle) -> impl IntoElement {

--- a/src/app.rs
+++ b/src/app.rs
@@ -3737,6 +3737,7 @@ impl AppView {
         let create_path = path.clone();
         let area_weak = weak.clone();
         let area_path = path.clone();
+        let ext_path = path.clone();
         view.update(cx, move |v, cx| {
             v.set_highlights(highlights, cx);
             v.set_highlight_palette(crate::pdf::highlight_palette(), cx);
@@ -3760,6 +3761,11 @@ impl AppView {
                         )
                     });
                 }
+            }));
+            // Failure pane's hand-off: give the unparseable file to the OS viewer.
+            let ext_path = ext_path.clone();
+            v.set_on_open_external(Rc::new(move |_window, _cx| {
+                AppView::open_with_default_app(&ext_path);
             }));
             // Box-drag in area mode → the same store path; the rect rides as an
             // `@area(…)` quote token (parse_highlights turns it back into a region).
@@ -6085,6 +6091,24 @@ impl AppView {
         #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
         let cmd = "xdg-open";
         let _ = std::process::Command::new(cmd).arg(&dir).spawn();
+    }
+
+    /// Open a file with the OS default application (e.g. a PDF hayro can't
+    /// parse, handed to Preview/Edge/evince from the viewer's failure pane).
+    pub fn open_with_default_app(file: &Path) {
+        #[cfg(target_os = "macos")]
+        let mut cmd = std::process::Command::new("open");
+        // `start` is a cmd built-in; the empty "" is its window-title slot so
+        // a path with spaces isn't mistaken for the title.
+        #[cfg(target_os = "windows")]
+        let mut cmd = {
+            let mut c = std::process::Command::new("cmd");
+            c.args(["/C", "start", ""]);
+            c
+        };
+        #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+        let mut cmd = std::process::Command::new("xdg-open");
+        let _ = cmd.arg(file).spawn();
     }
 
     /// Open a folder in the OS file manager (Finder / Explorer / file manager).

--- a/src/app.rs
+++ b/src/app.rs
@@ -3992,6 +3992,23 @@ impl AppView {
         cx.notify();
     }
 
+    /// Commit a choice field to `value` directly (an option row was clicked —
+    /// bypasses the input's text).
+    fn commit_pdf_field_choice(
+        &mut self,
+        value: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(edit) = self.pdf_field_edit.take() else {
+            return;
+        };
+        if value != edit.field.value {
+            self.write_pdf_field(&edit.path, &edit.field.name, value, window, cx);
+        }
+        cx.notify();
+    }
+
     /// Write one form field: read the stored PDF, rewrite it through
     /// `set_form_value` (value + regenerated appearance), save it back, and
     /// hot-swap the open viewer's document (scroll/zoom preserved).
@@ -8156,7 +8173,16 @@ impl Render for AppView {
         // from the focused input); the seat swallows its own clicks.
         let pdf_field_overlay = self.pdf_field_edit.as_ref().map(|e| {
             let seat_w = e.bounds.size.width.clamp(px(220.0), px(460.0));
-            let seat_h = px(64.0);
+            // Choice fields list their /Opt entries below the input (clicking
+            // one commits immediately; typing still works for editable combos).
+            let options: Vec<String> = if e.field.kind == gpui_pdf::FieldKind::Choice {
+                e.field.options.clone()
+            } else {
+                Vec::new()
+            };
+            const OPT_ROW_H: f32 = 22.0;
+            let opt_h = (options.len().min(6) as f32) * OPT_ROW_H;
+            let seat_h = px(64.0 + opt_h);
             let gap = px(6.0);
             let below = e.bounds.origin.y + e.bounds.size.height + gap;
             let win_h = window.viewport_size().height;
@@ -8208,7 +8234,46 @@ impl Render for AppView {
                                         e.field.name
                                     )),
                             )
-                            .child(Input::new(&e.input).small()),
+                            .child(Input::new(&e.input).small())
+                            .children((!options.is_empty()).then(|| {
+                                let current = e.field.value.clone();
+                                let mut col = div()
+                                    .id("pdf-choice-options")
+                                    .max_h(px(6.0 * OPT_ROW_H))
+                                    .overflow_y_scroll()
+                                    .flex()
+                                    .flex_col();
+                                for (i, opt) in options.iter().enumerate() {
+                                    let value = opt.clone();
+                                    let mut row = div()
+                                        .id(("pdf-choice-opt", i))
+                                        .h(px(OPT_ROW_H))
+                                        .flex_none();
+                                    if *opt == current {
+                                        row = row.bg(theme::accent_tint());
+                                    }
+                                    col = col.child(
+                                        row.flex()
+                                            .items_center()
+                                            .px(px(6.0))
+                                            .rounded(px(4.0))
+                                            .text_size(px(12.0))
+                                            .cursor_pointer()
+                                            .hover(|d| d.bg(theme::hover()))
+                                            .child(opt.clone())
+                                            .on_mouse_down(
+                                                MouseButton::Left,
+                                                cx.listener(move |this, _, window, cx| {
+                                                    cx.stop_propagation();
+                                                    this.commit_pdf_field_choice(
+                                                        &value, window, cx,
+                                                    );
+                                                }),
+                                            ),
+                                    );
+                                }
+                                col
+                            })),
                     ),
             )
             .into_any_element()

--- a/src/app.rs
+++ b/src/app.rs
@@ -3735,6 +3735,8 @@ impl AppView {
         let weak = cx.entity().downgrade();
         let create_weak = weak.clone();
         let create_path = path.clone();
+        let area_weak = weak.clone();
+        let area_path = path.clone();
         view.update(cx, move |v, cx| {
             v.set_highlights(highlights, cx);
             v.set_highlight_palette(crate::pdf::highlight_palette(), cx);
@@ -3759,6 +3761,29 @@ impl AppView {
                     });
                 }
             }));
+            // Box-drag in area mode → the same store path; the rect rides as an
+            // `@area(…)` quote token (parse_highlights turns it back into a region).
+            let area_weak = area_weak.clone();
+            let area_path = area_path.clone();
+            v.set_on_create_area(
+                Rc::new(move |page, rect, color, window, cx| {
+                    if let Some(app) = area_weak.upgrade() {
+                        let token = crate::pdf::area_token(rect);
+                        app.update(cx, |a, cx| {
+                            a.add_pdf_highlight(
+                                &area_path,
+                                page,
+                                &token,
+                                0,
+                                color.as_ref(),
+                                window,
+                                cx,
+                            )
+                        });
+                    }
+                }),
+                cx,
+            );
         });
         // Re-render the surrounding UI on lock/unlock, so the password prompt
         // appears when an encrypted PDF loads and is replaced by the viewer once

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -9,7 +9,7 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-pub use gpui_pdf::{Highlight, PdfEvent, PdfStyle, PdfView, is_pdf};
+pub use gpui_pdf::{Highlight, NormRect, PdfEvent, PdfStyle, PdfView, is_pdf};
 
 use crate::paths;
 
@@ -128,6 +128,26 @@ fn strip_quote_meta(s: &str) -> (String, gpui::Hsla) {
     (quote, color)
 }
 
+/// Encode an area (image-region) highlight's rect as the stored quote token:
+/// `@area(x,y,w,h)`, normalized page coordinates. No spaces — the token must
+/// survive `add_pdf_highlight`'s whitespace normalization.
+pub fn area_token(r: NormRect) -> String {
+    format!("@area({:.4},{:.4},{:.4},{:.4})", r.x, r.y, r.w, r.h)
+}
+
+/// Parse an `@area(x,y,w,h)` quote token back into its rect. `None` for
+/// ordinary text quotes (or a malformed token, which then just fails to locate
+/// as a quote — harmless).
+fn parse_area(quote: &str) -> Option<NormRect> {
+    let inner = quote.strip_prefix("@area(")?.strip_suffix(')')?;
+    let mut nums = inner.split(',').map(|v| v.trim().parse::<f32>());
+    let mut next = || nums.next().and_then(Result::ok);
+    let (x, y, w, h) = (next()?, next()?, next()?, next()?);
+    let unit = 0.0..=1.0;
+    (unit.contains(&x) && unit.contains(&y) && w > 0.0 && h > 0.0 && nums.next().is_none())
+        .then_some(NormRect { x, y, w, h })
+}
+
 /// Record a highlight, assigning the next occurrence index for its `(page, quote)`.
 fn push_highlight(
     out: &mut Vec<Highlight>,
@@ -143,12 +163,14 @@ fn push_highlight(
         *c += 1;
         v
     };
+    let region = parse_area(&quote);
     out.push(Highlight {
         id: id as u64,
         page,
         quote,
         occurrence,
         color,
+        region,
     });
 }
 
@@ -244,6 +266,37 @@ mod tests {
         assert_eq!(hs[0].occurrence, 0);
         assert_eq!(hs[1].page, 0);
         assert_eq!(hs[1].quote, "Overview");
+    }
+
+    #[test]
+    fn area_token_roundtrips_through_parse() {
+        let r = NormRect {
+            x: 0.1234,
+            y: 0.5,
+            w: 0.25,
+            h: 0.125,
+        };
+        let line = format!("- p3: {} {{green}} [[pdf/scan.pdf#p3|↗]]", area_token(r));
+        let hs = parse_highlights(&line);
+        assert_eq!(hs.len(), 1);
+        let got = hs[0].region.expect("area region");
+        assert!((got.x - r.x).abs() < 1e-4 && (got.h - r.h).abs() < 1e-4);
+        assert_eq!(hs[0].page, 2);
+        assert_eq!(hs[0].color, known_color("green").unwrap());
+        // Ordinary quotes stay quote highlights.
+        assert_eq!(parse_highlights("- p1: plain words")[0].region, None);
+    }
+
+    #[test]
+    fn malformed_area_tokens_stay_quotes() {
+        for bad in [
+            "- p1: @area(0.1,0.2,0.3)",     // three fields
+            "- p1: @area(2.0,0.2,0.3,0.4)", // out of range
+            "- p1: @area(0.1,0.2,0.0,0.4)", // zero size
+            "- p1: @area(a,b,c,d)",         // not numbers
+        ] {
+            assert_eq!(parse_highlights(bad)[0].region, None, "{bad}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Four PDF TODO items, one commit each:

- **Area (image-region) highlights** — a `⬚` tool beside the highlight pen: drag a box over any page region (figures, scans — no text layer needed). Stored on the highlights page as an `@area(x,y,w,h)` quote token, so colors, reverse jump-links, and flash-on-jump ride the existing machinery; the token parses back into a drawn region (unit-tested, malformed tokens degrade to ordinary quotes). gpui-pdf grows `Highlight.region`, `toggle_area_mode`, `CreateAreaFn`.
- **Fit-width / fit-page zoom** — sticky `↔`/`⤢` header controls that re-fit on viewport resize until a manual zoom takes over; toggling and active-state highlight. `PdfView::fit_width` / `fit_page`.
- **Graceful fallback for unsupported files** — the load-failure pane offers **"Open in system viewer"**; the crate fires a host callback (`set_on_open_external`) and the app launches the OS default app (`open` / `cmd /C start` / `xdg-open`).
- **Choice-field dropdowns** — a Ch form field's seat editor lists its `/Opt` entries (current highlighted, click commits through the write-and-hot-swap path); typing still covers editable combos.

gpui-pdf API.md updated for every new public item.

## Testing

All four live-verified on macOS (area create/reload/jump, fit re-fit on resize, hand-off on a corrupt file, dropdown on a generated AcroForm). `fmt` / `clippy -D warnings` / `test --workspace` green; new unit tests for the `@area` token parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)