### PR TITLE
Cditor-inspired: WYSIWYG polish, tables, windowed rendering, block reorder

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -123,6 +123,51 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
 - Skipped (no markdown representation): text/background color marks, cell
   merge/split, per-cell backgrounds, header *columns*, toggle-list containers.
 
+**Ultrareview of PR #52 (2026-07-18)** — non-blocking findings (the two
+blockers, occluded grip presses + turn-into grammar, were fixed in 3c050f6):
+
+*Correctness-adjacent:*
+- [ ] Feed-window day heights are keyed by child POSITION and invalidated only
+  on width change — key by date + invalidate on content change so a day-set or
+  offscreen-content change can't leave stale spacer heights. (S)
+- [ ] Caret-parked-on-marker is patched at two entry points (resize-band press,
+  `rewrite_table_marker`); other focus-without-caret-move affordances (pills,
+  delete handles, code Copy, fold chevrons, image grips) can still flash raw
+  markers — enforce "caret never rests on a collapsed marker line" once in the
+  collapse/caret logic. (M)
+
+*Per-frame / per-event efficiency (gpui-editor):*
+- [ ] Window-level MouseMove listener runs `editor.update` + a full line scan
+  in EVERY loaded editor per pointer move — gate on markdown_style + a y-range
+  early-out (or register only for the hovered editor). (S)
+- [ ] Windowed skip path still hashes every offscreen line twice and makes an
+  empty `shape_runs` call per line per frame; lines containing `$`/`![` never
+  window — key heights by (row, content_gen, epoch), make the placeholder
+  cheap (`Option<WrappedLine>`), derive eligibility from scan output. (M/L)
+- [ ] `line_runs` cache HIT deep-clones (String + Vec<TextRun> + Vec<usize>)
+  per visible line per frame — store the payload behind an `Rc`. (S)
+- [ ] `region_cols` cache rehashes all table text + clones the width vecs per
+  frame even on a hit — key on content_gen instead, store `Rc`. (S)
+- [ ] `on_scroll_wheel` walks O(lines) before the `dx == 0` check — hoist. (S)
+- [ ] Slash flyout rebuilds its item Vec every frame while open (+ twice per
+  arrow key for nth/len) — cache on the Slash state per selected category. (S)
+
+*Dedup / structure:*
+- [ ] Scrolled-table content-left (`bounds.left + GUTTER - sx`) is hand-built
+  at 6+ sites and paint re-implements the clamp inline — one shared
+  `table_left`/`table_avail` helper. (S)
+- [ ] `ShapedLines` is a 9-tuple with 7 hand-replicated placeholder-push sites
+  — a named struct + one `push_placeholder` helper. (M)
+- [ ] Fence-block walk ×3 + quote-run walk ×3 (turn_into, drag_block_rows,
+  snap_drop_boundary/block_kind_at) — `fence_block_rows` + `quote_run_rows`
+  helpers. (S)
+- [ ] `is_backslash_escaped` duplicates `is_escaped` in markdown_syntax.rs —
+  delete one. (S)
+- [ ] `grip_hover_row_at` hand-mirrors the prepaint grip geometry (26 vs
+  grip_left−4 constants) — extract one shared row/band computation. (S)
+- [ ] `menu_turn_into` belongs inside `DiagMenu` (dies with the menu; today
+  it's sticky once hovered and reset at only one open site). (S)
+
 ## App & polish
 - [ ] **Graph-node context menu** — nodes hit-test inside one
   canvas element (`g.hit(position)`), so the shared page-menu builder

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@ work is collected under [Completed](#completed) at the bottom.
 - [Notes & navigation](#notes--navigation)
 - [Notebooks (multiple data folders)](#notebooks-multiple-data-folders)
 - [Performance](#performance)
+- [Cditor audit (2026-07-17)](#cditor-audit-2026-07-17)
 - [App & polish](#app--polish)
 - [Import & export](#import--export)
 - [Crates](#crates)
@@ -46,6 +47,81 @@ per-notebook settings sync.
 
 ## Performance
 - [ ] Move SQLite writes off the UI thread (background executor) — **fsync stall handled** for now via WAL + `synchronous = NORMAL` in `Db::open` (per-keystroke autosave no longer fsyncs on the UI thread; measured worst case ~1.2 ms at a 50k-char page, well within a frame). The full off-thread refactor is now a lower-priority fast-follow (pathological pages / slow or contended disks)
+
+## Cditor audit (2026-07-17)
+
+Findings from a full sweep of JYChen-8866's Cditor codebase against zorite
+(four parallel reviews: input/IME, rendering perf, features, markdown engines).
+His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
+
+**Bugs (fix first — 1–6 make a good single batch):**
+- [ ] **Table column insert/delete corrupts `\|` cells** — `rewrite_table_columns`
+  splits raw + rejoins without re-escaping; a cell containing a pipe becomes two
+  cells / shifts columns (data loss). Lift Cditor's `escape_table_cell`
+  unescape-on-split / re-escape-on-join. (S)
+- [ ] **Editor splits table cells on escaped `\|`** — `table_cells` is a blind
+  `split('|')`; the reader (GFM) treats `\|` as a literal pipe → grid, caret,
+  and click hit-tests disagree with the rendered table. (S/M)
+- [ ] **CRLF paste** — no `\r\n` normalization anywhere in gpui-editor; Windows/
+  browser pastes inject literal `\r` (garbled render + column-math desync).
+  Normalize in `paste` + IME `replace_text_in_range`. (S)
+- [ ] **Paste into a table cell breaks the row** — paste inserts `\n`/`|`
+  verbatim even though Enter is carefully guarded (`caret_in_table`); sanitize
+  (newline→space, escape pipes) or route like Cditor's cell paste. (M)
+- [ ] **Double-backtick code spans** — `` ``a`b`` `` closes at the wrong
+  backtick (only single-` matched); detect the backtick-run length first. (S)
+- [ ] **Backslash escapes ignored for `*` `` ` `` `~` `[`** — only `_` checks;
+  `\*text\*` styles in WYSIWYG but shows literal in the reader. Shared
+  `is_escaped` helper (one exists for math). (S/M)
+- [ ] **Nested inline inside emphasis dropped** — `**bold *italic* bold**` /
+  `` **bold `code`** ``: scan_line consumes the outer construct wholesale, inner
+  marks render literal; reader nests correctly. Needs body re-scan. (M/L)
+- [ ] Table well-formedness: body rows with a different cell count than the
+  header render ragged (Cditor rejects); validate in `table_regions`. (S)
+
+**Performance (gpui-editor):**
+- [ ] **Document shaped TWICE per frame** — `shape_document` runs in the measure
+  closure AND prepaint with identical inputs; memoize one frame's result across
+  the two passes. Halves editor cost, removes a divergence hazard. (S)
+- [ ] **Cross-frame shaped-line cache** — every blink/hover reshapes every
+  visible day's full text; adopt Cditor's `LayoutCacheKey` (content version +
+  width bucket + font/theme/scale). gpui-markdown's `PARSE_CACHE` is the
+  in-repo template. (M)
+- [ ] **IME UTF-16↔UTF-8 mapping is O(document) per call** — scan from the
+  caret's line start instead of byte 0; CJK composition latency currently grows
+  with note size. Also: `bounds_for_range` anchors the candidate window at the
+  composition START (zero-width) — return the marked range's real span. (S/M)
+- [ ] Whole-document scans in `shape_document` (`ordered_numbers`,
+  `mermaid_blocks`, `math_regions`, selection `row_of`) recomputed 2×/frame —
+  memoize on the content version once the cache exists. (S)
+- [ ] **Table cells re-measured every frame** (`table_row_wrap_rows` +
+  `paint_table_row` shape per cell per paint) — cache by (content version,
+  column-width bucket). (M)
+- [ ] **Scroll anchoring** — an async math/mermaid/image render above the
+  viewport jumps the content the user is reading; Cditor's
+  `AnchorFrame::restore_once` (capture top-visible row before shaping, restore
+  after height deltas) fixes it without windowing. (M)
+- [ ] `apply_auto_replace` rescans all lines above for fence parity on every
+  boundary keystroke — cache/bound it. (S)
+- [ ] **Windowed rendering + estimated heights** — Cditor's actual 100k-block
+  machinery (render window + spacers, estimated↔measured convergence, budgeted
+  layout); the editor's only L-sized perf item, defer until someone has a huge
+  note. (L)
+
+**Features (natural markdown fits, from his UI):**
+- [ ] **"Turn into" block conversion menu** — right-click/handle menu converting
+  a block between text/H1–3/lists/todo/quote/callout/code/math, with the
+  current kind checked; flat-markdown natural (rewrite the prefix). (M)
+- [ ] **Block drag-reorder** — gutter grip drag to move a block/line (his
+  gutter_drag + move-subtree pipeline; ours = reorder markdown lines). (M/L)
+- [ ] **Type-to-filter search in the table menu** — the menu is 18 rows now;
+  his cell menu filters by label + keywords as you type. (S/M)
+- [ ] **Clear contents** verb (cell/row/column) in the table menu. (S)
+- [ ] **⌘D duplicate** keybinding + shortcut hints rendered in menu rows. (S)
+- [ ] Wide-table **horizontal scroll** instead of scaling columns down — UX
+  decision; his tables scroll in-place with their own scrollbar. (M)
+- Skipped (no markdown representation): text/background color marks, cell
+  merge/split, per-cell backgrounds, header *columns*, toggle-list containers.
 
 ## App & polish
 - [ ] **Graph-node context menu** — nodes hit-test inside one

--- a/TODO.md
+++ b/TODO.md
@@ -156,7 +156,7 @@ blockers, occluded grip presses + turn-into grammar, were fixed in 3c050f6):
 - [x] Scrolled-table content-left (`bounds.left + GUTTER - sx`) is hand-built
   at 6+ sites and paint re-implements the clamp inline — one shared
   `table_left`/`table_avail` helper. (S)
-- [ ] `ShapedLines` is a 9-tuple with 7 hand-replicated placeholder-push sites
+- [x] `ShapedLines` is a 9-tuple with 7 hand-replicated placeholder-push sites
   — a named struct + one `push_placeholder` helper. (M)
 - [x] Fence-block walk ×3 + quote-run walk ×3 (turn_into, drag_block_rows,
   snap_drop_boundary/block_kind_at) — `fence_block_rows` + `quote_run_rows`

--- a/TODO.md
+++ b/TODO.md
@@ -73,7 +73,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
 - [x] **Backslash escapes ignored for `*` `` ` `` `~` `[`** — only `_` checks;
   `\*text\*` styles in WYSIWYG but shows literal in the reader. Shared
   `is_escaped` helper (one exists for math). (S/M)
-- [ ] **Nested inline inside emphasis dropped** — `**bold *italic* bold**` /
+- [x] **Nested inline inside emphasis dropped** — `**bold *italic* bold**` /
   `` **bold `code`** ``: scan_line consumes the outer construct wholesale, inner
   marks render literal; reader nests correctly. Needs body re-scan. (M/L)
 - [ ] Table well-formedness: body rows with a different cell count than the

--- a/TODO.md
+++ b/TODO.md
@@ -103,7 +103,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
   after height deltas) fixes it without windowing. (M)
 - [x] `apply_auto_replace` rescans all lines above for fence parity on every
   boundary keystroke — cache/bound it. (S)
-- [ ] **Windowed rendering + estimated heights** — Cditor's actual 100k-block
+- [x] **Windowed rendering + estimated heights** — Cditor's actual 100k-block
   machinery (render window + spacers, estimated↔measured convergence, budgeted
   layout); the editor's only L-sized perf item, defer until someone has a huge
   note. (L)

--- a/TODO.md
+++ b/TODO.md
@@ -118,7 +118,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
   his cell menu filters by label + keywords as you type. (S/M)
 - [ ] **Clear contents** verb (cell/row/column) in the table menu. (S)
 - [ ] **⌘D duplicate** keybinding + shortcut hints rendered in menu rows. (S)
-- [ ] Wide-table **horizontal scroll** instead of scaling columns down — UX
+- [x] Wide-table **horizontal scroll** instead of scaling columns down — UX
   decision; his tables scroll in-place with their own scrollbar. (M)
 - Skipped (no markdown representation): text/background color marks, cell
   merge/split, per-cell backgrounds, header *columns*, toggle-list containers.

--- a/TODO.md
+++ b/TODO.md
@@ -91,7 +91,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
   caret's line start instead of byte 0; CJK composition latency currently grows
   with note size. Also: `bounds_for_range` anchors the candidate window at the
   composition START (zero-width) — return the marked range's real span. (S/M)
-- [ ] Whole-document scans in `shape_document` (`ordered_numbers`,
+- [x] Whole-document scans in `shape_document` (`ordered_numbers`,
   `mermaid_blocks`, `math_regions`, selection `row_of`) recomputed 2×/frame —
   memoize on the content version once the cache exists. (S)
 - [ ] **Table cells re-measured every frame** (`table_row_wrap_rows` +
@@ -101,7 +101,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
   viewport jumps the content the user is reading; Cditor's
   `AnchorFrame::restore_once` (capture top-visible row before shaping, restore
   after height deltas) fixes it without windowing. (M)
-- [ ] `apply_auto_replace` rescans all lines above for fence parity on every
+- [x] `apply_auto_replace` rescans all lines above for fence parity on every
   boundary keystroke — cache/bound it. (S)
 - [ ] **Windowed rendering + estimated heights** — Cditor's actual 100k-block
   machinery (render window + spacers, estimated↔measured convergence, budgeted

--- a/TODO.md
+++ b/TODO.md
@@ -83,7 +83,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
 - [x] **Document shaped TWICE per frame** — `shape_document` runs in the measure
   closure AND prepaint with identical inputs; memoize one frame's result across
   the two passes. Halves editor cost, removes a divergence hazard. (S)
-- [ ] **Cross-frame shaped-line cache** — every blink/hover reshapes every
+- [x] **Cross-frame shaped-line cache** — every blink/hover reshapes every
   visible day's full text; adopt Cditor's `LayoutCacheKey` (content version +
   width bucket + font/theme/scale). gpui-markdown's `PARSE_CACHE` is the
   in-repo template. (M)

--- a/TODO.md
+++ b/TODO.md
@@ -94,7 +94,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
 - [x] Whole-document scans in `shape_document` (`ordered_numbers`,
   `mermaid_blocks`, `math_regions`, selection `row_of`) recomputed 2×/frame —
   memoize on the content version once the cache exists. (S)
-- [ ] **Table cells re-measured every frame** (`table_row_wrap_rows` +
+- [x] **Table cells re-measured every frame** (`table_row_wrap_rows` +
   `paint_table_row` shape per cell per paint) — cache by (content version,
   column-width bucket). (M)
 - [x] **Scroll anchoring** — an async math/mermaid/image render above the

--- a/TODO.md
+++ b/TODO.md
@@ -55,22 +55,22 @@ Findings from a full sweep of JYChen-8866's Cditor codebase against zorite
 His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
 
 **Bugs (fix first — 1–6 make a good single batch):**
-- [ ] **Table column insert/delete corrupts `\|` cells** — `rewrite_table_columns`
+- [x] **Table column insert/delete corrupts `\|` cells** — `rewrite_table_columns`
   splits raw + rejoins without re-escaping; a cell containing a pipe becomes two
   cells / shifts columns (data loss). Lift Cditor's `escape_table_cell`
   unescape-on-split / re-escape-on-join. (S)
-- [ ] **Editor splits table cells on escaped `\|`** — `table_cells` is a blind
+- [x] **Editor splits table cells on escaped `\|`** — `table_cells` is a blind
   `split('|')`; the reader (GFM) treats `\|` as a literal pipe → grid, caret,
   and click hit-tests disagree with the rendered table. (S/M)
-- [ ] **CRLF paste** — no `\r\n` normalization anywhere in gpui-editor; Windows/
+- [x] **CRLF paste** — no `\r\n` normalization anywhere in gpui-editor; Windows/
   browser pastes inject literal `\r` (garbled render + column-math desync).
   Normalize in `paste` + IME `replace_text_in_range`. (S)
-- [ ] **Paste into a table cell breaks the row** — paste inserts `\n`/`|`
+- [x] **Paste into a table cell breaks the row** — paste inserts `\n`/`|`
   verbatim even though Enter is carefully guarded (`caret_in_table`); sanitize
   (newline→space, escape pipes) or route like Cditor's cell paste. (M)
-- [ ] **Double-backtick code spans** — `` ``a`b`` `` closes at the wrong
+- [x] **Double-backtick code spans** — `` ``a`b`` `` closes at the wrong
   backtick (only single-` matched); detect the backtick-run length first. (S)
-- [ ] **Backslash escapes ignored for `*` `` ` `` `~` `[`** — only `_` checks;
+- [x] **Backslash escapes ignored for `*` `` ` `` `~` `[`** — only `_` checks;
   `\*text\*` styles in WYSIWYG but shows literal in the reader. Shared
   `is_escaped` helper (one exists for math). (S/M)
 - [ ] **Nested inline inside emphasis dropped** — `**bold *italic* bold**` /

--- a/TODO.md
+++ b/TODO.md
@@ -137,19 +137,24 @@ blockers, occluded grip presses + turn-into grammar, were fixed in 3c050f6):
   collapse/caret logic. (M)
 
 *Per-frame / per-event efficiency (gpui-editor):*
-- [ ] Window-level MouseMove listener runs `editor.update` + a full line scan
+- [x] Window-level MouseMove listener runs `editor.update` + a full line scan
   in EVERY loaded editor per pointer move — gate on markdown_style + a y-range
   early-out (or register only for the hovered editor). (S)
-- [ ] Windowed skip path still hashes every offscreen line twice and makes an
+- [x] Windowed skip path still hashes every offscreen line twice and makes an
   empty `shape_runs` call per line per frame; lines containing `$`/`![` never
   window — key heights by (row, content_gen, epoch), make the placeholder
   cheap (`Option<WrappedLine>`), derive eligibility from scan output. (M/L)
-- [ ] `line_runs` cache HIT deep-clones (String + Vec<TextRun> + Vec<usize>)
+  DONE via a per-row content-key memo (hash 3 u64s/line steady-state, diags
+  invalidate explicitly). Deliberately NOT taken: (row, content_gen) height
+  keys (would invalidate ALL offscreen heights per keystroke) and the
+  `Option<WrappedLine>` placeholder (the empty shape_runs is a gpui cache
+  hit); the `$`/`![` eligibility gates stay (conservative, correct).
+- [x] `line_runs` cache HIT deep-clones (String + Vec<TextRun> + Vec<usize>)
   per visible line per frame — store the payload behind an `Rc`. (S)
-- [ ] `region_cols` cache rehashes all table text + clones the width vecs per
+- [x] `region_cols` cache rehashes all table text + clones the width vecs per
   frame even on a hit — key on content_gen instead, store `Rc`. (S)
-- [ ] `on_scroll_wheel` walks O(lines) before the `dx == 0` check — hoist. (S)
-- [ ] Slash flyout rebuilds its item Vec every frame while open (+ twice per
+- [x] `on_scroll_wheel` walks O(lines) before the `dx == 0` check — hoist. (S)
+- [x] Slash flyout rebuilds its item Vec every frame while open (+ twice per
   arrow key for nth/len) — cache on the Slash state per selected category. (S)
 
 *Dedup / structure:*

--- a/TODO.md
+++ b/TODO.md
@@ -109,7 +109,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
   note. (L)
 
 **Features (natural markdown fits, from his UI):**
-- [ ] **"Turn into" block conversion menu** — right-click/handle menu converting
+- [x] **"Turn into" block conversion menu** — right-click/handle menu converting
   a block between text/H1–3/lists/todo/quote/callout/code/math, with the
   current kind checked; flat-markdown natural (rewrite the prefix). (M)
 - [ ] **Block drag-reorder** — gutter grip drag to move a block/line (his

--- a/TODO.md
+++ b/TODO.md
@@ -76,7 +76,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
 - [x] **Nested inline inside emphasis dropped** — `**bold *italic* bold**` /
   `` **bold `code`** ``: scan_line consumes the outer construct wholesale, inner
   marks render literal; reader nests correctly. Needs body re-scan. (M/L)
-- [ ] Table well-formedness: body rows with a different cell count than the
+- [x] Table well-formedness: body rows with a different cell count than the
   header render ragged (Cditor rejects); validate in `table_regions`. (S)
 
 **Performance (gpui-editor):**

--- a/TODO.md
+++ b/TODO.md
@@ -97,7 +97,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
 - [ ] **Table cells re-measured every frame** (`table_row_wrap_rows` +
   `paint_table_row` shape per cell per paint) — cache by (content version,
   column-width bucket). (M)
-- [ ] **Scroll anchoring** — an async math/mermaid/image render above the
+- [x] **Scroll anchoring** — an async math/mermaid/image render above the
   viewport jumps the content the user is reading; Cditor's
   `AnchorFrame::restore_once` (capture top-visible row before shaping, restore
   after height deltas) fixes it without windowing. (M)

--- a/TODO.md
+++ b/TODO.md
@@ -153,19 +153,19 @@ blockers, occluded grip presses + turn-into grammar, were fixed in 3c050f6):
   arrow key for nth/len) — cache on the Slash state per selected category. (S)
 
 *Dedup / structure:*
-- [ ] Scrolled-table content-left (`bounds.left + GUTTER - sx`) is hand-built
+- [x] Scrolled-table content-left (`bounds.left + GUTTER - sx`) is hand-built
   at 6+ sites and paint re-implements the clamp inline — one shared
   `table_left`/`table_avail` helper. (S)
 - [ ] `ShapedLines` is a 9-tuple with 7 hand-replicated placeholder-push sites
   — a named struct + one `push_placeholder` helper. (M)
-- [ ] Fence-block walk ×3 + quote-run walk ×3 (turn_into, drag_block_rows,
+- [x] Fence-block walk ×3 + quote-run walk ×3 (turn_into, drag_block_rows,
   snap_drop_boundary/block_kind_at) — `fence_block_rows` + `quote_run_rows`
   helpers. (S)
-- [ ] `is_backslash_escaped` duplicates `is_escaped` in markdown_syntax.rs —
+- [x] `is_backslash_escaped` duplicates `is_escaped` in markdown_syntax.rs —
   delete one. (S)
-- [ ] `grip_hover_row_at` hand-mirrors the prepaint grip geometry (26 vs
+- [x] `grip_hover_row_at` hand-mirrors the prepaint grip geometry (26 vs
   grip_left−4 constants) — extract one shared row/band computation. (S)
-- [ ] `menu_turn_into` belongs inside `DiagMenu` (dies with the menu; today
+- [x] `menu_turn_into` belongs inside `DiagMenu` (dies with the menu; today
   it's sticky once hovered and reset at only one open site). (S)
 
 ## App & polish

--- a/TODO.md
+++ b/TODO.md
@@ -130,7 +130,7 @@ blockers, occluded grip presses + turn-into grammar, were fixed in 3c050f6):
 - [ ] Feed-window day heights are keyed by child POSITION and invalidated only
   on width change — key by date + invalidate on content change so a day-set or
   offscreen-content change can't leave stale spacer heights. (S)
-- [ ] Caret-parked-on-marker is patched at two entry points (resize-band press,
+- [x] Caret-parked-on-marker is patched at two entry points (resize-band press,
   `rewrite_table_marker`); other focus-without-caret-move affordances (pills,
   delete handles, code Copy, fold chevrons, image grips) can still flash raw
   markers — enforce "caret never rests on a collapsed marker line" once in the

--- a/TODO.md
+++ b/TODO.md
@@ -80,14 +80,14 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
   header render ragged (Cditor rejects); validate in `table_regions`. (S)
 
 **Performance (gpui-editor):**
-- [ ] **Document shaped TWICE per frame** — `shape_document` runs in the measure
+- [x] **Document shaped TWICE per frame** — `shape_document` runs in the measure
   closure AND prepaint with identical inputs; memoize one frame's result across
   the two passes. Halves editor cost, removes a divergence hazard. (S)
 - [ ] **Cross-frame shaped-line cache** — every blink/hover reshapes every
   visible day's full text; adopt Cditor's `LayoutCacheKey` (content version +
   width bucket + font/theme/scale). gpui-markdown's `PARSE_CACHE` is the
   in-repo template. (M)
-- [ ] **IME UTF-16↔UTF-8 mapping is O(document) per call** — scan from the
+- [x] **IME UTF-16↔UTF-8 mapping is O(document) per call** — scan from the
   caret's line start instead of byte 0; CJK composition latency currently grows
   with note size. Also: `bounds_for_range` anchors the candidate window at the
   composition START (zero-width) — return the marked range's real span. (S/M)

--- a/TODO.md
+++ b/TODO.md
@@ -112,7 +112,7 @@ His `ding-board` whiteboard fork is already adopted. Costs: S/M/L.
 - [x] **"Turn into" block conversion menu** — right-click/handle menu converting
   a block between text/H1–3/lists/todo/quote/callout/code/math, with the
   current kind checked; flat-markdown natural (rewrite the prefix). (M)
-- [ ] **Block drag-reorder** — gutter grip drag to move a block/line (his
+- [x] **Block drag-reorder** — gutter grip drag to move a block/line (his
   gutter_drag + move-subtree pipeline; ours = reorder markdown lines). (M/L)
 - [ ] **Type-to-filter search in the table menu** — the menu is 18 rows now;
   his cell menu filters by label + keywords as you type. (S/M)

--- a/assets/icons/align-center.svg
+++ b/assets/icons/align-center.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v1.18.0 - ISC -->
+<svg
+  class="lucide lucide-align-center"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 5H3" />
+  <path d="M17 12H7" />
+  <path d="M19 19H5" />
+</svg>

--- a/assets/icons/align-right.svg
+++ b/assets/icons/align-right.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v1.18.0 - ISC -->
+<svg
+  class="lucide lucide-align-right"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 5H3" />
+  <path d="M21 12H9" />
+  <path d="M21 19H7" />
+</svg>

--- a/assets/icons/app-window.svg
+++ b/assets/icons/app-window.svg
@@ -1,0 +1,18 @@
+<!-- @license lucide-static v1.18.0 - ISC -->
+<svg
+  class="lucide lucide-app-window"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect x="2" y="4" width="20" height="16" rx="2" />
+  <path d="M10 4v4" />
+  <path d="M2 8h20" />
+  <path d="M6 4v4" />
+</svg>

--- a/assets/icons/file-down.svg
+++ b/assets/icons/file-down.svg
@@ -1,0 +1,18 @@
+<!-- @license lucide-static v1.18.0 - ISC -->
+<svg
+  class="lucide lucide-file-down"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+  <path d="M12 18v-6" />
+  <path d="m9 15 3 3 3-3" />
+</svg>

--- a/assets/icons/file-text.svg
+++ b/assets/icons/file-text.svg
@@ -1,0 +1,19 @@
+<!-- @license lucide-static v1.18.0 - ISC -->
+<svg
+  class="lucide lucide-file-text"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+  <path d="M10 9H8" />
+  <path d="M16 13H8" />
+  <path d="M16 17H8" />
+</svg>

--- a/assets/icons/trash-2.svg
+++ b/assets/icons/trash-2.svg
@@ -1,0 +1,19 @@
+<!-- @license lucide-static v1.18.0 - ISC -->
+<svg
+  class="lucide lucide-trash-2"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 11v6" />
+  <path d="M14 11v6" />
+  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+  <path d="M3 6h18" />
+  <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+</svg>

--- a/crates/gpui-editor/API.md
+++ b/crates/gpui-editor/API.md
@@ -45,6 +45,8 @@ crate root; nothing from `gpui-markdown` is re-exported.)
 | [`EditorState::on_suggest`](#on_suggest) | method | `fn on_suggest(&mut self, provider: impl Fn(&str) -> Vec<String> + 'static)` | Lazy right-click suggestion provider |
 | [`EditorState::set_markdown_style`](#set_markdown_style) | method | `fn set_markdown_style(&mut self, style: SyntaxStyle, cx: &mut Context<Self>)` | Turn on WYSIWYG styling |
 | [`EditorState::set_code_languages`](#set_code_languages) | method | `fn set_code_languages(&mut self, langs: Vec<SharedString>)` | Languages for the code card's picker |
+| [`EditorState::set_scroll_compensator`](#set_scroll_compensator) | method | `fn set_scroll_compensator(&mut self, f: impl Fn(Pixels, &mut Window, &mut App) + 'static)` | Scroll anchoring for async block renders |
+| [`ScrollCompensatorFn`](#set_scroll_compensator) | type alias | `Rc<dyn Fn(Pixels, &mut Window, &mut App)>` | The installed compensator's shape |
 | [`EditorState::clear_markdown_style`](#clear_markdown_style) | method | `fn clear_markdown_style(&mut self, cx: &mut Context<Self>)` | Back to plain text at runtime |
 | [`EditorState::set_block_image_provider`](#set_block_image_provider) | method | `fn set_block_image_provider(&mut self, impl Fn(&str) -> Option<Arc<RenderImage>> + 'static)` | Standalone `![](src)` → decoded image |
 | [`EditorState::set_block_chip_provider`](#set_block_chip_provider) | method | `fn set_block_chip_provider(&mut self, impl Fn(&str) -> Option<SharedString> + 'static)` | Classify `![](src)` as a file chip + label |
@@ -515,6 +517,21 @@ selecting one rewrites the opening fence (` ```lang `) as one undo step.
 Supply the host highlighter's grammar set (a `"text"` entry maps to no
 language). Empty — the default — leaves the tag click-inert. The Copy button
 needs no setup: it writes the block's body through the clipboard writer.
+
+#### `set_scroll_compensator`
+
+```rust
+pub fn set_scroll_compensator(&mut self, f: impl Fn(Pixels, &mut Window, &mut App) + 'static)
+```
+
+Scroll anchoring: when an ASYNC height change — a math/mermaid/image raster
+arriving and collapsing raw source lines into a rendered block — lands above
+the window's viewport, the hook receives the height delta so the host can
+shift its scroll container's offset by it (`offset.y -= delta`) and the
+content being read stays put. Detected in the measure pass (same content
+generation as the last paint but different heights ⇒ no edit was involved),
+and called before the scroll container places its children, so the
+compensation applies in the same frame. Edits never trigger it.
 
 #### `clear_markdown_style`
 

--- a/crates/gpui-editor/API.md
+++ b/crates/gpui-editor/API.md
@@ -109,9 +109,10 @@ works on macOS, Windows, and Linux): backspace/delete/enter; arrows,
 home/end; `shift-` + any movement to extend the selection;
 `alt-left`/`alt-right` (± `shift`) word-wise; `cmd-a` select all;
 `cmd-c`/`cmd-x`/`cmd-v`; `cmd-z` undo, `cmd-shift-z`/`ctrl-y` redo;
-`tab`/`shift-tab` indent/outdent; `cmd-b`/`cmd-i`/`cmd-e`
-bold/italic/inline-code; `ctrl-cmd-space` character palette; `escape`
-dismisses the built-in right-click menus.
+`tab`/`shift-tab` indent/outdent; `cmd-b`/`cmd-i`/`cmd-u`/`cmd-e`/
+`cmd-shift-x` bold/italic/underline (`<u>`)/inline-code/strikethrough;
+`ctrl-cmd-space` character palette; `escape` dismisses the built-in
+right-click menus.
 
 ---
 

--- a/crates/gpui-editor/API.md
+++ b/crates/gpui-editor/API.md
@@ -44,6 +44,7 @@ crate root; nothing from `gpui-markdown` is re-exported.)
 | [`EditorState::set_diagnostics`](#set_diagnostics) | method | `fn set_diagnostics(&mut self, diagnostics: Vec<Diagnostic>, cx: &mut Context<Self>)` | Replace the underlined spans |
 | [`EditorState::on_suggest`](#on_suggest) | method | `fn on_suggest(&mut self, provider: impl Fn(&str) -> Vec<String> + 'static)` | Lazy right-click suggestion provider |
 | [`EditorState::set_markdown_style`](#set_markdown_style) | method | `fn set_markdown_style(&mut self, style: SyntaxStyle, cx: &mut Context<Self>)` | Turn on WYSIWYG styling |
+| [`EditorState::set_code_languages`](#set_code_languages) | method | `fn set_code_languages(&mut self, langs: Vec<SharedString>)` | Languages for the code card's picker |
 | [`EditorState::clear_markdown_style`](#clear_markdown_style) | method | `fn clear_markdown_style(&mut self, cx: &mut Context<Self>)` | Back to plain text at runtime |
 | [`EditorState::set_block_image_provider`](#set_block_image_provider) | method | `fn set_block_image_provider(&mut self, impl Fn(&str) -> Option<Arc<RenderImage>> + 'static)` | Standalone `![](src)` → decoded image |
 | [`EditorState::set_block_chip_provider`](#set_block_chip_provider) | method | `fn set_block_chip_provider(&mut self, impl Fn(&str) -> Option<SharedString> + 'static)` | Classify `![](src)` as a file chip + label |
@@ -497,6 +498,19 @@ revealed only around the caret, lists/quotes/alerts/rules drawn, tables
 gridded. Without it the editor is the **raw** view: plain text, spell
 squiggles only. The block providers below are each independently optional on
 top of this.
+
+#### `set_code_languages`
+
+```rust
+pub fn set_code_languages(&mut self, langs: Vec<SharedString>)
+```
+
+The languages offered in a code block's language picker — the tag at the
+card's top-right (next to its Copy button) opens a scrollable menu of these;
+selecting one rewrites the opening fence (` ```lang `) as one undo step.
+Supply the host highlighter's grammar set (a `"text"` entry maps to no
+language). Empty — the default — leaves the tag click-inert. The Copy button
+needs no setup: it writes the block's body through the clipboard writer.
 
 #### `clear_markdown_style`
 

--- a/crates/gpui-editor/API.md
+++ b/crates/gpui-editor/API.md
@@ -46,6 +46,7 @@ crate root; nothing from `gpui-markdown` is re-exported.)
 | [`EditorState::set_markdown_style`](#set_markdown_style) | method | `fn set_markdown_style(&mut self, style: SyntaxStyle, cx: &mut Context<Self>)` | Turn on WYSIWYG styling |
 | [`EditorState::set_code_languages`](#set_code_languages) | method | `fn set_code_languages(&mut self, langs: Vec<SharedString>)` | Languages for the code card's picker |
 | [`EditorState::set_scroll_compensator`](#set_scroll_compensator) | method | `fn set_scroll_compensator(&mut self, f: impl Fn(Pixels, &mut Window, &mut App) + 'static)` | Scroll anchoring for async block renders |
+| `EditorState::set_grip_inset` | method | `fn set_grip_inset(&mut self, inset: Pixels)` | Shift the block-drag gutter grip left of host gutter chrome (e.g. line numbers) |
 | [`ScrollCompensatorFn`](#set_scroll_compensator) | type alias | `Rc<dyn Fn(Pixels, &mut Window, &mut App)>` | The installed compensator's shape |
 | [`EditorState::clear_markdown_style`](#clear_markdown_style) | method | `fn clear_markdown_style(&mut self, cx: &mut Context<Self>)` | Back to plain text at runtime |
 | [`EditorState::set_block_image_provider`](#set_block_image_provider) | method | `fn set_block_image_provider(&mut self, impl Fn(&str) -> Option<Arc<RenderImage>> + 'static)` | Standalone `![](src)` → decoded image |

--- a/crates/gpui-editor/API.md
+++ b/crates/gpui-editor/API.md
@@ -76,8 +76,11 @@ crate root; nothing from `gpui-markdown` is re-exported.)
 | [`EditorState::insert_table_column`](#insert_table_column) | method | `fn insert_table_column(&mut self, right: bool, cx: &mut Context<Self>)` | Empty column left/right of the caret's |
 | [`EditorState::delete_table_column`](#delete_table_column) | method | `fn delete_table_column(&mut self, cx: &mut Context<Self>)` | Delete the caret's column (not the last) |
 | [`EditorState::delete_table`](#delete_table) | method | `fn delete_table(&mut self, cx: &mut Context<Self>)` | Delete the whole table block |
+| [`EditorState::duplicate_table_row`](#duplicate_table_row) | method | `fn duplicate_table_row(&mut self, cx: &mut Context<Self>)` | Copy the caret's row below itself |
+| [`EditorState::copy_table`](#copy_table) | method | `fn copy_table(&mut self, cx: &mut Context<Self>)` | Whole table to the clipboard (markdown) |
+| [`EditorState::set_table_style`](#set_table_style) | method | `fn set_table_style(&mut self, name: Option<&'static str>, cx: &mut Context<Self>)` | Rewrite the table's style marker |
 | [`EditorEvent`](#enum-editorevent) | enum | 8 variants | Everything the editor asks the host to do |
-| [`SyntaxStyle`](#struct-syntaxstyle) | struct | 21 public fields | Colors + fonts + icon hooks for WYSIWYG |
+| [`SyntaxStyle`](#struct-syntaxstyle) | struct | 22 public fields | Colors + fonts + icon hooks for WYSIWYG |
 | [`AlertIcons`](#struct-alerticons) | struct | 5 public fields | SVG asset paths for alert title icons |
 | [`Diagnostic`](#struct-diagnostic) | struct | `pub range: Range<usize>` | A flagged (underlined) span |
 | [`CellAlign`](#enum-cellalign) | enum | `Left · Center · Right` | A table column's alignment |
@@ -895,6 +898,38 @@ Set the caret column's alignment by rewriting the table's `|---|` separator
 row (`:--` / `:-:` / `--:`); the caret stays put. No-op outside a table or on
 the separator row itself.
 
+#### `duplicate_table_row`
+
+```rust
+pub fn duplicate_table_row(&mut self, cx: &mut Context<Self>)
+```
+
+Duplicate the caret's row directly below itself (a duplicated header lands
+below the separator, as the first body row). The caret lands in the copy —
+same cell, same in-cell offset. No-op on the separator or outside a table.
+
+#### `copy_table`
+
+```rust
+pub fn copy_table(&mut self, cx: &mut Context<Self>)
+```
+
+Copy the caret's whole table — its grid source plus any
+`<!-- table:STYLE -->` marker line — to the clipboard through the installed
+clipboard writer (plain markdown, pasteable anywhere). No-op outside a table.
+
+#### `set_table_style`
+
+```rust
+pub fn set_table_style(&mut self, name: Option<&'static str>, cx: &mut Context<Self>)
+```
+
+Set the caret table's visual style by rewriting the `<!-- table:STYLE -->`
+marker line above its header: `Some("striped" | "header" | "minimal")`
+writes/replaces the marker, `None` (Grid — the default style) removes it. One
+undo step; the caret stays in its cell. Offered in the built-in right-click
+table menu with the current style checked.
+
 #### `insert_table_row`
 
 ```rust
@@ -1076,6 +1111,7 @@ every field explicit. All fields are `gpui::Hsla` unless noted.
 | `popover_fg` | `Hsla` | menu text |
 | `popover_hover` | `Hsla` | menu hovered-row background |
 | `popover_divider` | `Hsla` | menu group divider |
+| `popover_danger` | `Hsla` | menu destructive rows (Delete …) |
 | `mono` | `gpui::Font` | monospace font for inline code + code blocks |
 | `property_icon` | `Option<PropertyIconFn>` | property key → icon asset path for the property panel; `None` = no icons |
 

--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -77,6 +77,7 @@ fn demo_markdown_style() -> SyntaxStyle {
         popover_fg: hsla(0., 0., 0.9, 1.),           // menu text
         popover_hover: hsla(0.58, 0.75, 0.66, 0.16), // soft accent tint
         popover_divider: hsla(0., 0., 1., 0.18),     // group divider
+        popover_danger: gpui::rgb(0xE5484D).into(),  // destructive rows
         mono: font("Menlo"),
         property_icon: None,
     }

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -307,6 +307,38 @@ impl TurnKind {
     }
 }
 
+/// If `offset` sits on a collapsed marker line (a table style marker or a
+/// math align marker), the offset of the nearest line that reveals nothing
+/// when the caret rests there: the table's header, or the line after the
+/// math block. Otherwise `offset` unchanged.
+fn caret_off_marker_line(content: &str, offset: usize) -> usize {
+    let row = content[..offset.min(content.len())].matches('\n').count();
+    let line_start = |r: usize| {
+        let mut off = 0;
+        for (i, l) in content.split('\n').enumerate() {
+            if i == r {
+                return off;
+            }
+            off += l.len() + 1;
+        }
+        content.len()
+    };
+    if let Some(t) = markdown_syntax::table_regions(content)
+        .iter()
+        .find(|t| t.marker_line == Some(row))
+    {
+        return line_start(t.lines.start);
+    }
+    if let Some(m) = markdown_syntax::math_regions(content)
+        .iter()
+        .find(|m| m.marker_line == Some(row))
+    {
+        // Anywhere inside a math region reveals it whole — land after it.
+        return line_start(m.range.end);
+    }
+    offset
+}
+
 /// Strip a line's block dressing (heading hashes, list/todo bullet, ordered
 /// number, quote `>`), leaving the text a "Turn into" conversion re-prefixes.
 fn strip_block_prefix(line: &str) -> &str {
@@ -976,7 +1008,12 @@ impl EditorState {
     pub fn set_text(&mut self, text: impl Into<String>, cx: &mut Context<Self>) {
         self.content_gen += 1;
         self.content = text.into();
-        self.selected_range = 0..0;
+        // Never park the loaded caret on a collapsed marker line (`<!-- table/
+        // math:… -->`): the first focus would reveal it raw mid-interaction.
+        // This is the ONE passive parking path — every other caret write is a
+        // deliberate placement (which SHOULD reveal markers for editing).
+        let caret = caret_off_marker_line(&self.content, 0);
+        self.selected_range = caret..caret;
         self.selection_reversed = false;
         self.marked_range = None;
         // A programmatic load isn't undoable to the prior document.
@@ -2791,20 +2828,6 @@ impl EditorState {
                 orig: width,
                 width,
             });
-            // The press focuses the editor without moving the caret — if it
-            // was parked on this table's style-marker line (offset 0 right
-            // after a document loads), reveal-on-caret would flash the raw
-            // `<!-- table:… -->` mid-drag. Seat it in the header cell instead.
-            let caret_row = self.row_col(self.selected_range.start).0;
-            if self
-                .scan_data()
-                .tables
-                .iter()
-                .any(|r| r.lines.start == header_row && r.marker_line == Some(caret_row))
-            {
-                let caret = self.caret_pos_for_cell(header_row, 0, 0);
-                self.selected_range = caret..caret;
-            }
             self.is_selecting = false;
             cx.notify();
             return;
@@ -11204,6 +11227,21 @@ fn word_boundary_input(new_text: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn caret_off_marker_line_cases() {
+        use super::caret_off_marker_line;
+        // Table marker at the top: the caret steps to the header line.
+        let doc = "<!-- table:grid cols=40,40 -->\n| a | b |\n| --- | --- |\n| 1 | 2 |";
+        assert_eq!(caret_off_marker_line(doc, 0), 31);
+        // Math align marker: the caret lands after the block.
+        let doc = "<!-- math:center -->\n$$\nx^2\n$$\nafter";
+        assert_eq!(caret_off_marker_line(doc, 0), 31);
+        assert_eq!(&doc[31..], "after");
+        // Plain lines pass through untouched.
+        assert_eq!(caret_off_marker_line("hello\nworld", 0), 0);
+        assert_eq!(caret_off_marker_line("", 0), 0);
+    }
+
     #[test]
     fn strip_block_prefix_cases() {
         use super::strip_block_prefix;

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -2006,7 +2006,31 @@ impl EditorState {
                 .any(|e| matches!(e, gpui::ClipboardEntry::ExternalPaths(_)))
         });
         match item.and_then(|i| i.text()).filter(|_| !has_files) {
-            Some(text) => self.replace_text_in_range(None, &text, window, cx),
+            Some(text) => {
+                // Normalize foreign line endings — a Windows/browser copy
+                // carries \r\n (or bare \r), and a literal \r in the buffer
+                // garbles rendering + desyncs the \n-based column math.
+                let mut text = if text.contains('\r') {
+                    text.replace("\r\n", "\n").replace('\r', "\n")
+                } else {
+                    text
+                };
+                // Inside a table cell, a raw paste of newlines/pipes would
+                // break the `| … |` row markup (Enter is guarded the same
+                // way): flatten newlines and escape pipes so the paste stays
+                // one cell's content.
+                if self.caret_in_table() && text.contains(['\n', '|']) {
+                    // Unescape-then-escape so text already carrying `\|`
+                    // doesn't double up into `\\|` (an escaped backslash
+                    // followed by a live separator).
+                    text = text
+                        .trim_end_matches('\n')
+                        .replace('\n', " ")
+                        .replace("\\|", "|")
+                        .replace('|', "\\|");
+                }
+                self.replace_text_in_range(None, &text, window, cx);
+            }
             None => cx.propagate(),
         }
     }

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -647,6 +647,13 @@ pub struct EditorState {
     scan_cache: std::cell::RefCell<Option<(u64, std::rc::Rc<ScanData>)>>,
     /// See [`ScrollCompensatorFn`].
     scroll_compensator: Option<ScrollCompensatorFn>,
+    /// Cross-frame cache of each markdown line's `hidden_runs` output — the
+    /// residual per-frame cost after the scan cache (gpui's own layout cache
+    /// already absorbs glyph shaping): building every line's display string +
+    /// run list on every repaint. Keyed by a hash of the line + its reveal
+    /// state; edits miss only the lines they changed. Capacity-capped in
+    /// `shape_document`.
+    line_run_cache: std::cell::RefCell<std::collections::HashMap<u64, CachedLineRuns>>,
     /// `content_gen` as of the last paint — a measure with the SAME generation
     /// but different heights means an async (non-edit) height change, the
     /// scroll-anchoring trigger.
@@ -786,6 +793,7 @@ impl EditorState {
             scan_cache: std::cell::RefCell::new(None),
             scroll_compensator: None,
             last_paint_gen: 0,
+            line_run_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
             content_gen: 0,
             utf16_anchor: std::cell::Cell::new((0, 0, 0)),
             editing_block: None,
@@ -6140,6 +6148,8 @@ fn shape_document(
     col_resize: Option<TableColResize>,
     // The content's cached structural scans (see [`ScanData`]).
     scan: &ScanData,
+    // Cross-frame per-line run cache (see `EditorState::line_run_cache`).
+    line_cache: &std::cell::RefCell<std::collections::HashMap<u64, CachedLineRuns>>,
     // Collapsed headings (trimmed source lines) — their section lines fold to
     // height 0 like a folded callout's body.
     folded_headings: &std::collections::HashSet<String>,
@@ -6310,6 +6320,8 @@ fn shape_document(
     };
     // Table regions (W4c); content-fit column widths shared by each region's rows.
     let regions: &[markdown_syntax::TableRegion] = if md.is_some() { &scan.tables } else { &[] };
+    // Shared component of the per-line run-cache key (see `CachedLineRuns`).
+    let run_epoch = line_run_epoch(base_font, md);
     let mut region_cols: Vec<Vec<Pixels>> = Vec::with_capacity(regions.len());
     for r in regions {
         region_cols.push(table_column_widths(
@@ -7018,17 +7030,60 @@ fn shape_document(
         {
             // Markers hidden (except the caret's construct): shape the display
             // string + keep a map back to source.
-            let (disp, runs, m) = markdown_syntax::hidden_runs(
-                line,
-                base_font,
-                line_base,
-                &line_diags,
-                caret_col,
-                reveal_prefix,
-                hide_prefix,
-                reveal_inline,
-                st,
-            );
+            // Cross-frame cache: most repaints (caret blink, hover, another
+            // editor's edit) rebuild identical lines — reuse the built display
+            // string + runs when the line and its reveal state are unchanged.
+            let key = {
+                use std::hash::{Hash, Hasher};
+                let mut h = std::collections::hash_map::DefaultHasher::new();
+                line.hash(&mut h);
+                line_base.a.to_bits().hash(&mut h);
+                line_base.h.to_bits().hash(&mut h);
+                line_base.s.to_bits().hash(&mut h);
+                line_base.l.to_bits().hash(&mut h);
+                caret_col.hash(&mut h);
+                reveal_prefix.hash(&mut h);
+                hide_prefix.hash(&mut h);
+                reveal_inline.hash(&mut h);
+                for d in &line_diags {
+                    d.range.start.hash(&mut h);
+                    d.range.end.hash(&mut h);
+                }
+                run_epoch.hash(&mut h);
+                h.finish()
+            };
+            let cached = line_cache
+                .borrow()
+                .get(&key)
+                .filter(|c| c.src == line && c.line_base == line_base)
+                .map(|c| (c.disp.clone(), c.runs.clone(), c.map.clone()));
+            let (disp, runs, m) = match cached {
+                Some(v) => v,
+                None => {
+                    let (disp, runs, m) = markdown_syntax::hidden_runs(
+                        line,
+                        base_font,
+                        line_base,
+                        &line_diags,
+                        caret_col,
+                        reveal_prefix,
+                        hide_prefix,
+                        reveal_inline,
+                        st,
+                    );
+                    line_cache.borrow_mut().insert(
+                        key,
+                        CachedLineRuns {
+                            src: line.to_string(),
+                            line_base,
+                            disp: disp.clone(),
+                            runs: runs.clone(),
+                            map: m.clone(),
+                        },
+                    );
+                    (disp, runs, m)
+                }
+            };
             // A checked task's body renders struck through + muted (the reader
             // does the same) — a whole-line restyle over the finished runs.
             let (disp, runs, m) = if matches!(mark, Some(LineMark::Check { checked: true, .. })) {
@@ -7170,6 +7225,16 @@ fn shape_document(
                 cb.width = bw;
                 cb.bottom = bi == last;
             }
+        }
+    }
+    // Cap the run cache: edits retire entries (each changed line re-keys), so
+    // without a bound it grows one dead entry per keystroke. Clearing wholesale
+    // is fine — the next frame rebuilds only what's visible… which is
+    // everything today, but each rebuild re-primes the cache.
+    {
+        let mut cache = line_cache.borrow_mut();
+        if cache.len() > lines.len() * 2 + 64 {
+            cache.clear();
         }
     }
     (
@@ -8051,6 +8116,41 @@ struct TableAffordance {
     accent: Hsla,
 }
 
+/// One markdown line's built display + runs, cached across frames (see
+/// `EditorState::line_run_cache`). `src` and `line_base` verify a hash hit —
+/// the rest of the inputs are folded into the key's hash.
+struct CachedLineRuns {
+    src: String,
+    line_base: Hsla,
+    disp: String,
+    runs: Vec<TextRun>,
+    map: Vec<usize>,
+}
+
+/// A hash of the inputs shared by every line's run build (font + palette) —
+/// part of the per-line cache key, so a theme or font change misses cleanly.
+fn line_run_epoch(font: &Font, st: Option<&SyntaxStyle>) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    font.family.hash(&mut h);
+    font.weight.0.to_bits().hash(&mut h);
+    let hash_hsla = |c: Hsla, h: &mut std::collections::hash_map::DefaultHasher| {
+        c.h.to_bits().hash(h);
+        c.s.to_bits().hash(h);
+        c.l.to_bits().hash(h);
+        c.a.to_bits().hash(h);
+    };
+    if let Some(st) = st {
+        for c in [
+            st.marker, st.code, st.code_bg, st.link, st.tag, st.quote, st.mark_bg,
+        ] {
+            hash_hsla(c, &mut h);
+        }
+        st.mono.family.hash(&mut h);
+    }
+    h.finish()
+}
+
 /// Host hook for scroll anchoring: called from the measure pass when an
 /// ASYNC height change (a math/mermaid/image raster arriving) lands ABOVE
 /// the window's viewport, with the height delta — the host shifts its scroll
@@ -8269,6 +8369,7 @@ impl Element for EditorElement {
                     editor.image_resize,
                     editor.table_col_resize,
                     &scan,
+                    &editor.line_run_cache,
                     &editor.folded_headings,
                 );
                 // Mirror prepaint's `line_tops` walk exactly (same `line_pads`),
@@ -8442,6 +8543,7 @@ impl Element for EditorElement {
                     editor.image_resize,
                     editor.table_col_resize,
                     &editor.scan_data(),
+                    &editor.line_run_cache,
                     &editor.folded_headings,
                 )
             };

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -257,6 +257,100 @@ struct DiagMenu {
     scroll: ScrollHandle,
 }
 
+/// A block kind the right-click "Turn into" menu converts between —
+/// flat-markdown natural: each conversion is a line-prefix rewrite (fenced
+/// kinds wrap/unwrap the block's lines).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TurnKind {
+    Text,
+    H1,
+    H2,
+    H3,
+    Bullet,
+    Numbered,
+    Todo,
+    Quote,
+    Callout,
+    Code,
+    Math,
+}
+
+impl TurnKind {
+    const ALL: [TurnKind; 11] = [
+        TurnKind::Text,
+        TurnKind::H1,
+        TurnKind::H2,
+        TurnKind::H3,
+        TurnKind::Bullet,
+        TurnKind::Numbered,
+        TurnKind::Todo,
+        TurnKind::Quote,
+        TurnKind::Callout,
+        TurnKind::Code,
+        TurnKind::Math,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            TurnKind::Text => "Text",
+            TurnKind::H1 => "Heading 1",
+            TurnKind::H2 => "Heading 2",
+            TurnKind::H3 => "Heading 3",
+            TurnKind::Bullet => "Bulleted list",
+            TurnKind::Numbered => "Numbered list",
+            TurnKind::Todo => "To-do",
+            TurnKind::Quote => "Quote",
+            TurnKind::Callout => "Callout",
+            TurnKind::Code => "Code block",
+            TurnKind::Math => "Math block",
+        }
+    }
+}
+
+/// Strip a line's block dressing (heading hashes, list/todo bullet, ordered
+/// number, quote `>`), leaving the text a "Turn into" conversion re-prefixes.
+fn strip_block_prefix(line: &str) -> &str {
+    let t = line.trim_start();
+    for p in ["- [ ] ", "- [x] ", "- [X] "] {
+        if let Some(r) = t.strip_prefix(p) {
+            return r;
+        }
+    }
+    let hashes = t.len() - t.trim_start_matches('#').len();
+    if (1..=6).contains(&hashes)
+        && let Some(r) = t[hashes..].strip_prefix(' ')
+    {
+        return r;
+    }
+    for p in ["- ", "* ", "+ "] {
+        if let Some(r) = t.strip_prefix(p) {
+            return r;
+        }
+    }
+    let digits = t.len() - t.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+    if digits > 0
+        && let Some(r) = t[digits..]
+            .strip_prefix(". ")
+            .or_else(|| t[digits..].strip_prefix(") "))
+    {
+        return r;
+    }
+    if let Some(r) = t.strip_prefix("> ").or_else(|| t.strip_prefix('>')) {
+        return r;
+    }
+    t
+}
+
+/// Join `body` lines each carrying the prefix `p(index)` produces — the
+/// assembly half of a "Turn into" conversion.
+fn prefix_lines(body: &[String], p: impl Fn(usize) -> String) -> String {
+    body.iter()
+        .enumerate()
+        .map(|(i, l)| format!("{}{l}", p(i)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// A column edit applied to every row of a table (insert/delete a cell at index).
 #[derive(Clone, Copy)]
 enum ColEdit {
@@ -560,6 +654,9 @@ pub struct EditorState {
     markdown_style: Option<SyntaxStyle>,
     /// The open right-click suggestions menu, if any.
     menu: Option<DiagMenu>,
+    /// Whether the menu's "Turn into" flyout is open (hover-opened, lives
+    /// until the menu closes).
+    menu_turn_into: bool,
     /// The open table right-click menu's anchor (window space), if any. Its actions
     /// operate on the caret's table cell.
     table_menu: Option<Point<Pixels>>,
@@ -757,6 +854,7 @@ impl EditorState {
             diagnostics: Vec::new(),
             markdown_style: None,
             menu: None,
+            menu_turn_into: false,
             table_menu: None,
             table_menu_scroll: ScrollHandle::new(),
             image_menu: None,
@@ -3042,6 +3140,7 @@ impl EditorState {
             }
             None => (offset..offset, Vec::new()),
         };
+        self.menu_turn_into = false;
         self.menu = Some(DiagMenu {
             anchor,
             range,
@@ -3082,6 +3181,156 @@ impl EditorState {
         self.selected_range = range;
         self.selection_reversed = false;
         self.replace_text_in_range(None, text, window, cx);
+    }
+
+    /// The "Turn into" kind of the block containing `row` — what the flyout
+    /// shows checked.
+    fn block_kind_at(&self, row: usize) -> TurnKind {
+        let scan = self.scan_data();
+        if scan.math.iter().any(|m| m.range.contains(&row)) {
+            return TurnKind::Math;
+        }
+        let starts = self.line_starts();
+        let Some(&start) = starts.get(row) else {
+            return TurnKind::Text;
+        };
+        let t = self.content[start..self.line_end(row)].trim_start();
+        if scan.fence_odd.get(row).copied().unwrap_or(false) || t.starts_with("```") {
+            return TurnKind::Code;
+        }
+        if ["- [ ]", "- [x]", "- [X]"].iter().any(|p| t.starts_with(p)) {
+            return TurnKind::Todo;
+        }
+        match t.len() - t.trim_start_matches('#').len() {
+            1 if t.starts_with("# ") => return TurnKind::H1,
+            2 if t.starts_with("## ") => return TurnKind::H2,
+            3 if t.starts_with("### ") => return TurnKind::H3,
+            _ => {}
+        }
+        if ["- ", "* ", "+ "].iter().any(|p| t.starts_with(p)) {
+            return TurnKind::Bullet;
+        }
+        let digits = t.len() - t.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+        if digits > 0 && (t[digits..].starts_with(". ") || t[digits..].starts_with(") ")) {
+            return TurnKind::Numbered;
+        }
+        if t.starts_with('>') {
+            // Callout if the caret's contiguous `>`-run carries a `[!KIND]`
+            // marker anywhere; the marker line itself or any body line counts.
+            let line_at = |r: usize| self.content[starts[r]..self.line_end(r)].trim_start();
+            let mut first = row;
+            while first > 0 && line_at(first - 1).starts_with('>') {
+                first -= 1;
+            }
+            let mut r = first;
+            while r < starts.len() && line_at(r).starts_with('>') {
+                if line_at(r)[1..].trim_start().starts_with("[!") {
+                    return TurnKind::Callout;
+                }
+                r += 1;
+            }
+            return TurnKind::Quote;
+        }
+        TurnKind::Text
+    }
+
+    /// Convert the caret's block to `kind` — the "Turn into" menu action.
+    /// One undoable edit rewriting the block's lines; fenced kinds (code,
+    /// math) and quote runs convert as whole blocks.
+    fn turn_into(&mut self, kind: TurnKind, window: &mut Window, cx: &mut Context<Self>) {
+        let row = self.row_col(self.selected_range.start).0;
+        let cur = self.block_kind_at(row);
+        if cur == kind {
+            return;
+        }
+        let scan = self.scan_data();
+        let starts = self.line_starts();
+        let last_row = starts.len().saturating_sub(1);
+        let line_at = |r: usize| self.content[starts[r]..self.line_end(r)].to_string();
+        // The block's line span + its content with the current dressing removed.
+        let (first, last, mut body): (usize, usize, Vec<String>) = match cur {
+            TurnKind::Code => {
+                let open = (0..=row)
+                    .rev()
+                    .find(|&r| !scan.fence_odd.get(r).copied().unwrap_or(false))
+                    .unwrap_or(0);
+                let close =
+                    ((open + 1)..=last_row).find(|&r| line_at(r).trim_start().starts_with("```"));
+                let last = close.unwrap_or(last_row);
+                let body_end = close.map(|c| c - 1).unwrap_or(last_row);
+                let body = ((open + 1)..=body_end).map(line_at).collect();
+                (open, last, body)
+            }
+            TurnKind::Math => {
+                let Some(reg) = scan.math.iter().find(|m| m.range.contains(&row)) else {
+                    return;
+                };
+                let first = reg.range.start;
+                let last = reg.range.end.saturating_sub(1).max(first);
+                let body = ((first + 1)..last).map(line_at).collect();
+                (first, last, body)
+            }
+            TurnKind::Quote | TurnKind::Callout => {
+                let is_q = |r: usize| line_at(r).trim_start().starts_with('>');
+                let mut first = row;
+                while first > 0 && is_q(first - 1) {
+                    first -= 1;
+                }
+                let mut last = row;
+                while last < last_row && is_q(last + 1) {
+                    last += 1;
+                }
+                let body = (first..=last)
+                    .filter_map(|r| {
+                        let line = line_at(r);
+                        let stripped = strip_block_prefix(&line);
+                        // Drop the `[!KIND]` marker token; keep any title text
+                        // after it (and skip the line if that leaves nothing).
+                        if let Some(rest) = stripped.trim_start().strip_prefix("[!") {
+                            let after = rest.split_once(']').map(|(_, a)| a).unwrap_or("");
+                            let after = after.trim_start_matches(['-', '+']).trim();
+                            return (!after.is_empty()).then(|| after.to_string());
+                        }
+                        Some(stripped.to_string())
+                    })
+                    .collect();
+                (first, last, body)
+            }
+            _ => (
+                row,
+                row,
+                vec![strip_block_prefix(&line_at(row)).to_string()],
+            ),
+        };
+        if body.is_empty() {
+            body.push(String::new());
+        }
+        let text = match kind {
+            TurnKind::Text => body.join("\n"),
+            TurnKind::H1 => prefix_lines(&body, |_| "# ".into()),
+            TurnKind::H2 => prefix_lines(&body, |_| "## ".into()),
+            TurnKind::H3 => prefix_lines(&body, |_| "### ".into()),
+            TurnKind::Bullet => prefix_lines(&body, |_| "- ".into()),
+            TurnKind::Numbered => prefix_lines(&body, |i| format!("{}. ", i + 1)),
+            TurnKind::Todo => prefix_lines(&body, |_| "- [ ] ".into()),
+            TurnKind::Quote => prefix_lines(&body, |_| "> ".into()),
+            TurnKind::Callout => format!("> [!NOTE]\n{}", prefix_lines(&body, |_| "> ".into())),
+            TurnKind::Code => format!("```\n{}\n```", body.join("\n")),
+            TurnKind::Math => format!("$$\n{}\n$$", body.join("\n")),
+        };
+        let range = starts[first]..self.line_end(last);
+        let range_start = range.start;
+        self.selected_range = range;
+        self.selection_reversed = false;
+        self.replace_text_in_range(None, &text, window, cx);
+        // Fenced kinds: the caret parks after the closing fence, revealing the
+        // raw markers (reveal-on-caret) — seat it on the body's first line
+        // instead, like `set_code_lang`.
+        if matches!(kind, TurnKind::Code | TurnKind::Math) {
+            let caret =
+                (range_start + text.find('\n').map_or(0, |i| i + 1)).min(self.content.len());
+            self.selected_range = caret..caret;
+        }
     }
 
     // --- Selection helpers ---------------------------------------------------
@@ -5010,49 +5259,134 @@ impl Render for EditorState {
                         )
                 });
 
+                // "Turn into" block conversion (Cditor-style): a row whose
+                // hover opens a kind-list flyout beside the menu, the caret
+                // block's current kind checked.
+                let cur_kind = self.block_kind_at(self.row_col(self.selected_range.start).0);
+                let turn_row = div()
+                    .id("menu-turn-into")
+                    .flex_shrink_0()
+                    .px(px(10.))
+                    .py(px(3.))
+                    .hover(move |s| s.bg(hover))
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .justify_between()
+                    .gap(px(16.))
+                    .child("Turn into")
+                    .child(div().text_size(px(10.)).child("\u{25b8}"))
+                    .on_hover(cx.listener(|editor, hovered: &bool, _, cx| {
+                        if *hovered && !editor.menu_turn_into {
+                            editor.menu_turn_into = true;
+                            cx.notify();
+                        }
+                    }));
+                let turn_flyout = self.menu_turn_into.then(|| {
+                    let rows: Vec<_> = TurnKind::ALL
+                        .iter()
+                        .enumerate()
+                        .map(|(i, &k)| {
+                            let checked = k == cur_kind;
+                            div()
+                                .id(("turn-kind", i))
+                                .flex_shrink_0()
+                                .px(px(10.))
+                                .py(px(3.))
+                                .hover(move |s| s.bg(hover))
+                                .flex()
+                                .flex_row()
+                                .items_center()
+                                .gap(px(6.))
+                                .child(div().w(px(12.)).flex_shrink_0().child(if checked {
+                                    "\u{2713}"
+                                } else {
+                                    ""
+                                }))
+                                .child(k.label())
+                                .on_mouse_down(
+                                    MouseButton::Left,
+                                    cx.listener(move |editor, _: &MouseDownEvent, window, cx| {
+                                        cx.stop_propagation();
+                                        editor.menu = None;
+                                        editor.turn_into(k, window, cx);
+                                    }),
+                                )
+                        })
+                        .collect();
+                    // An absolute sibling of the (overflow-clipped) menu box —
+                    // out of flow, so it can't inflate the anchored bounds and
+                    // re-trigger the window snap (the slash-flyout lesson).
+                    div()
+                        .absolute()
+                        .left(gpui::relative(1.))
+                        .bottom(px(0.))
+                        .ml(px(2.))
+                        .occlude()
+                        .min_w(px(140.))
+                        .cursor(CursorStyle::Arrow)
+                        .bg(menu_bg)
+                        .border_1()
+                        .border_color(menu_border)
+                        .rounded(px(6.))
+                        .shadow_md()
+                        .text_color(menu_fg)
+                        .text_size(px(13.))
+                        .flex()
+                        .flex_col()
+                        .py(px(4.))
+                        .children(rows)
+                });
+
                 // Deferred + anchored to a window-space top layer with `.occlude()`,
                 // so it renders above the page chrome and captures the wheel — else a
                 // scroll over the popup scrolls the page behind it.
                 gpui::deferred(
                     gpui::anchored().position(anchor).snap_to_window().child(
-                        div()
-                            .relative()
-                            .occlude()
-                            .min_w(px(150.))
-                            // Override the editor's I-beam — the menu is a normal
-                            // pointer surface (children inherit this hitbox's cursor).
-                            .cursor(CursorStyle::Arrow)
-                            .bg(menu_bg)
-                            .border_1()
-                            .border_color(menu_border)
-                            .rounded(px(6.))
-                            .shadow_md()
-                            // Clip rows + thumb to the rounded box.
-                            .overflow_hidden()
-                            .text_color(menu_fg)
-                            .text_size(px(13.))
-                            // A click anywhere outside the menu dismisses it.
-                            .on_mouse_down_out(cx.listener(|editor, _: &MouseDownEvent, _, cx| {
-                                editor.menu = None;
-                                cx.notify();
-                            }))
-                            .children(format_bar)
-                            .children(has_sel.then(|| div().h(px(1.)).bg(menu_border)))
-                            .children((count > 0).then(|| {
-                                // The scroll viewport: shows ~6 rows, the rest scroll.
-                                div()
-                                    .id("suggestion-menu")
-                                    .max_h(px(MAX_H))
-                                    .overflow_y_scroll()
-                                    .track_scroll(&scroll)
-                                    .flex()
-                                    .flex_col()
-                                    .py(px(PAD))
-                                    .children(rows)
-                            }))
-                            .children((count > 0).then(|| div().h(px(1.)).bg(menu_border)))
-                            .child(clipboard)
-                            .children(thumb),
+                        div().relative().children(turn_flyout).child(
+                            div()
+                                .relative()
+                                .occlude()
+                                .min_w(px(150.))
+                                // Override the editor's I-beam — the menu is a normal
+                                // pointer surface (children inherit this hitbox's cursor).
+                                .cursor(CursorStyle::Arrow)
+                                .bg(menu_bg)
+                                .border_1()
+                                .border_color(menu_border)
+                                .rounded(px(6.))
+                                .shadow_md()
+                                // Clip rows + thumb to the rounded box.
+                                .overflow_hidden()
+                                .text_color(menu_fg)
+                                .text_size(px(13.))
+                                // A click anywhere outside the menu dismisses it.
+                                .on_mouse_down_out(cx.listener(
+                                    |editor, _: &MouseDownEvent, _, cx| {
+                                        editor.menu = None;
+                                        cx.notify();
+                                    },
+                                ))
+                                .children(format_bar)
+                                .children(has_sel.then(|| div().h(px(1.)).bg(menu_border)))
+                                .children((count > 0).then(|| {
+                                    // The scroll viewport: shows ~6 rows, the rest scroll.
+                                    div()
+                                        .id("suggestion-menu")
+                                        .max_h(px(MAX_H))
+                                        .overflow_y_scroll()
+                                        .track_scroll(&scroll)
+                                        .flex()
+                                        .flex_col()
+                                        .py(px(PAD))
+                                        .children(rows)
+                                }))
+                                .children((count > 0).then(|| div().h(px(1.)).bg(menu_border)))
+                                .child(clipboard)
+                                .child(div().h(px(1.)).bg(menu_border))
+                                .child(div().flex().flex_col().py(px(4.)).child(turn_row))
+                                .children(thumb),
+                        ),
                     ),
                 )
             }))
@@ -10082,6 +10416,22 @@ fn word_boundary_input(new_text: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn strip_block_prefix_cases() {
+        use super::strip_block_prefix;
+        assert_eq!(strip_block_prefix("# Title"), "Title");
+        assert_eq!(strip_block_prefix("### Deep"), "Deep");
+        assert_eq!(strip_block_prefix("- [x] done"), "done");
+        assert_eq!(strip_block_prefix("- item"), "item");
+        assert_eq!(strip_block_prefix("12. nth"), "nth");
+        assert_eq!(strip_block_prefix("> quoted"), "quoted");
+        assert_eq!(strip_block_prefix(">bare"), "bare");
+        assert_eq!(strip_block_prefix("plain"), "plain");
+        // Not block prefixes: mid-word hash runs, `#tag`, a lone dash.
+        assert_eq!(strip_block_prefix("#tag"), "#tag");
+        assert_eq!(strip_block_prefix("-dash"), "-dash");
+    }
+
     #[test]
     fn find_in_source_cases() {
         use super::find_in_source;

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -632,6 +632,14 @@ pub struct EditorState {
     /// The in-progress corner-grip drag, if any (see [`ImageResize`]). While set,
     /// that image paints at the live width and other mouse handling is suppressed.
     image_resize: Option<ImageResize>,
+    /// An in-progress table column-border drag (drag-to-resize, issue #16):
+    /// the column resizes live; release persists `cols=` into the table's
+    /// marker line. `None` = no drag.
+    table_col_resize: Option<TableColResize>,
+    /// Last-paint column-resize grip bands: `(band, header row, column, width)`.
+    table_col_resize_rects: Vec<(Bounds<Pixels>, usize, usize, f32)>,
+    /// The band index the pointer is on (repaint-on-change for its accent line).
+    table_resize_hover: Option<usize>,
     /// A `$$…$$` block being edited in-line: its byte range + the host-supplied view (the
     /// structural editor) painted in a reserved gap at the block's spot. `None` = none.
     editing_block: Option<EditingBlock>,
@@ -751,6 +759,9 @@ impl EditorState {
             code_langs: Vec::new(),
             alert_fold_rects: Vec::new(),
             image_resize: None,
+            table_col_resize: None,
+            table_col_resize_rects: Vec::new(),
+            table_resize_hover: None,
             editing_block: None,
             inline_math_rects: Vec::new(),
             editing_inline: None,
@@ -2532,6 +2543,24 @@ impl EditorState {
             }
             return;
         }
+        // A press on a column border's resize band starts a drag — the column
+        // resizes live; release persists the width (issue #16).
+        if let Some(&(_, header_row, col, width)) = self
+            .table_col_resize_rects
+            .iter()
+            .find(|(band, ..)| band.contains(&event.position))
+        {
+            self.table_col_resize = Some(TableColResize {
+                header_row,
+                col,
+                start_x: event.position.x,
+                orig: width,
+                width,
+            });
+            self.is_selecting = false;
+            cx.notify();
+            return;
+        }
         // A click on a table cell drops the caret inside the cell, not in the raw
         // `| … |` source.
         let offset = self
@@ -2618,6 +2647,13 @@ impl EditorState {
             cx.notify();
             return;
         }
+        // End a column-border drag by persisting every column's width into the
+        // table marker's `cols=` list (one undo step, emits Changed).
+        if let Some(resize) = self.table_col_resize.take() {
+            self.commit_table_col_widths(resize, cx);
+            cx.notify();
+            return;
+        }
         self.is_selecting = false;
     }
 
@@ -2633,6 +2669,18 @@ impl EditorState {
         // matches `block_img`, no snap-back on release, and it can't run off the
         // page). The paint reads this live width for the dragged image (aspect
         // preserved).
+        // While dragging a table column's border, track the pointer: the new
+        // width is the grab width plus the travel, floored so the column can't
+        // vanish. Shaping applies it live (see `table_column_widths`).
+        if let Some(resize) = self.table_col_resize {
+            let dx = f32::from(event.position.x - resize.start_x);
+            let width = (resize.orig + dx).max(24.);
+            if let Some(r) = self.table_col_resize.as_mut() {
+                r.width = width;
+            }
+            cx.notify();
+            return;
+        }
         if let Some(resize) = self.image_resize {
             let avail = self
                 .last_bounds
@@ -2667,6 +2715,16 @@ impl EditorState {
         if region != self.table_hover_region || cell != self.table_hover_cell {
             self.table_hover_region = region;
             self.table_hover_cell = cell;
+            cx.notify();
+        }
+        // Repaint the column-resize border accent as the pointer crosses a band
+        // (the cursor comes from the hitbox; the painted line needs a frame).
+        let on_band = self
+            .table_col_resize_rects
+            .iter()
+            .position(|(b, ..)| b.contains(&event.position));
+        if on_band != self.table_resize_hover {
+            self.table_resize_hover = on_band;
             cx.notify();
         }
         // Repaint the property-panel hover border when the pointer moves between
@@ -3548,14 +3606,25 @@ impl EditorState {
         let cw = t.col_widths[cell];
         let cf = cell_font(&font, t.is_header);
         let full_w = measure_width(window, content, &cf, font_size);
-        let avail = (cw - pad * 2.).max(px(0.));
-        let align_off = match t.aligns.get(cell) {
-            Some(markdown_syntax::Align::Center) => (avail - full_w).max(px(0.)) / 2.,
-            Some(markdown_syntax::Align::Right) => (avail - full_w).max(px(0.)),
-            _ => px(0.),
+        let avail = (cw - pad * 2.).max(px(8.));
+        // Alignment shifts only unwrapped content (a wrapped cell fills its width).
+        let align_off = if full_w > avail {
+            px(0.)
+        } else {
+            match t.aligns.get(cell) {
+                Some(markdown_syntax::Align::Center) => (avail - full_w).max(px(0.)) / 2.,
+                Some(markdown_syntax::Align::Right) => (avail - full_w).max(px(0.)),
+                _ => px(0.),
+            }
         };
-        let target = (rel.x - cx - pad - align_off).max(px(0.));
-        let in_cell = cell_offset_for_x(content, target, &cf, font_size, window);
+        // In-cell y: from the row's top, minus the cell's constant 6px top pad
+        // (`table_row_h` = line height + 12, text centered → 6 above).
+        let pad_y = px(6.);
+        let target = point(
+            (rel.x - cx - pad - align_off).max(px(0.)),
+            rel.y - self.line_tops[row] - pad_y,
+        );
+        let in_cell = cell_offset_for_point(content, target, avail, &cf, font_size, window);
         Some(self.line_starts()[row] + t.cell_ranges.get(cell)?.start + in_cell)
     }
 
@@ -3971,31 +4040,33 @@ impl EditorState {
     /// Set the caret table's visual style by rewriting its
     /// `<!-- table:STYLE -->` marker line: `Some(name)` writes/replaces the
     /// marker, `None` (Grid, the default) removes it. One undo step.
-    pub fn set_table_style(&mut self, name: Option<&'static str>, cx: &mut Context<Self>) {
-        let Some(region) = self.caret_table_region() else {
-            return;
-        };
+    /// Rewrite (or insert/remove) the marker line above `region` to say
+    /// `marker` (`None` = no marker needed). The caret keeps its cell. One
+    /// undo step; shared by the style menu and drag-to-resize.
+    fn rewrite_table_marker(
+        &mut self,
+        region: &markdown_syntax::TableRegion,
+        marker: Option<String>,
+        cx: &mut Context<Self>,
+    ) {
         let starts = self.line_starts();
-        let (range, new) = match (region.marker_line, name) {
+        let (range, new) = match (region.marker_line, marker) {
             // Marker present → replace its line, or remove it (with the newline).
-            (Some(m), Some(name)) => (
-                starts[m]..self.line_end(m),
-                format!("<!-- table:{name} -->"),
-            ),
+            (Some(m), Some(text)) => (starts[m]..self.line_end(m), text),
             (Some(m), None) => (starts[m]..self.line_end(m) + 1, String::new()),
-            // No marker → insert one above the header; Grid is already implicit.
-            (None, Some(name)) => (
+            // No marker → insert one above the header.
+            (None, Some(text)) => (
                 starts[region.lines.start]..starts[region.lines.start],
-                format!("<!-- table:{name} -->\n"),
+                format!("{text}\n"),
             ),
             (None, None) => return,
         };
         let (row, cell, in_cell) = self.caret_table_cell_pos().unwrap_or((0, 0, 0));
         // The marker edit adds/removes one line ABOVE the table (or replaces in
         // place) — shift the caret's row index to keep it in its cell.
-        let row_shift: isize = match (region.marker_line, name) {
-            (Some(_), None) => -1,
-            (None, Some(_)) => 1,
+        let row_shift: isize = match (region.marker_line, new.is_empty()) {
+            (Some(_), true) => -1,
+            (None, false) => 1,
             _ => 0,
         };
         self.record_edit(&range, &new);
@@ -4007,6 +4078,44 @@ impl EditorState {
         self.table_menu = None;
         cx.emit(EditorEvent::Changed);
         cx.notify();
+    }
+
+    /// Set the caret table's visual style (`None` = Grid, the default),
+    /// preserving any drag-resized `cols=` widths in the marker.
+    pub fn set_table_style(&mut self, name: Option<&'static str>, cx: &mut Context<Self>) {
+        let Some(region) = self.caret_table_region() else {
+            return;
+        };
+        let style = gpui_markdown::syntax::TableStyle::from_name(name.unwrap_or("grid"))
+            .unwrap_or_default();
+        let marker =
+            gpui_markdown::syntax::table_marker_text(style, region.col_widths_attr.as_deref());
+        self.rewrite_table_marker(&region, marker, cx);
+    }
+
+    /// Persist a finished column-border drag: every column's current display
+    /// width goes into the marker's `cols=` list (style preserved).
+    fn commit_table_col_widths(&mut self, resize: TableColResize, cx: &mut Context<Self>) {
+        let Some(region) = markdown_syntax::table_regions(&self.content)
+            .into_iter()
+            .find(|r| r.lines.start == resize.header_row)
+        else {
+            return;
+        };
+        // The header row's committed display widths already carry the live drag.
+        let Some(t) = self
+            .table_rows
+            .get(resize.header_row)
+            .and_then(Option::as_ref)
+        else {
+            return;
+        };
+        let mut widths: Vec<f32> = t.col_widths.iter().map(|w| f32::from(*w)).collect();
+        if let Some(w) = widths.get_mut(resize.col) {
+            *w = resize.width.max(24.);
+        }
+        let marker = gpui_markdown::syntax::table_marker_text(region.style, Some(&widths));
+        self.rewrite_table_marker(&region, marker, cx);
     }
 
     /// The caret's table position as `(row, cell_index, offset_within_cell)`, or
@@ -5780,6 +5889,8 @@ fn shape_document(
     // here (driving its row height) so the layout reflows live, rather than the
     // image painting over a stale, saved-size row.
     resize: Option<ImageResize>,
+    // An in-progress column-border drag: that column takes the live width.
+    col_resize: Option<TableColResize>,
     // Collapsed headings (trimmed source lines) — their section lines fold to
     // height 0 like a folded callout's body.
     folded_headings: &std::collections::HashSet<String>,
@@ -5954,6 +6065,7 @@ fn shape_document(
             base_font_size,
             base_color,
             wrap_width,
+            col_resize,
         ));
     }
     let table_row_h = base_font_size * LINE_HEIGHT_RATIO + px(12.);
@@ -6735,7 +6847,19 @@ fn shape_document(
                     // renderer doesn't show it; the first body row's top divider
                     // becomes the header/body border.
                     Some(t) if t.is_separator => px(0.),
-                    Some(_) => table_row_h,
+                    // A drag-narrowed column wraps its cells — the row grows to
+                    // the tallest cell's wrap rows.
+                    Some(t) => {
+                        let rows = table_row_wrap_rows(
+                            window,
+                            &t.cells,
+                            &t.col_widths,
+                            t.is_header,
+                            base_font,
+                            base_font_size,
+                        );
+                        table_row_h + base_font_size * LINE_HEIGHT_RATIO * (rows - 1) as f32
+                    }
                     None => match widget.as_ref() {
                         // Reserve a little space around an inline image so a list
                         // of photos doesn't stack edge-to-edge.
@@ -7213,6 +7337,7 @@ fn table_column_widths(
     font_size: Pixels,
     color: Hsla,
     wrap_width: Option<Pixels>,
+    col_resize: Option<TableColResize>,
 ) -> Vec<Pixels> {
     let cols = region.aligns.len().max(1);
     let pad = px(TABLE_CELL_PAD);
@@ -7257,6 +7382,19 @@ fn table_column_widths(
     for w in &mut widths {
         *w = (*w).max(px(48.));
     }
+    // Explicit widths — the marker's `cols=` list (drag-to-resize persisted),
+    // then the live drag — override the measurement (floored so a column can't
+    // vanish). Content-measured columns keep the 48px floor above.
+    if let Some(attr) = &region.col_widths_attr {
+        for (c, w) in attr.iter().enumerate().take(cols) {
+            widths[c] = px(w.max(24.));
+        }
+    }
+    if let Some(r) = col_resize.filter(|r| r.header_row == region.lines.start)
+        && r.col < cols
+    {
+        widths[r.col] = px(r.width.max(24.));
+    }
     if let Some(avail) = wrap_width {
         let total = widths.iter().sum::<Pixels>();
         if total > avail && total > px(0.) {
@@ -7292,11 +7430,13 @@ fn shape_cell(
     content: &str,
     font: &Font,
     font_size: Pixels,
+    wrap: Option<Pixels>,
+    color: Hsla,
 ) -> Option<WrappedLine> {
     let run = TextRun {
         len: content.len(),
         font: font.clone(),
-        color: Hsla::default(),
+        color,
         background_color: None,
         underline: None,
         strikethrough: None,
@@ -7312,12 +7452,40 @@ fn shape_cell(
             SharedString::from(content.to_string()),
             font_size,
             runs,
-            None,
+            wrap,
             None,
         )
         .ok()?
         .into_iter()
         .next()
+}
+
+/// How many wrap rows table row `cells` need at `col_widths` — 1 for content
+/// that fits; more once a drag-narrowed column forces its text to wrap.
+fn table_row_wrap_rows(
+    window: &mut Window,
+    cells: &[SharedString],
+    col_widths: &[Pixels],
+    is_header: bool,
+    font: &Font,
+    font_size: Pixels,
+) -> usize {
+    let pad = px(TABLE_CELL_PAD);
+    let cf = cell_font(font, is_header);
+    let mut rows = 1;
+    for (c, cell) in cells.iter().enumerate() {
+        if cell.is_empty() {
+            continue;
+        }
+        let Some(&cw) = col_widths.get(c) else {
+            continue;
+        };
+        let avail = (cw - pad * 2.).max(px(8.));
+        if let Some(wl) = shape_cell(window, cell, &cf, font_size, Some(avail), Hsla::default()) {
+            rows = rows.max(wl.wrap_boundaries().len() + 1);
+        }
+    }
+    rows
 }
 
 /// The cell a source column `col` (line-local) falls in for a table row — clamped
@@ -7339,7 +7507,7 @@ fn table_caret_pos(
     font: &Font,
     font_size: Pixels,
     window: &mut Window,
-) -> Option<(Pixels, usize, usize)> {
+) -> Option<(Pixels, Pixels, usize, usize)> {
     if t.cell_ranges.is_empty() {
         return None;
     }
@@ -7351,38 +7519,64 @@ fn table_caret_pos(
     let cell_x = left + t.col_widths[..cell].iter().sum::<Pixels>();
     let cw = t.col_widths.get(cell).copied().unwrap_or(px(0.));
     // The header is bold, so shape with the bold font or the caret lands left of
-    // the (wider) bold glyphs; position_for_index gives the exact kerned x.
+    // the (wider) bold glyphs; position_for_index gives the exact kerned x — and,
+    // shaped at the cell's width, the wrap row's y for drag-narrowed columns.
     let cf = cell_font(font, t.is_header);
     let line_h = font_size * LINE_HEIGHT_RATIO;
-    let wl = shape_cell(window, content, &cf, font_size)?;
-    let prefix_w = wl
-        .position_for_index(in_cell, line_h)
-        .map_or(px(0.), |p| p.x);
+    let avail = (cw - pad * 2.).max(px(8.));
+    let wl = shape_cell(
+        window,
+        content,
+        &cf,
+        font_size,
+        Some(avail),
+        Hsla::default(),
+    )?;
+    let pos = wl.position_for_index(in_cell, line_h).unwrap_or_default();
+    let wrapped = !wl.wrap_boundaries().is_empty();
     let full_w = wl.width();
-    let avail = (cw - pad * 2.).max(px(0.));
-    let align_off = match t.aligns.get(cell) {
-        Some(markdown_syntax::Align::Center) => (avail - full_w).max(px(0.)) / 2.,
-        Some(markdown_syntax::Align::Right) => (avail - full_w).max(px(0.)),
-        _ => px(0.),
+    // Alignment shifts only unwrapped content (a wrapped cell fills its width).
+    let align_off = if wrapped {
+        px(0.)
+    } else {
+        match t.aligns.get(cell) {
+            Some(markdown_syntax::Align::Center) => (avail - full_w).max(px(0.)) / 2.,
+            Some(markdown_syntax::Align::Right) => (avail - full_w).max(px(0.)),
+            _ => px(0.),
+        }
     };
-    Some((cell_x + pad + align_off + prefix_w, cell, in_cell))
+    Some((cell_x + pad + align_off + pos.x, pos.y, cell, in_cell))
 }
 
 /// The byte offset within `content` whose rendered x (from the text's left edge)
 /// is closest to `target` — hit-tests a click inside a table cell, using the
 /// shaped line so it matches the kerned glyphs.
-fn cell_offset_for_x(
+fn cell_offset_for_point(
     content: &str,
-    target: Pixels,
+    target: Point<Pixels>,
+    wrap: Pixels,
     font: &Font,
     font_size: Pixels,
     window: &mut Window,
 ) -> usize {
     let line_h = font_size * LINE_HEIGHT_RATIO;
-    let Some(wl) = shape_cell(window, content, font, font_size) else {
+    let Some(wl) = shape_cell(
+        window,
+        content,
+        font,
+        font_size,
+        Some(wrap),
+        Hsla::default(),
+    ) else {
         return 0;
     };
-    match wl.closest_index_for_position(point(target, line_h / 2.), line_h) {
+    match wl.closest_index_for_position(
+        point(
+            target.x,
+            target.y.max(px(0.)).min(wl.size(line_h).height - px(1.)),
+        ),
+        line_h,
+    ) {
         Ok(i) | Err(i) => i,
     }
 }
@@ -7452,30 +7646,30 @@ fn paint_table_row(
             ));
         }
         if let Some(cell) = t.cells.get(c).filter(|s| !s.is_empty()) {
-            let run = TextRun {
-                len: cell.len(),
-                font: cell_font.clone(),
-                color,
-                background_color: None,
-                underline: None,
-                strikethrough: None,
-            };
-            let shaped = window
-                .text_system()
-                .shape_line(cell.clone(), font_size, &[run], None);
-            let align = match t.aligns.get(c) {
-                Some(markdown_syntax::Align::Center) => gpui::TextAlign::Center,
-                Some(markdown_syntax::Align::Right) => gpui::TextAlign::Right,
-                _ => gpui::TextAlign::Left,
-            };
-            let _ = shaped.paint(
-                point(x + pad, origin.y + (row_h - line_h) / 2.),
-                line_h,
-                align,
-                Some(cw - pad * 2.),
-                window,
-                cx,
-            );
+            // Shaped at the cell's width so a drag-narrowed column word-wraps
+            // (the row height already reserves the wrap rows). Top-anchored at
+            // the single-line pad, not centered — wraps grow downward.
+            let avail = (cw - pad * 2.).max(px(8.));
+            if let Some(shaped) =
+                shape_cell(window, cell, &cell_font, font_size, Some(avail), color)
+            {
+                let align = match t.aligns.get(c) {
+                    Some(markdown_syntax::Align::Center) => gpui::TextAlign::Center,
+                    Some(markdown_syntax::Align::Right) => gpui::TextAlign::Right,
+                    _ => gpui::TextAlign::Left,
+                };
+                let _ = shaped.paint(
+                    point(x + pad, origin.y + px(6.)),
+                    line_h,
+                    align,
+                    Some(Bounds::new(
+                        point(x + pad, origin.y + px(6.)),
+                        size(avail, (row_h - px(12.)).max(line_h)),
+                    )),
+                    window,
+                    cx,
+                );
+            }
         }
         x += cw;
     }
@@ -7552,6 +7746,34 @@ fn paint_table_pill(a: &TableAffordance, sep_h: bool, mouse: Point<Pixels>, wind
 /// measured layout (it depends on the resolved width once soft-wrap is applied).
 struct EditorElement {
     editor: Entity<EditorState>,
+}
+
+/// An in-progress table column-border drag (issue #16): identifies the column
+/// by its table's header line + index, and carries the live width the shaping
+/// applies each frame; release writes it into the marker's `cols=` list.
+#[derive(Clone, Copy)]
+struct TableColResize {
+    header_row: usize,
+    col: usize,
+    start_x: Pixels,
+    orig: f32,
+    width: f32,
+}
+
+/// A column-resize grip: a slim band over one column's right border in the
+/// hovered table (issue #16). Dragging it resizes that column live.
+struct ColResizeGrip {
+    band: Bounds<Pixels>,
+    hit: Hitbox,
+    header_row: usize,
+    col: usize,
+    width: f32,
+    /// The border's x + the table's vertical extent, for painting the accent
+    /// line while hovered/dragged.
+    x: Pixels,
+    top: Pixels,
+    bottom: Pixels,
+    accent: Hsla,
 }
 
 /// The hovered row's / column's affordance (issue #16, Cditor-style): an accent
@@ -7634,6 +7856,10 @@ struct PrepaintState {
     col_aff: Option<TableAffordance>,
     /// The caret's cell, outlined in the accent color (Cditor-style).
     caret_cell: Option<(Bounds<Pixels>, Hsla)>,
+    /// Column-resize grip bands over the hovered table's vertical borders:
+    /// `(band, hitbox, header row, column, current width, border x, table top,
+    /// table bottom, accent)`.
+    col_resize_grips: Vec<ColResizeGrip>,
     cursor: Option<PaintQuad>,
     selections: Vec<PaintQuad>,
     /// Find-match highlight quads, painted beneath the selection.
@@ -7740,6 +7966,7 @@ impl Element for EditorElement {
                     sf,
                     selection,
                     editor.image_resize,
+                    editor.table_col_resize,
                     &editor.folded_headings,
                 );
                 // Mirror prepaint's `line_tops` walk exactly (same `line_pads`),
@@ -7858,6 +8085,7 @@ impl Element for EditorElement {
                     sf,
                     selection,
                     editor.image_resize,
+                    editor.table_col_resize,
                     &editor.folded_headings,
                 )
             };
@@ -8208,6 +8436,8 @@ impl Element for EditorElement {
         let mut table_zones: Vec<Bounds<Pixels>> = Vec::new();
         let mut row_aff: Option<TableAffordance> = None;
         let mut col_aff: Option<TableAffordance> = None;
+        let mut col_resize_grips: Vec<ColResizeGrip> = Vec::new();
+        let dragging_col = editor.table_col_resize;
         let mut caret_cell: Option<(Bounds<Pixels>, Hsla)> = None;
         let caret_pos = editor.caret_table_cell_pos();
         let mut tbl_top: Option<Pixels> = None;
@@ -8250,6 +8480,28 @@ impl Element for EditorElement {
                     caret_cell = Some((rect, accent));
                 }
 
+                // Column-resize grips: a slim band on each column's right
+                // border (hover-gated; kept while a drag on this table is live).
+                if zone.contains(&mouse) || dragging_col.is_some_and(|r| r.header_row == tbl_header)
+                {
+                    let mut xacc = left;
+                    for (col, &cw) in t.col_widths.iter().enumerate() {
+                        xacc += cw;
+                        let band =
+                            Bounds::new(point(xacc - px(3.), top), size(px(6.), bottom - top));
+                        col_resize_grips.push(ColResizeGrip {
+                            band,
+                            hit: window.insert_hitbox(band, HitboxBehavior::Normal),
+                            header_row: tbl_header,
+                            col,
+                            width: f32::from(cw),
+                            x: xacc,
+                            top,
+                            bottom,
+                            accent,
+                        });
+                    }
+                }
                 if zone.contains(&mouse) {
                     // Hovered BODY row → outline + a vertical pill on its left border.
                     for line in tbl_header..=i {
@@ -8317,6 +8569,12 @@ impl Element for EditorElement {
                 }
                 tbl_top = None;
             }
+        }
+        // A border drag (or the pointer on a resize band) owns the interaction —
+        // the row/column outlines + pills would just flicker under it.
+        if dragging_col.is_some() || col_resize_grips.iter().any(|gr| gr.band.contains(&mouse)) {
+            row_aff = None;
+            col_aff = None;
         }
 
         // Map a (line-relative) point to a screen point. Captures `bounds` (Copy)
@@ -8485,7 +8743,7 @@ impl Element for EditorElement {
                 );
                 (Some(c), Vec::new())
             } else if let Some(t) = tables.get(row).and_then(Option::as_ref)
-                && let Some((x, _, _)) = table_caret_pos(
+                && let Some((x, y_off, _, _)) = table_caret_pos(
                     t,
                     col,
                     bounds.left() + px(TABLE_GUTTER),
@@ -8494,7 +8752,8 @@ impl Element for EditorElement {
                     window,
                 )
             {
-                let y = bounds.top() + top + (lh - base_lh) / 2.;
+                // Top pad + the wrap row's y (0 for unwrapped cells).
+                let y = bounds.top() + top + px(6.) + y_off;
                 let c = fill(
                     Bounds::new(point(x, y), size(px(CARET_WIDTH), base_lh)),
                     text_color,
@@ -8577,6 +8836,7 @@ impl Element for EditorElement {
             row_aff,
             col_aff,
             caret_cell,
+            col_resize_grips,
             cursor,
             selections,
             search,
@@ -9127,6 +9387,25 @@ impl Element for EditorElement {
             table_col_add_rects.push((a.plus, a.row, a.col));
             table_col_del = Some((a.minus, a.row, a.col));
         }
+        // Column-resize grips: a resize cursor over each border band; the
+        // hovered/dragged border draws in the accent color.
+        let mut table_col_resize_rects: Vec<(Bounds<Pixels>, usize, usize, f32)> = Vec::new();
+        let dragging = self.editor.read(cx).table_col_resize;
+        for gr in &prepaint.col_resize_grips {
+            window.set_cursor_style(CursorStyle::ResizeLeftRight, &gr.hit);
+            table_col_resize_rects.push((gr.band, gr.header_row, gr.col, gr.width));
+            let active = dragging.is_some_and(|d| d.header_row == gr.header_row && d.col == gr.col)
+                || (dragging.is_none() && gr.band.contains(&mouse));
+            if active {
+                window.paint_quad(fill(
+                    Bounds::new(
+                        point(gr.x - px(1.), gr.top),
+                        size(px(2.), gr.bottom - gr.top),
+                    ),
+                    gr.accent,
+                ));
+            }
+        }
 
         let wrapped = std::mem::take(&mut prepaint.wrapped);
         let line_tops = std::mem::take(&mut prepaint.line_tops);
@@ -9229,6 +9508,7 @@ impl Element for EditorElement {
             editor.prop_row_rects = prop_row_rects;
             editor.checkbox_rects = checkbox_rects;
             editor.code_chip_rects = code_chip_rects;
+            editor.table_col_resize_rects = table_col_resize_rects;
             editor.code_card_rects = std::mem::take(&mut prepaint.code_card_rects);
             editor.alert_fold_rects = alert_fold_rects;
             editor.heading_fold_rects = heading_fold_rects;

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -9744,6 +9744,13 @@ impl Element for EditorElement {
         let mouse = window.mouse_position();
         let mut grip: Option<(usize, Bounds<Pixels>)> = None;
         let mut grip_hb: Option<Hitbox> = None;
+        // While a drag is live, a viewport-sized hitbox (inserted after the
+        // editor's own, so it sits on top) keeps the closed-hand cursor
+        // everywhere — otherwise the text I-beam takes over mid-drag.
+        if editor.line_drag.is_some() {
+            let all = Bounds::new(gpui::Point::default(), window.viewport_size());
+            grip_hb = Some(window.insert_hitbox(all, HitboxBehavior::Normal));
+        }
         let grip_left = bounds.origin.x - px(22.) - editor.grip_inset;
         if editor.markdown_style.is_some()
             && editor.line_drag.is_none()

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -310,35 +310,22 @@ impl TurnKind {
 /// Strip a line's block dressing (heading hashes, list/todo bullet, ordered
 /// number, quote `>`), leaving the text a "Turn into" conversion re-prefixes.
 fn strip_block_prefix(line: &str) -> &str {
-    let t = line.trim_start();
-    for p in ["- [ ] ", "- [x] ", "- [X] "] {
-        if let Some(r) = t.strip_prefix(p) {
-            return r;
-        }
+    // Composes the renderer's own recognizers so the strip grammar can't
+    // drift from what WYSIWYG classifies (task/list/heading/quote).
+    if let Some((p, ..)) = markdown_syntax::task_prefix(line) {
+        return &line[p..];
     }
-    let hashes = t.len() - t.trim_start_matches('#').len();
-    if (1..=6).contains(&hashes)
-        && let Some(r) = t[hashes..].strip_prefix(' ')
-    {
-        return r;
+    if let Some((p, ..)) = markdown_syntax::list_prefix(line) {
+        return &line[p..];
     }
-    for p in ["- ", "* ", "+ "] {
-        if let Some(r) = t.strip_prefix(p) {
-            return r;
-        }
+    if let Some(n) = markdown_syntax::heading_level(line) {
+        let after = &line[n as usize..];
+        return after.strip_prefix(' ').unwrap_or(after);
     }
-    let digits = t.len() - t.trim_start_matches(|c: char| c.is_ascii_digit()).len();
-    if digits > 0
-        && let Some(r) = t[digits..]
-            .strip_prefix(". ")
-            .or_else(|| t[digits..].strip_prefix(") "))
-    {
-        return r;
+    if let Some(p) = markdown_syntax::blockquote_prefix(line) {
+        return &line[p..];
     }
-    if let Some(r) = t.strip_prefix("> ").or_else(|| t.strip_prefix('>')) {
-        return r;
-    }
-    t
+    line.trim_start()
 }
 
 /// Join `body` lines each carrying the prefix `p(index)` produces — the
@@ -3264,37 +3251,43 @@ impl EditorState {
         let Some(&start) = starts.get(row) else {
             return TurnKind::Text;
         };
-        let t = self.content[start..self.line_end(row)].trim_start();
-        if scan.fence_odd.get(row).copied().unwrap_or(false) || t.starts_with("```") {
+        // The renderer's own recognizers (task/list/heading/quote/alert), so
+        // the checked kind always agrees with what WYSIWYG actually renders.
+        let line = &self.content[start..self.line_end(row)];
+        if scan.fence_odd.get(row).copied().unwrap_or(false) || line.trim_start().starts_with("```")
+        {
             return TurnKind::Code;
         }
-        if ["- [ ]", "- [x]", "- [X]"].iter().any(|p| t.starts_with(p)) {
+        if markdown_syntax::task_prefix(line).is_some() {
             return TurnKind::Todo;
         }
-        match t.len() - t.trim_start_matches('#').len() {
-            1 if t.starts_with("# ") => return TurnKind::H1,
-            2 if t.starts_with("## ") => return TurnKind::H2,
-            3 if t.starts_with("### ") => return TurnKind::H3,
+        match markdown_syntax::heading_level(line) {
+            Some(1) => return TurnKind::H1,
+            Some(2) => return TurnKind::H2,
+            Some(3) => return TurnKind::H3,
             _ => {}
         }
-        if ["- ", "* ", "+ "].iter().any(|p| t.starts_with(p)) {
-            return TurnKind::Bullet;
+        if let Some((_, _, ordered, _)) = markdown_syntax::list_prefix(line) {
+            return if ordered {
+                TurnKind::Numbered
+            } else {
+                TurnKind::Bullet
+            };
         }
-        let digits = t.len() - t.trim_start_matches(|c: char| c.is_ascii_digit()).len();
-        if digits > 0 && (t[digits..].starts_with(". ") || t[digits..].starts_with(") ")) {
-            return TurnKind::Numbered;
-        }
-        if t.starts_with('>') {
-            // Callout if the caret's contiguous `>`-run carries a `[!KIND]`
-            // marker anywhere; the marker line itself or any body line counts.
-            let line_at = |r: usize| self.content[starts[r]..self.line_end(r)].trim_start();
+        if markdown_syntax::blockquote_prefix(line).is_some() {
+            // Callout if the caret's contiguous `>`-run carries a VALID
+            // `[!KIND]` marker anywhere (marker line or body line).
+            let line_at = |r: usize| &self.content[starts[r]..self.line_end(r)];
+            let is_q = |r: usize| markdown_syntax::blockquote_prefix(line_at(r)).is_some();
             let mut first = row;
-            while first > 0 && line_at(first - 1).starts_with('>') {
+            while first > 0 && is_q(first - 1) {
                 first -= 1;
             }
             let mut r = first;
-            while r < starts.len() && line_at(r).starts_with('>') {
-                if line_at(r)[1..].trim_start().starts_with("[!") {
+            while r < starts.len() && is_q(r) {
+                let l = line_at(r);
+                let p = markdown_syntax::blockquote_prefix(l).unwrap_or(0);
+                if markdown_syntax::alert_kind(&l[p..]).is_some() {
                     return TurnKind::Callout;
                 }
                 r += 1;
@@ -3341,7 +3334,7 @@ impl EditorState {
                 (first, last, body)
             }
             TurnKind::Quote | TurnKind::Callout => {
-                let is_q = |r: usize| line_at(r).trim_start().starts_with('>');
+                let is_q = |r: usize| markdown_syntax::blockquote_prefix(&line_at(r)).is_some();
                 let mut first = row;
                 while first > 0 && is_q(first - 1) {
                     first -= 1;
@@ -3452,8 +3445,8 @@ impl EditorState {
                 .unwrap_or(last_row);
             return (open, close);
         }
-        if line_at(row).trim_start().starts_with('>') {
-            let is_q = |r: usize| line_at(r).trim_start().starts_with('>');
+        if markdown_syntax::blockquote_prefix(&line_at(row)).is_some() {
+            let is_q = |r: usize| markdown_syntax::blockquote_prefix(&line_at(r)).is_some();
             let mut first = row;
             while first > 0 && is_q(first - 1) {
                 first -= 1;
@@ -11003,13 +10996,15 @@ impl Element for EditorElement {
         }
         // The grip sits OUTSIDE the editor div's bounds, so the div's own
         // mouse listeners never see a press on it — start the drag from a
-        // window-level listener gated on the grip's rect instead.
-        if let Some((row, rect)) = prepaint.grip {
+        // window-level listener instead, gated on the grip's HITBOX (not the
+        // bare rect): is_hovered respects occlusion, so a dialog/menu/popover
+        // covering the gutter blocks the drag from starting through it.
+        if let (Some((row, _)), Some(hb)) = (prepaint.grip, prepaint.grip_hb.clone()) {
             let editor = self.editor.clone();
-            window.on_mouse_event(move |e: &MouseDownEvent, phase, _window, cx| {
+            window.on_mouse_event(move |e: &MouseDownEvent, phase, window, cx| {
                 if phase == gpui::DispatchPhase::Bubble
                     && e.button == MouseButton::Left
-                    && rect.contains(&e.position)
+                    && hb.is_hovered(window)
                 {
                     editor.update(cx, |ed, cx| {
                         let (bs, be) = ed.drag_block_rows(row);
@@ -11220,6 +11215,11 @@ mod tests {
         assert_eq!(strip_block_prefix("> quoted"), "quoted");
         assert_eq!(strip_block_prefix(">bare"), "bare");
         assert_eq!(strip_block_prefix("plain"), "plain");
+        // Renderer-grammar forms the old hand-rolled version missed.
+        assert_eq!(strip_block_prefix("* [ ] star task"), "star task");
+        assert_eq!(strip_block_prefix("+ [x] plus task"), "plus task");
+        assert_eq!(strip_block_prefix("3) paren"), "paren");
+        assert_eq!(strip_block_prefix("#### H4"), "H4");
         // Not block prefixes: mid-word hash runs, `#tag`, a lone dash.
         assert_eq!(strip_block_prefix("#tag"), "#tag");
         assert_eq!(strip_block_prefix("-dash"), "-dash");

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -645,6 +645,12 @@ pub struct EditorState {
     shape_memo: std::cell::RefCell<Option<ShapeMemo>>,
     /// See [`ScanData`].
     scan_cache: std::cell::RefCell<Option<(u64, std::rc::Rc<ScanData>)>>,
+    /// See [`ScrollCompensatorFn`].
+    scroll_compensator: Option<ScrollCompensatorFn>,
+    /// `content_gen` as of the last paint — a measure with the SAME generation
+    /// but different heights means an async (non-edit) height change, the
+    /// scroll-anchoring trigger.
+    last_paint_gen: u64,
     /// Bumped on every content mutation — cheap staleness key for caches
     /// (the UTF-16 conversion anchor below; a shape cache later).
     content_gen: u64,
@@ -778,6 +784,8 @@ impl EditorState {
             table_resize_hover: None,
             shape_memo: std::cell::RefCell::new(None),
             scan_cache: std::cell::RefCell::new(None),
+            scroll_compensator: None,
+            last_paint_gen: 0,
             content_gen: 0,
             utf16_anchor: std::cell::Cell::new((0, 0, 0)),
             editing_block: None,
@@ -871,6 +879,14 @@ impl EditorState {
     /// default — leaves the tag click-inert.
     pub fn set_code_languages(&mut self, langs: Vec<SharedString>) {
         self.code_langs = langs;
+    }
+
+    /// Install the scroll-anchoring hook (see [`ScrollCompensatorFn`]): when
+    /// an async block render (math/mermaid/image) changes heights above the
+    /// window viewport, the host receives the delta and shifts its scroll
+    /// offset so the visible content stays put (Cditor's anchor-restore).
+    pub fn set_scroll_compensator(&mut self, f: impl Fn(Pixels, &mut Window, &mut App) + 'static) {
+        self.scroll_compensator = Some(std::rc::Rc::new(f));
     }
 
     pub fn set_markdown_style(&mut self, style: SyntaxStyle, cx: &mut Context<Self>) {
@@ -8035,6 +8051,12 @@ struct TableAffordance {
     accent: Hsla,
 }
 
+/// Host hook for scroll anchoring: called from the measure pass when an
+/// ASYNC height change (a math/mermaid/image raster arriving) lands ABOVE
+/// the window's viewport, with the height delta — the host shifts its scroll
+/// container's offset by it so the content being read doesn't jump.
+pub type ScrollCompensatorFn = std::rc::Rc<dyn Fn(Pixels, &mut Window, &mut App)>;
+
 /// Content-derived structural scans — tables, ordered-list numbering,
 /// mermaid/math regions, property runs, foldable callouts, and per-line
 /// fence parity — cached per [`EditorState::content_gen`]. `shape_document`
@@ -8186,6 +8208,10 @@ impl Element for EditorElement {
                 AvailableSpace::Definite(w) => Some(w),
                 _ => known.width,
             };
+            // Scroll anchoring: set when an async height change lands above
+            // the viewport (see below); called after the borrow of `editor`
+            // ends, before returning.
+            let mut compensate: Option<(ScrollCompensatorFn, Pixels)> = None;
             let height = if editor.content.is_empty() {
                 // Placeholder rows at the base size.
                 let rows = shape_all(
@@ -8251,10 +8277,12 @@ impl Element for EditorElement {
                     (&shaped.0, &shaped.1, &shaped.3, &shaped.4);
                 let mut y = px(0.);
                 let mut needed = px(0.);
+                let mut new_tops: Vec<Pixels> = Vec::with_capacity(wrapped.len());
                 for (i, (line, h)) in wrapped.iter().zip(heights).enumerate() {
                     let tbl = tables.get(i).and_then(Option::as_ref);
                     let (top, bot) = line_pads(backgrounds[i], tbl);
                     y += top;
+                    new_tops.push(y);
                     let row_h = *h * (line.wrap_boundaries().len() + 1) as f32;
                     // A table's hover "+" add-row strip paints just below its
                     // last row (see `TableAdds`). Keep that space inside the
@@ -8271,6 +8299,34 @@ impl Element for EditorElement {
                     }
                     y += row_h + bot;
                 }
+                // Scroll anchoring (Cditor's anchor-restore): the SAME content
+                // generation as the last paint means no edit happened — so a
+                // height difference here is an ASYNC change (a math/mermaid/
+                // image raster arriving, collapsing raw lines to a rendered
+                // block). If the first changed row sits above the window's
+                // viewport, everything the user is reading would shift; hand
+                // the delta to the host NOW (this measure runs before the
+                // scroll container places its children) so its scroll offset
+                // absorbs it in the same frame.
+                let total = y.max(base_lh).max(needed);
+                if let (Some(f), Some(last)) = (&editor.scroll_compensator, editor.last_bounds)
+                    && editor.content_gen == editor.last_paint_gen
+                    && !editor.line_tops.is_empty()
+                    && wrap_width.is_none_or(|w| (w - last.size.width).abs() < px(1.))
+                {
+                    let delta = total - last.size.height;
+                    if delta.abs() > px(0.5) {
+                        let n = new_tops.len().min(editor.line_tops.len());
+                        let j = (0..n)
+                            .find(|&k| (new_tops[k] - editor.line_tops[k]).abs() > px(0.5))
+                            .unwrap_or(n);
+                        let changed_y =
+                            editor.line_tops.get(j).copied().unwrap_or(last.size.height);
+                        if last.origin.y + changed_y < px(0.) {
+                            compensate = Some((f.clone(), delta));
+                        }
+                    }
+                }
                 // Hand the shaping to this frame's prepaint (see ShapeMemo).
                 *editor.shape_memo.borrow_mut() = Some(ShapeMemo {
                     wrap_width,
@@ -8279,9 +8335,12 @@ impl Element for EditorElement {
                     font_size,
                     shaped,
                 });
-                y.max(base_lh).max(needed)
+                total
             };
             let width = wrap_width.or(known.width).unwrap_or(px(0.));
+            if let Some((f, delta)) = compensate {
+                f(delta, window, cx);
+            }
             size(width, height)
         });
         (id, ())
@@ -9816,6 +9875,7 @@ impl Element for EditorElement {
             editor.table_row_del = table_row_del;
             editor.table_col_del = table_col_del;
             editor.last_bounds = Some(bounds);
+            editor.last_paint_gen = editor.content_gen;
             editor.line_height = base_lh;
             editor.font_size = font_size;
         });

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -3468,8 +3468,8 @@ impl EditorState {
                 .unwrap_or(last_row);
             return (open, close);
         }
-        if markdown_syntax::blockquote_prefix(&line_at(row)).is_some() {
-            let is_q = |r: usize| markdown_syntax::blockquote_prefix(&line_at(r)).is_some();
+        if markdown_syntax::blockquote_prefix(line_at(row)).is_some() {
+            let is_q = |r: usize| markdown_syntax::blockquote_prefix(line_at(r)).is_some();
             let mut first = row;
             while first > 0 && is_q(first - 1) {
                 first -= 1;

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -644,7 +644,7 @@ pub struct EditorState {
     widget_rows: Vec<bool>,
     /// Per-logical-line display→source byte map for rows with hidden markers
     /// (W6); `None` when the painted text equals the source. From the last paint.
-    offset_maps: Vec<Option<Vec<usize>>>,
+    offset_maps: Vec<Option<std::rc::Rc<Vec<usize>>>>,
     /// Per-logical-line horizontal text inset (and so the caret/selection/hit-test
     /// inset): non-zero for fenced code blocks and gutter marks (blockquotes,
     /// lists). From the last paint.
@@ -1025,6 +1025,9 @@ impl EditorState {
     /// (e.g. spell-check) and refreshes them as the text changes.
     pub fn set_diagnostics(&mut self, diagnostics: Vec<Diagnostic>, cx: &mut Context<Self>) {
         self.diagnostics = diagnostics;
+        // Diagnostics feed the per-row run keys (they underline spans) — drop
+        // the memo so the next shape re-keys affected lines.
+        *self.shape_caches.row_keys.borrow_mut() = (None, Vec::new());
         cx.notify();
     }
 
@@ -6531,8 +6534,9 @@ struct ShapedDoc {
     backgrounds: Vec<Option<CodeBg>>,
     tables: Vec<Option<TableRow>>,
     /// Per-line display→source byte map for lines with markers hidden (W6);
-    /// `None` when the displayed text equals the source.
-    maps: Vec<Option<Vec<usize>>>,
+    /// `None` when the displayed text equals the source. Shared with the
+    /// line-run cache (a hit re-uses the same allocation across frames).
+    maps: Vec<Option<std::rc::Rc<Vec<usize>>>>,
     marks: Vec<Option<LineMark>>,
     /// Per-line inline `$…$` formulas painted over spacers (empty when none).
     inline_maths: Vec<Vec<InlineMath>>,
@@ -6640,7 +6644,7 @@ fn set_image_width(line: &str, width: u32) -> String {
 /// as full source). The prepaint cursor/selection pass this frame's fresh map
 /// (the committed `EditorState::offset_maps` lags a frame); event handlers go
 /// through [`EditorState::display_col`], which uses the committed map.
-fn display_col_in(map: Option<&Vec<usize>>, source_col: usize) -> usize {
+fn display_col_in(map: Option<&std::rc::Rc<Vec<usize>>>, source_col: usize) -> usize {
     match map {
         // The first display byte whose source ≥ `source_col` (a leftmost lower-bound). Unlike
         // `binary_search`, this is deterministic when several display bytes share one source
@@ -7068,6 +7072,20 @@ fn shape_document(
     let regions: &[markdown_syntax::TableRegion] = if md.is_some() { &scan.tables } else { &[] };
     // Shared component of the per-line run-cache key (see `CachedLineRuns`).
     let run_epoch = line_run_epoch(base_font, md);
+    // Per-row content-key memo, valid for this (scan generation, epoch).
+    let row_keys_epoch = {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        scan.generation.hash(&mut h);
+        run_epoch.hash(&mut h);
+        Some(h.finish())
+    };
+    {
+        let mut rk = caches.row_keys.borrow_mut();
+        if rk.0 != row_keys_epoch || rk.1.len() != lines.len() {
+            *rk = (row_keys_epoch, vec![None; lines.len()]);
+        }
+    }
     // Measured column widths, cached across frames: rebuilt only when the
     // tables' source text, the wrap width, the font epoch, or a live column
     // drag changes — measuring shaped every cell of every table per call.
@@ -7657,10 +7675,20 @@ fn shape_document(
         let mut plain_hkey: Option<u64> = None;
         let (shaped_text, runs, bg, map) = if collapse_fence || collapse_marker {
             // Hidden ``` fence line or table-style marker: nothing, zero height.
-            (String::new(), Vec::new(), None, None)
+            (
+                SharedString::default(),
+                std::rc::Rc::new(Vec::new()),
+                None,
+                None,
+            )
         } else if is_rule {
             // Thematic break: the divider is painted from the mark; no body text.
-            (String::new(), Vec::new(), None, None)
+            (
+                SharedString::default(),
+                std::rc::Rc::new(Vec::new()),
+                None,
+                None,
+            )
         } else if let Some(st) = md.filter(|_| is_code) {
             // Monospace runs; ``` delimiters dimmed. A highlighted line (from
             // the host's code highlighter) splits into token-colored runs with
@@ -7707,8 +7735,8 @@ fn shape_document(
             // First visible code line of the block rounds the box's top corners.
             let top = code_block.is_empty();
             (
-                line.to_string(),
-                runs,
+                SharedString::from(line.to_string()),
+                std::rc::Rc::new(runs),
                 Some(CodeBg {
                     color: st.code_bg,
                     width: px(0.), // back-patched to the block's widest line
@@ -7724,23 +7752,43 @@ fn shape_document(
             // Cross-frame cache: most repaints (caret blink, hover, another
             // editor's edit) rebuild identical lines — reuse the built display
             // string + runs when the line and its reveal state are unchanged.
+            // CONTENT part of the key, memoized per row for the current
+            // (generation, epoch) — steady-state frames skip rehashing the
+            // line's bytes. The caret/reveal parts vary per frame and are
+            // cheap (a hash of four small values).
+            let ckey = {
+                let cached = caches.row_keys.borrow().1.get(idx).copied().flatten();
+                match cached {
+                    Some(k) => k,
+                    None => {
+                        use std::hash::{Hash, Hasher};
+                        let mut h = std::collections::hash_map::DefaultHasher::new();
+                        line.hash(&mut h);
+                        line_base.a.to_bits().hash(&mut h);
+                        line_base.h.to_bits().hash(&mut h);
+                        line_base.s.to_bits().hash(&mut h);
+                        line_base.l.to_bits().hash(&mut h);
+                        for d in &line_diags {
+                            d.range.start.hash(&mut h);
+                            d.range.end.hash(&mut h);
+                        }
+                        run_epoch.hash(&mut h);
+                        let k = h.finish();
+                        if let Some(slot) = caches.row_keys.borrow_mut().1.get_mut(idx) {
+                            *slot = Some(k);
+                        }
+                        k
+                    }
+                }
+            };
             let key = {
                 use std::hash::{Hash, Hasher};
                 let mut h = std::collections::hash_map::DefaultHasher::new();
-                line.hash(&mut h);
-                line_base.a.to_bits().hash(&mut h);
-                line_base.h.to_bits().hash(&mut h);
-                line_base.s.to_bits().hash(&mut h);
-                line_base.l.to_bits().hash(&mut h);
+                ckey.hash(&mut h);
                 caret_col.hash(&mut h);
                 reveal_prefix.hash(&mut h);
                 hide_prefix.hash(&mut h);
                 reveal_inline.hash(&mut h);
-                for d in &line_diags {
-                    d.range.start.hash(&mut h);
-                    d.range.end.hash(&mut h);
-                }
-                run_epoch.hash(&mut h);
                 h.finish()
             };
             // Windowed shaping: an offscreen plain text line whose height is
@@ -7812,65 +7860,107 @@ fn shape_document(
                         reveal_inline,
                         st,
                     );
+                    let v = (
+                        SharedString::from(disp),
+                        std::rc::Rc::new(runs),
+                        std::rc::Rc::new(m),
+                    );
                     caches.line_runs.borrow_mut().insert(
                         key,
                         CachedLineRuns {
                             src: line.to_string(),
                             line_base,
-                            disp: disp.clone(),
-                            runs: runs.clone(),
-                            map: m.clone(),
+                            disp: v.0.clone(),
+                            runs: v.1.clone(),
+                            map: v.2.clone(),
                         },
                     );
-                    (disp, runs, m)
+                    v
                 }
             };
             // A checked task's body renders struck through + muted (the reader
             // does the same) — a whole-line restyle over the finished runs.
             let (disp, runs, m) = if matches!(mark, Some(LineMark::Check { checked: true, .. })) {
-                let runs = runs
-                    .into_iter()
-                    .map(|mut r| {
-                        r.strikethrough = Some(gpui::StrikethroughStyle {
-                            thickness: px(1.0),
-                            color: None,
-                        });
-                        r.color = st.quote;
-                        r
-                    })
-                    .collect();
+                let runs = std::rc::Rc::new(
+                    runs.iter()
+                        .cloned()
+                        .map(|mut r| {
+                            r.strikethrough = Some(gpui::StrikethroughStyle {
+                                thickness: px(1.0),
+                                color: None,
+                            });
+                            r.color = st.quote;
+                            r
+                        })
+                        .collect(),
+                );
                 (disp, runs, m)
             } else {
                 (disp, runs, m)
             };
             // Inline `$…$` math AND `![](src)` images: swap each ready one's
             // glyphs for a spacer to paint the raster over (shared machinery).
+            // Span checks gate the calls, so span-less lines (the common case)
+            // keep their shared payloads untouched.
             let (disp, runs, m) = match (block_math, block_math_em) {
-                (Some(mathf), Some(em)) => {
+                (Some(mathf), Some(em)) if !markdown_syntax::inline_math_spans(line).is_empty() => {
                     let (disp, runs, m, im) = shape_inline_math(
-                        window, line, line_start, disp, runs, m, caret_col, base_font, fs, mathf,
+                        window,
+                        line,
+                        line_start,
+                        disp.to_string(),
+                        runs.as_ref().clone(),
+                        m.as_ref().clone(),
+                        caret_col,
+                        base_font,
+                        fs,
+                        mathf,
                         em,
                     );
                     line_inline_math = im;
-                    (disp, runs, m)
+                    (
+                        SharedString::from(disp),
+                        std::rc::Rc::new(runs),
+                        std::rc::Rc::new(m),
+                    )
                 }
                 _ => (disp, runs, m),
             };
             match block_image {
-                Some(imgf) => {
+                Some(imgf) if !markdown_syntax::inline_image_spans(line).is_empty() => {
                     let (disp, runs, m, imgs) = shape_inline_images(
-                        window, line, line_start, disp, runs, m, caret_col, base_font, fs, imgf,
+                        window,
+                        line,
+                        line_start,
+                        disp.to_string(),
+                        runs.as_ref().clone(),
+                        m.as_ref().clone(),
+                        caret_col,
+                        base_font,
+                        fs,
+                        imgf,
                     );
                     line_inline_math.extend(imgs);
-                    (disp, runs, None, Some(m))
+                    (
+                        SharedString::from(disp),
+                        std::rc::Rc::new(runs),
+                        None,
+                        Some(std::rc::Rc::new(m)),
+                    )
                 }
-                None => (disp, runs, None, Some(m)),
+                _ => (disp, runs, None, Some(m)),
             }
         } else {
             // Full source with diagnostics (the caret/selected line, or md off).
             (
-                line.to_string(),
-                markdown_syntax::styled_runs(line, base_font, line_base, &line_diags, md),
+                SharedString::from(line.to_string()),
+                std::rc::Rc::new(markdown_syntax::styled_runs(
+                    line,
+                    base_font,
+                    line_base,
+                    &line_diags,
+                    md,
+                )),
                 None,
                 None,
             )
@@ -7891,13 +7981,7 @@ fn shape_document(
         } else {
             wrap_width
         };
-        let shaped = shape_runs(
-            window,
-            &SharedString::from(shaped_text),
-            fs,
-            &runs,
-            line_wrap,
-        );
+        let shaped = shape_runs(window, &shaped_text, fs, &runs, line_wrap);
         if let Some(wl) = shaped.into_iter().next() {
             let h = if collapse_fence || collapse_marker {
                 px(0.)
@@ -8934,9 +9018,11 @@ struct TableAffordance {
 struct CachedLineRuns {
     src: String,
     line_base: Hsla,
-    disp: String,
-    runs: Vec<TextRun>,
-    map: Vec<usize>,
+    /// Shared payloads: a cache HIT is three refcount bumps, not three deep
+    /// clones (this runs per visible line per frame).
+    disp: SharedString,
+    runs: std::rc::Rc<Vec<TextRun>>,
+    map: std::rc::Rc<Vec<usize>>,
 }
 
 /// The editor-owned caches `shape_document` reads and writes (interior-
@@ -8955,6 +9041,11 @@ struct ShapeCaches {
     /// size ⊕ wrap width — the shaping window's exact heights for skipped
     /// offscreen lines.
     line_heights: std::cell::RefCell<std::collections::HashMap<u64, (Pixels, usize)>>,
+    /// Per-row CONTENT-part run keys (line bytes + line_base + diags + epoch),
+    /// valid for one (scan generation, epoch) pair — so a steady-state frame
+    /// hashes three u64s per line instead of every line's bytes. Diagnostics
+    /// changes invalidate explicitly (see `set_diagnostics`).
+    row_keys: std::cell::RefCell<(Option<u64>, Vec<Option<u64>>)>,
 }
 
 /// A hash of the inputs shared by every line's run build (font + palette) —
@@ -9040,7 +9131,7 @@ struct PrepaintState {
     /// `Some` for a line painted as a table-grid row instead of source.
     tables: Vec<Option<TableRow>>,
     /// Per-line display→source byte map for marker-hidden rows (W6).
-    maps: Vec<Option<Vec<usize>>>,
+    maps: Vec<Option<std::rc::Rc<Vec<usize>>>>,
     /// Per-line gutter decoration (blockquote / list / checkbox).
     marks: Vec<Option<LineMark>>,
     /// Per-line inline `$…$` formulas (image + display offset + source range), painted over
@@ -11204,11 +11295,11 @@ mod tests {
         // repeated across display 2..5). The caret at source 2 must land at the spacer's LEFT
         // edge (display 2), not an arbitrary spot inside it; source 5 (just past the formula)
         // lands at display 5.
-        let map = vec![0, 1, 2, 2, 2, 5, 6, 7];
+        let map = std::rc::Rc::new(vec![0, 1, 2, 2, 2, 5, 6, 7]);
         assert_eq!(display_col_in(Some(&map), 2), 2);
         assert_eq!(display_col_in(Some(&map), 5), 5);
         // A strictly-increasing map (hidden markers) is unaffected.
-        let plain = vec![0, 1, 2, 3];
+        let plain = std::rc::Rc::new(vec![0, 1, 2, 3]);
         assert_eq!(display_col_in(Some(&plain), 2), 2);
         assert_eq!(display_col_in(None, 4), 4);
     }

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -586,6 +586,10 @@ pub struct EditorState {
     /// cursor/IME positioning.
     wrapped: Vec<WrappedLine>,
     line_tops: Vec<Pixels>,
+    /// Per-logical-line wrap-row count (from the last paint). Geometry reads
+    /// this, not `wrapped[i].wrap_boundaries()` — a windowed-out line's entry
+    /// in `wrapped` is an empty placeholder.
+    wrap_rows: Vec<usize>,
     /// Per-logical-line wrap-row height. Variable so a heading (bigger font) gets
     /// a taller row (W2); `line_height` is the base/fallback for the empty doc
     /// and any row without a recorded height.
@@ -747,6 +751,15 @@ pub struct EditorState {
     /// Cross-frame shaping caches — line runs, table column widths, and table
     /// wrap rows (see [`ShapeCaches`]). Capacity-capped in `shape_document`.
     shape_caches: ShapeCaches,
+    /// The shaping window (element-local y, quantized), set after each
+    /// prepaint from the painted bounds — one frame stale by design, so the
+    /// measure pass and prepaint always shape with the SAME band and the
+    /// measure→prepaint memo keeps hitting.
+    shape_band: std::cell::Cell<Option<(f32, f32)>>,
+    /// Latch: the scroll compensator fired since the last paint. Measure can
+    /// run several times before a paint commits fresh `line_tops`; without
+    /// this, one async height change compensates once per measure call.
+    compensated: std::cell::Cell<bool>,
     /// `content_gen` as of the last paint — a measure with the SAME generation
     /// but different heights means an async (non-edit) height change, the
     /// scroll-anchoring trigger.
@@ -830,6 +843,7 @@ impl EditorState {
             wrapped: Vec::new(),
             line_tops: Vec::new(),
             line_heights: Vec::new(),
+            wrap_rows: Vec::new(),
             widget_rows: Vec::new(),
             offset_maps: Vec::new(),
             line_insets: Vec::new(),
@@ -888,6 +902,8 @@ impl EditorState {
             scroll_compensator: None,
             last_paint_gen: 0,
             shape_caches: ShapeCaches::default(),
+            shape_band: std::cell::Cell::new(None),
+            compensated: std::cell::Cell::new(false),
             content_gen: 0,
             utf16_anchor: std::cell::Cell::new((0, 0, 0)),
             editing_block: None,
@@ -1482,6 +1498,11 @@ impl EditorState {
         });
         *self.scan_cache.borrow_mut() = Some((self.content_gen, data.clone()));
         data
+    }
+
+    /// The wrap-row count of logical line `row` (1 when unrecorded).
+    fn row_span(&self, row: usize) -> usize {
+        self.wrap_rows.get(row).copied().unwrap_or(1).max(1)
     }
 
     /// The wrap-row height of logical line `row` (a heading is taller). Falls
@@ -3512,8 +3533,7 @@ impl EditorState {
             return 0;
         }
         let last = self.wrapped.len() - 1;
-        let total = self.line_tops[last]
-            + self.line_h(last) * (self.wrapped[last].wrap_boundaries().len() + 1) as f32;
+        let total = self.line_tops[last] + self.line_h(last) * self.row_span(last) as f32;
         if target_y >= total {
             // Landing at the very end would park the caret on a trailing
             // collapsed row (a hidden closing ``` fence) and reveal it — clamp
@@ -3530,7 +3550,7 @@ impl EditorState {
         }
         let mut trow = last;
         for i in 0..self.wrapped.len() {
-            let h = self.line_h(i) * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
+            let h = self.line_h(i) * self.row_span(i) as f32;
             if target_y < self.line_tops[i] + h {
                 trow = i;
                 break;
@@ -3661,7 +3681,7 @@ impl EditorState {
         let rel_y = position.y - bounds.top();
         let mut row = self.wrapped.len() - 1;
         for i in 0..self.wrapped.len() {
-            let h = self.line_h(i) * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
+            let h = self.line_h(i) * self.row_span(i) as f32;
             if rel_y < self.line_tops[i] + h {
                 row = i;
                 break;
@@ -3869,7 +3889,7 @@ impl EditorState {
             if t.is_separator {
                 return false;
             }
-            let h = self.line_h(i) * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
+            let h = self.line_h(i) * self.row_span(i) as f32;
             let lo = if t.is_header {
                 self.line_tops[i] - g
             } else {
@@ -3933,7 +3953,7 @@ impl EditorState {
         );
         let mut row = self.wrapped.len() - 1;
         for i in 0..self.wrapped.len() {
-            let h = self.line_h(i) * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
+            let h = self.line_h(i) * self.row_span(i) as f32;
             if rel.y < self.line_tops[i] + h {
                 row = i;
                 break;
@@ -4611,7 +4631,7 @@ impl EditorState {
         // Which logical line, by the vertical band each occupies (variable height).
         let mut row = self.wrapped.len() - 1;
         for i in 0..self.wrapped.len() {
-            let height = self.line_h(i) * (self.wrapped[i].wrap_boundaries().len() + 1) as f32;
+            let height = self.line_h(i) * self.row_span(i) as f32;
             if rel.y < self.line_tops[i] + height {
                 row = i;
                 break;
@@ -6160,6 +6180,10 @@ type ShapedLines = (
     // Per-line inline `$…$` formulas painted over spacers in the shaped text (empty for
     // lines without any).
     Vec<Vec<InlineMath>>,
+    // Per-line wrap-row count. Geometry (line tops, total height) reads THIS,
+    // not `wrap_boundaries()` — a windowed-out line's `WrappedLine` is an empty
+    // placeholder, but its cached count keeps the layout exact.
+    Vec<usize>,
 );
 
 /// Fit-to-width display size for an inline image from its natural (device) size:
@@ -6482,15 +6506,20 @@ fn shape_document(
     scan: &ScanData,
     // Cross-frame shaping caches (see [`ShapeCaches`]).
     caches: &ShapeCaches,
+    // The shaping window, in element-local y (quantized, one frame stale):
+    // plain lines wholly outside it may skip shaping when their height is
+    // cached. `None` = shape everything (first frame, raw view).
+    band: Option<(Pixels, Pixels)>,
     // Collapsed headings (trimmed source lines) — their section lines fold to
     // height 0 like a folded callout's body.
     folded_headings: &std::collections::HashSet<String>,
 ) -> ShapedLines {
-    let mut wrapped = Vec::new();
-    let mut heights = Vec::new();
+    let mut wrapped: Vec<WrappedLine> = Vec::new();
+    let mut heights: Vec<Pixels> = Vec::new();
+    let mut wrap_rows: Vec<usize> = Vec::new();
     let mut widgets = Vec::new();
     let mut backgrounds: Vec<Option<CodeBg>> = Vec::new();
-    let mut tables = Vec::new();
+    let mut tables: Vec<Option<TableRow>> = Vec::new();
     let mut maps = Vec::new();
     let mut marks: Vec<Option<LineMark>> = Vec::new();
     let mut inline_maths: Vec<Vec<InlineMath>> = Vec::new();
@@ -6773,8 +6802,15 @@ fn shape_document(
     // while blockquote lines continue, cleared by anything else — so every
     // line of the alert gets the kind's bar color.
     let mut alert_run: Option<Hsla> = None;
+    let mut y_acc = px(0.);
     for (idx, &line) in lines.iter().enumerate() {
         let line_end = line_start + line.len();
+        // Running top of this line — mirrors the prepaint `line_tops` walk
+        // (including `line_pads`) so the band test is exact.
+        if idx > 0 {
+            let (tp, bp) = line_pads(backgrounds[idx - 1], tables[idx - 1].as_ref());
+            y_acc += tp + bp + heights[idx - 1] * wrap_rows[idx - 1] as f32;
+        }
 
         // A ready mermaid block renders as its diagram (on the first line) with the
         // rest of the block collapsed — bypassing the normal per-line handling. Its
@@ -6806,6 +6842,7 @@ fn shape_document(
             maps.push(None);
             marks.push(None);
             inline_maths.push(Vec::new());
+            wrap_rows.push(1);
             line_start = line_end + 1;
             alert_run = None;
             continue;
@@ -6835,6 +6872,7 @@ fn shape_document(
             maps.push(None);
             marks.push(None);
             inline_maths.push(Vec::new());
+            wrap_rows.push(1);
             line_start = line_end + 1;
             alert_run = None;
             continue;
@@ -6866,6 +6904,7 @@ fn shape_document(
             maps.push(None);
             marks.push(None);
             inline_maths.push(Vec::new());
+            wrap_rows.push(1);
             line_start = line_end + 1;
             alert_run = None;
             continue;
@@ -6898,6 +6937,7 @@ fn shape_document(
             maps.push(None);
             marks.push(None);
             inline_maths.push(Vec::new());
+            wrap_rows.push(1);
             line_start = line_end + 1;
             continue;
         }
@@ -6927,6 +6967,7 @@ fn shape_document(
             maps.push(None);
             marks.push(None);
             inline_maths.push(Vec::new());
+            wrap_rows.push(1);
             line_start = line_end + 1;
             continue;
         }
@@ -6958,6 +6999,7 @@ fn shape_document(
             maps.push(None);
             marks.push(None);
             inline_maths.push(Vec::new());
+            wrap_rows.push(1);
             line_start = line_end + 1;
             alert_run = None;
             continue;
@@ -7343,6 +7385,10 @@ fn shape_document(
         };
         // Inline `$…$` formulas spliced into this line (populated by the hidden-markers branch).
         let mut line_inline_math: Vec<InlineMath> = Vec::new();
+        // Set (in the markdown branch below) when this line is eligible for the
+        // per-line height cache — its (row height, wrap rows) get recorded at
+        // push time so a later frame can window it out without shaping.
+        let mut plain_hkey: Option<u64> = None;
         let (shaped_text, runs, bg, map) = if collapse_fence || collapse_marker {
             // Hidden ``` fence line or table-style marker: nothing, zero height.
             (String::new(), Vec::new(), None, None)
@@ -7431,6 +7477,65 @@ fn shape_document(
                 run_epoch.hash(&mut h);
                 h.finish()
             };
+            // Windowed shaping: an offscreen plain text line whose height is
+            // already cached skips run-building and shaping entirely — the
+            // cached (row height, wrap rows) keep the layout exact, and its
+            // placeholder WrappedLine is never painted (paint culls the same
+            // band). Never skipped: lines with inline math/images (height
+            // depends on async raster providers, not just the text) and
+            // collapsed lines (fold state isn't in the key).
+            let line_wrap_plain = match mark {
+                Some(m) => wrap_width.map(|w| (w - m.inset()).max(px(0.))),
+                None => wrap_width,
+            };
+            let skip_key = (!line.contains('$')
+                && !line.contains("![")
+                && !collapse_fence
+                && !collapse_marker)
+                .then(|| {
+                    use std::hash::{Hash, Hasher};
+                    let mut h = std::collections::hash_map::DefaultHasher::new();
+                    key.hash(&mut h);
+                    f32::from(fs).to_bits().hash(&mut h);
+                    line_wrap_plain
+                        .map(f32::from)
+                        .unwrap_or(-1.)
+                        .to_bits()
+                        .hash(&mut h);
+                    h.finish()
+                });
+            if let (Some((lo, hi)), Some(hk)) = (band, skip_key) {
+                let hit = caches.line_heights.borrow().get(&hk).copied();
+                if let Some((lh_c, wr_c)) = hit {
+                    let total = lh_c * wr_c as f32;
+                    if y_acc > hi || y_acc + total < lo {
+                        let wl = shape_runs(
+                            window,
+                            &SharedString::default(),
+                            base_font_size,
+                            &[],
+                            wrap_width,
+                        )
+                        .into_iter()
+                        .next()
+                        .expect("a line always shapes to one wrapped line");
+                        wrapped.push(wl);
+                        heights.push(lh_c);
+                        wrap_rows.push(wr_c);
+                        widgets.push(None);
+                        backgrounds.push(None);
+                        tables.push(None);
+                        maps.push(None);
+                        // The REAL mark: paint's nesting-guide bookkeeping
+                        // walks offscreen ancestors' marks.
+                        marks.push(mark);
+                        inline_maths.push(Vec::new());
+                        line_start = line_end + 1;
+                        continue;
+                    }
+                }
+            }
+            plain_hkey = skip_key;
             let cached = caches
                 .line_runs
                 .borrow()
@@ -7598,6 +7703,13 @@ fn shape_document(
                 }
             };
             let line_w = wl.width();
+            if let Some(hk) = plain_hkey {
+                caches
+                    .line_heights
+                    .borrow_mut()
+                    .insert(hk, (h, wl.wrap_boundaries().len() + 1));
+            }
+            wrap_rows.push(wl.wrap_boundaries().len() + 1);
             wrapped.push(wl);
             heights.push(h);
             widgets.push(widget);
@@ -7640,6 +7752,10 @@ fn shape_document(
         if rows.len() > lines.len() * 2 + 64 {
             rows.clear();
         }
+        let mut lh = caches.line_heights.borrow_mut();
+        if lh.len() > lines.len() * 2 + 64 {
+            lh.clear();
+        }
     }
     (
         wrapped,
@@ -7650,6 +7766,7 @@ fn shape_document(
         maps,
         marks,
         inline_maths,
+        wrap_rows,
     )
 }
 
@@ -8572,6 +8689,10 @@ struct ShapeCaches {
     line_runs: std::cell::RefCell<std::collections::HashMap<u64, CachedLineRuns>>,
     region_cols: std::cell::RefCell<Option<(u64, Vec<Vec<Pixels>>)>>,
     cell_rows: std::cell::RefCell<std::collections::HashMap<u64, usize>>,
+    /// Per-line (row height, wrap rows), keyed by the line-run key ⊕ font
+    /// size ⊕ wrap width — the shaping window's exact heights for skipped
+    /// offscreen lines.
+    line_heights: std::cell::RefCell<std::collections::HashMap<u64, (Pixels, usize)>>,
 }
 
 /// A hash of the inputs shared by every line's run build (font + palette) —
@@ -8638,6 +8759,8 @@ struct ShapeMemo {
 
 struct PrepaintState {
     wrapped: Vec<WrappedLine>,
+    /// Per-line wrap-row count (see [`EditorState::wrap_rows`]).
+    wrap_rows: Vec<usize>,
     /// Top offset of each logical line relative to the editor's top.
     line_tops: Vec<Pixels>,
     /// Per-logical-line wrap-row height (variable for headings + images).
@@ -8817,21 +8940,22 @@ impl Element for EditorElement {
                     editor.table_col_resize,
                     &scan,
                     &editor.shape_caches,
+                    editor.shape_band.get().map(|(a, b)| (px(a), px(b))),
                     &editor.folded_headings,
                 );
                 // Mirror prepaint's `line_tops` walk exactly (same `line_pads`),
                 // or the element lays out shorter than it paints.
-                let (wrapped, heights, backgrounds, tables) =
-                    (&shaped.0, &shaped.1, &shaped.3, &shaped.4);
+                let (heights, backgrounds, tables, rows) =
+                    (&shaped.1, &shaped.3, &shaped.4, &shaped.8);
                 let mut y = px(0.);
                 let mut needed = px(0.);
-                let mut new_tops: Vec<Pixels> = Vec::with_capacity(wrapped.len());
-                for (i, (line, h)) in wrapped.iter().zip(heights).enumerate() {
+                let mut new_tops: Vec<Pixels> = Vec::with_capacity(heights.len());
+                for (i, h) in heights.iter().enumerate() {
                     let tbl = tables.get(i).and_then(Option::as_ref);
                     let (top, bot) = line_pads(backgrounds[i], tbl);
                     y += top;
                     new_tops.push(y);
-                    let row_h = *h * (line.wrap_boundaries().len() + 1) as f32;
+                    let row_h = *h * rows[i] as f32;
                     // A table's hover "+" add-row strip paints just below its
                     // last row (see `TableAdds`). Keep that space inside the
                     // element for a table near the document's end — outside
@@ -8857,10 +8981,15 @@ impl Element for EditorElement {
                 // scroll container places its children) so its scroll offset
                 // absorbs it in the same frame.
                 let total = y.max(base_lh).max(needed);
+                // ONLY at the real, final width: taffy also measures at
+                // intrinsic (None / min-content) widths, whose unwrapped
+                // heights diverge wildly from the wrapped layout at a narrow
+                // window — a compensation from one of those yanks the scroll
+                // offset by thousands of px and fights the user's scrolling.
                 if let (Some(f), Some(last)) = (&editor.scroll_compensator, editor.last_bounds)
                     && editor.content_gen == editor.last_paint_gen
                     && !editor.line_tops.is_empty()
-                    && wrap_width.is_none_or(|w| (w - last.size.width).abs() < px(1.))
+                    && wrap_width.is_some_and(|w| (w - last.size.width).abs() < px(1.))
                 {
                     let delta = total - last.size.height;
                     if delta.abs() > px(0.5) {
@@ -8868,9 +8997,32 @@ impl Element for EditorElement {
                         let j = (0..n)
                             .find(|&k| (new_tops[k] - editor.line_tops[k]).abs() > px(0.5))
                             .unwrap_or(n);
+                        // Debug tap (ZORITE_WINDOW_DEBUG=1): a height change
+                        // with NO edit and NO width change means a cache
+                        // mismatch or an async raster — log which line moved.
+                        if std::env::var_os("ZORITE_WINDOW_DEBUG").is_some() {
+                            let line_txt = editor
+                                .content
+                                .split('\n')
+                                .nth(j)
+                                .unwrap_or("")
+                                .chars()
+                                .take(60)
+                                .collect::<String>();
+                            eprintln!(
+                                "[wdbg] gen={} delta={:?} first_changed_row={} old_top={:?} new_top={:?} line={:?}",
+                                editor.content_gen,
+                                delta,
+                                j,
+                                editor.line_tops.get(j),
+                                new_tops.get(j),
+                                line_txt
+                            );
+                        }
                         let changed_y =
                             editor.line_tops.get(j).copied().unwrap_or(last.size.height);
-                        if last.origin.y + changed_y < px(0.) {
+                        if last.origin.y + changed_y < px(0.) && !editor.compensated.get() {
+                            editor.compensated.set(true);
                             compensate = Some((f.clone(), delta));
                         }
                     }
@@ -8936,83 +9088,107 @@ impl Element for EditorElement {
                 && m.selection == selection
                 && m.font_size == font_size
         });
-        let (wrapped, line_heights, widgets, backgrounds, tables, maps, marks, inline_maths) =
-            if let Some(m) = memo {
-                m.shaped
-            } else if editor.content.is_empty() {
-                let w = shape_all(
-                    window,
-                    &editor.placeholder,
-                    font_size,
-                    font.clone(),
-                    hsla(0., 0., 0.5, 0.5),
-                    wrap_width,
-                );
-                let n = w.len();
-                (
-                    w,
-                    vec![base_lh; n],
-                    vec![None; n],
-                    vec![None; n],
-                    vec![None; n],
-                    vec![None; n],
-                    vec![None; n],
-                    vec![Vec::new(); n],
-                )
-            } else {
-                shape_document(
-                    window,
-                    &editor.content,
-                    &font,
-                    text_color,
-                    font_size,
-                    &editor.diagnostics,
-                    editor.markdown_style.as_ref(),
-                    wrap_width,
-                    caret_row,
-                    editor.block_image.as_ref(),
-                    editor.block_chip.as_ref(),
-                    editor.embed_view.as_ref(),
-                    editor.block_mermaid.as_ref(),
-                    editor.block_math.as_ref(),
-                    editor.code_highlight.as_ref(),
-                    editor.tab_indent,
-                    editor.block_math_em,
-                    editor.editing_block.as_ref().map(|eb| {
-                        let sr = editor.row_col(eb.range.start).0;
-                        let er = editor
-                            .row_col(eb.range.end.saturating_sub(1).max(eb.range.start))
-                            .0;
-                        (sr, er, eb.height)
-                    }),
-                    sf,
-                    selection,
-                    editor.image_resize,
-                    editor.table_col_resize,
-                    &editor.scan_data(),
-                    &editor.shape_caches,
-                    &editor.folded_headings,
-                )
-            };
+        let (
+            wrapped,
+            line_heights,
+            widgets,
+            backgrounds,
+            tables,
+            maps,
+            marks,
+            inline_maths,
+            wrap_rows,
+        ) = if let Some(m) = memo {
+            m.shaped
+        } else if editor.content.is_empty() {
+            let w = shape_all(
+                window,
+                &editor.placeholder,
+                font_size,
+                font.clone(),
+                hsla(0., 0., 0.5, 0.5),
+                wrap_width,
+            );
+            let n = w.len();
+            let rows: Vec<usize> = w.iter().map(|l| l.wrap_boundaries().len() + 1).collect();
+            (
+                w,
+                vec![base_lh; n],
+                vec![None; n],
+                vec![None; n],
+                vec![None; n],
+                vec![None; n],
+                vec![None; n],
+                vec![Vec::new(); n],
+                rows,
+            )
+        } else {
+            shape_document(
+                window,
+                &editor.content,
+                &font,
+                text_color,
+                font_size,
+                &editor.diagnostics,
+                editor.markdown_style.as_ref(),
+                wrap_width,
+                caret_row,
+                editor.block_image.as_ref(),
+                editor.block_chip.as_ref(),
+                editor.embed_view.as_ref(),
+                editor.block_mermaid.as_ref(),
+                editor.block_math.as_ref(),
+                editor.code_highlight.as_ref(),
+                editor.tab_indent,
+                editor.block_math_em,
+                editor.editing_block.as_ref().map(|eb| {
+                    let sr = editor.row_col(eb.range.start).0;
+                    let er = editor
+                        .row_col(eb.range.end.saturating_sub(1).max(eb.range.start))
+                        .0;
+                    (sr, er, eb.height)
+                }),
+                sf,
+                selection,
+                editor.image_resize,
+                editor.table_col_resize,
+                &editor.scan_data(),
+                &editor.shape_caches,
+                editor.shape_band.get().map(|(a, b)| (px(a), px(b))),
+                &editor.folded_headings,
+            )
+        };
+
+        // Publish NEXT frame's shaping window: the viewport band in
+        // element-local y with a viewport of margin each side, quantized so
+        // the band (and with it the measure→prepaint memo) stays stable
+        // across small scrolls. Read back one frame stale — both passes of a
+        // frame always shape with the same band.
+        {
+            let vh = f32::from(window.viewport_size().height).max(1.);
+            let top = -f32::from(bounds.origin.y);
+            let q = 512.0;
+            let lo = (((top - vh) / q).floor() * q).max(0.);
+            let hi = ((top + 2. * vh) / q).ceil() * q;
+            editor.shape_band.set(Some((lo, hi)));
+        }
 
         // Top offset of each logical line (running sum of variable wrap heights),
         // reserving a gap above/below each code block so its padded box has its
         // own space (no overlap with the adjacent line, no blank line required).
         let mut line_tops = Vec::with_capacity(wrapped.len());
         let mut y = px(0.);
-        for (idx, ((line, lh), bg)) in wrapped
-            .iter()
-            .zip(line_heights.iter())
-            .zip(backgrounds.iter())
-            .enumerate()
-        {
+        for (idx, lh) in line_heights.iter().enumerate() {
             // Code-box pads plus the table gutter rows (see `line_pads`) — baked
             // into line_tops so the caret / click / paint all shift with them,
             // and neither table affordance overlaps the adjacent line.
-            let (top_pad, bot_pad) = line_pads(*bg, tables.get(idx).and_then(Option::as_ref));
+            let (top_pad, bot_pad) = line_pads(
+                backgrounds.get(idx).copied().flatten(),
+                tables.get(idx).and_then(Option::as_ref),
+            );
             y += top_pad;
             line_tops.push(y);
-            y += *lh * (line.wrap_boundaries().len() + 1) as f32 + bot_pad;
+            y += *lh * wrap_rows[idx] as f32 + bot_pad;
         }
 
         // Corner-grip hitboxes for each inline image, in `widgets` order (matching
@@ -9135,7 +9311,7 @@ impl Element for EditorElement {
                 let card_top = bounds.origin.y + line_tops[i] - top_pad;
                 let card_bottom = bounds.origin.y
                     + line_tops[last]
-                    + line_heights[last] * (wrapped[last].wrap_boundaries().len() + 1) as f32
+                    + line_heights[last] * wrap_rows[last] as f32
                     + last_bot_pad;
                 let card = Bounds::new(
                     point(bounds.origin.x, card_top),
@@ -9716,6 +9892,7 @@ impl Element for EditorElement {
 
         PrepaintState {
             wrapped,
+            wrap_rows,
             line_tops,
             line_heights,
             widgets,
@@ -9818,6 +9995,7 @@ impl Element for EditorElement {
         // active ancestor level, so a faint vertical line can drop from each down
         // through its descendants. Popped on dedent, reset off the list.
         let mut outline: Vec<Pixels> = Vec::new();
+        let viewport_h = window.viewport_size().height;
         for (i, ((line, top), lh)) in prepaint
             .wrapped
             .iter()
@@ -9852,6 +10030,14 @@ impl Element for EditorElement {
                     outline.push(bullet_x);
                 }
                 _ => outline.clear(),
+            }
+            // Windowed paint: a line fully outside the window's viewport paints
+            // nothing. The guide bookkeeping above still runs — a visible list
+            // row's ancestor guides can start above the viewport. The slack
+            // covers code-box pads and table affordances that overhang the row.
+            let advance = *lh * prepaint.wrap_rows.get(i).copied().unwrap_or(1) as f32;
+            if origin.y + advance + px(64.) < px(0.) || origin.y - px(64.) > viewport_h {
+                continue;
             }
             // Fenced code block: one rounded, content-fit box (sized to the
             // widest line, like a table). The first line rounds + pads the top, the
@@ -10405,6 +10591,7 @@ impl Element for EditorElement {
             editor.wrapped = wrapped;
             editor.line_tops = line_tops;
             editor.line_heights = line_heights;
+            editor.wrap_rows = std::mem::take(&mut prepaint.wrap_rows);
             editor.widget_rows = widget_rows;
             editor.offset_maps = offset_maps;
             editor.chip_rows = chip_rows;
@@ -10427,6 +10614,7 @@ impl Element for EditorElement {
             editor.table_row_del = table_row_del;
             editor.table_col_del = table_col_del;
             editor.last_bounds = Some(bounds);
+            editor.compensated.set(false);
             editor.last_paint_gen = editor.content_gen;
             editor.line_height = base_lh;
             editor.font_size = font_size;

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -610,6 +610,16 @@ pub struct EditorState {
     /// Window-space bounds of each painted task checkbox, with its logical line —
     /// so a click on the box toggles `[ ]`↔`[x]` instead of placing the caret.
     checkbox_rects: Vec<(usize, Bounds<Pixels>)>,
+    /// Painted code-card chrome bounds from the last frame (lang tag + Copy per
+    /// code block, keyed by the opening-fence row) — clicks route here before
+    /// caret placement.
+    code_chip_rects: Vec<CodeChipHit>,
+    /// Open language picker for a code block: `(opening fence row, anchor)`.
+    code_lang_menu: Option<(usize, Point<Pixels>)>,
+    code_lang_scroll: ScrollHandle,
+    /// Languages the host's highlighter supports, offered in the code block's
+    /// language picker. Empty (the default) disables the picker.
+    code_langs: Vec<SharedString>,
     /// Painted chevron bounds of foldable callouts (`(line, rect)`, from the
     /// last paint) — a click flips the marker's `-`/`+` fold char.
     alert_fold_rects: Vec<(usize, Bounds<Pixels>)>,
@@ -727,6 +737,10 @@ impl EditorState {
             chip_rows: Vec::new(),
             image_rects: Vec::new(),
             checkbox_rects: Vec::new(),
+            code_chip_rects: Vec::new(),
+            code_lang_menu: None,
+            code_lang_scroll: ScrollHandle::new(),
+            code_langs: Vec::new(),
             alert_fold_rects: Vec::new(),
             image_resize: None,
             editing_block: None,
@@ -814,6 +828,13 @@ impl EditorState {
     /// tag formatting then renders as you type — markers stay in the text,
     /// dimmed. Without it the editor is the raw view: plain text, spell-check
     /// underlines only.
+    /// Languages offered in a code block's language picker (the host's
+    /// highlighter set, e.g. its compiled tree-sitter grammars). Empty — the
+    /// default — leaves the tag click-inert.
+    pub fn set_code_languages(&mut self, langs: Vec<SharedString>) {
+        self.code_langs = langs;
+    }
+
     pub fn set_markdown_style(&mut self, style: SyntaxStyle, cx: &mut Context<Self>) {
         self.markdown_style = Some(style);
         cx.notify();
@@ -2284,6 +2305,20 @@ impl EditorState {
             }
             return;
         }
+        // A press on a code card's chrome: Copy writes the block's body to the
+        // clipboard; the language tag opens the picker — neither places the caret.
+        if let Some((on_copy, fence_row)) = self.code_chip_at(event.position) {
+            if on_copy {
+                if let Some((_, body)) = self.code_block_at(fence_row) {
+                    let text = self.content[body].to_string();
+                    self.write_clipboard(text, cx);
+                }
+            } else if !self.code_langs.is_empty() {
+                self.code_lang_menu = Some((fence_row, event.position));
+                cx.notify();
+            }
+            return;
+        }
         // A press on a foldable callout's chevron flips its `-`/`+` fold char
         // (folding/unfolding the body) instead of placing the caret — the same
         // toggle-in-source model as the task checkbox.
@@ -2484,6 +2519,7 @@ impl EditorState {
         self.table_menu = None;
         self.image_menu = None;
         self.prop_menu = None;
+        self.code_lang_menu = None;
         self.goal_x = None;
         self.last_edit = EditKind::Other;
         match event.click_count {
@@ -2829,6 +2865,7 @@ impl EditorState {
             || self.table_menu.take().is_some()
             || self.image_menu.take().is_some()
             || self.prop_menu.take().is_some()
+            || self.code_lang_menu.take().is_some()
         {
             cx.notify();
         }
@@ -3202,6 +3239,61 @@ impl EditorState {
     /// If `position` lands on a task checkbox painted last frame, the logical line
     /// of that task — so a click can toggle it. The hit area is the box padded a
     /// little, to stay easy to tap without swallowing the body text beside it.
+    /// The code block whose opening fence is `fence_row`: its language token
+    /// (empty for none) and the byte range of the body between the fences.
+    fn code_block_at(&self, fence_row: usize) -> Option<(String, Range<usize>)> {
+        let starts = self.line_starts();
+        let &start = starts.get(fence_row)?;
+        let fence_line = &self.content[start..self.line_end(fence_row)];
+        let trimmed = fence_line.trim_start();
+        let lang = trimmed.strip_prefix("```")?.trim().to_string();
+        let body_start = (self.line_end(fence_row) + 1).min(self.content.len());
+        let mut body_end = self.content.len();
+        for (row, &row_start) in starts.iter().enumerate().skip(fence_row + 1) {
+            if self.content[row_start..self.line_end(row)]
+                .trim_start()
+                .starts_with("```")
+            {
+                body_end = row_start.saturating_sub(1).max(body_start);
+                break;
+            }
+        }
+        Some((lang, body_start..body_end))
+    }
+
+    /// If `position` lands on a code card's chrome painted last frame:
+    /// `(on_copy, fence_row)` — `true` = the Copy button, `false` = the
+    /// language tag.
+    fn code_chip_at(&self, position: Point<Pixels>) -> Option<(bool, usize)> {
+        self.code_chip_rects.iter().find_map(|c| {
+            if c.copy.contains(&position) {
+                Some((true, c.fence_row))
+            } else if c.lang.contains(&position) {
+                Some((false, c.fence_row))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Rewrite the block's opening fence to carry `lang` (one undo step).
+    fn set_code_lang(&mut self, fence_row: usize, lang: &str, cx: &mut Context<Self>) {
+        let starts = self.line_starts();
+        let Some(&start) = starts.get(fence_row) else {
+            return;
+        };
+        let end = self.line_end(fence_row);
+        let line = &self.content[start..end];
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with("```") {
+            return;
+        }
+        let indent = &line[..line.len() - trimmed.len()];
+        let new_line = format!("{indent}```{}", if lang == "text" { "" } else { lang });
+        self.replace_range(start..end, &new_line, cx);
+        cx.emit(EditorEvent::Changed);
+    }
+
     fn checkbox_at(&self, position: Point<Pixels>) -> Option<usize> {
         let pad = px(4.);
         self.checkbox_rects.iter().find_map(|&(line, rect)| {
@@ -4552,6 +4644,96 @@ impl Render for EditorState {
                     ),
                 )
             }))
+            .children(self.code_lang_menu.map(|(row, anchor)| {
+                // The code block's language picker (Cditor-inspired): the host's
+                // highlighter languages, scrollable past the cap, current one
+                // checked. Selecting rewrites the opening fence (one undo step).
+                let st = self.markdown_style.as_ref();
+                let menu_bg = st.map_or(rgb(0x26262b).into(), |s| s.popover_bg);
+                let menu_border = st.map_or(rgb(0x45454c).into(), |s| s.popover_border);
+                let menu_fg = st.map_or(rgb(0xe6e6e6).into(), |s| s.popover_fg);
+                let hover = st.map_or(rgba(0x2f6fd628).into(), |s| s.popover_hover);
+                let mut thumb_c = st.map_or(rgba(0xffffff66).into(), |s| s.marker);
+                thumb_c.a = 0.5;
+                let current = self.code_block_at(row).map(|(l, _)| l).unwrap_or_default();
+                const ROW_H: f32 = 22.0;
+                const MAX_H: f32 = 260.0;
+                const PAD: f32 = 4.0;
+                let langs = self.code_langs.clone();
+                let rows_h = langs.len() as f32 * ROW_H;
+                let view_h = MAX_H - 2.0 * PAD;
+                let thumb = (rows_h > view_h).then(|| {
+                    let scrolled =
+                        (-f32::from(self.code_lang_scroll.offset().y)).clamp(0.0, rows_h - view_h);
+                    let thumb_h = (view_h * view_h / rows_h).max(24.0);
+                    let thumb_top = PAD + scrolled / (rows_h - view_h) * (view_h - thumb_h);
+                    div()
+                        .absolute()
+                        .top(px(thumb_top))
+                        .right(px(2.))
+                        .w(px(6.))
+                        .h(px(thumb_h))
+                        .rounded(px(3.))
+                        .bg(thumb_c)
+                });
+                gpui::deferred(
+                    gpui::anchored().position(anchor).snap_to_window().child(
+                        div()
+                            .relative()
+                            .occlude()
+                            .min_w(px(140.))
+                            .cursor(CursorStyle::Arrow)
+                            .bg(menu_bg)
+                            .border_1()
+                            .border_color(menu_border)
+                            .rounded(px(6.))
+                            .overflow_hidden()
+                            .text_color(menu_fg)
+                            .text_size(px(13.))
+                            .py(px(PAD))
+                            .on_mouse_down_out(cx.listener(|editor, _: &MouseDownEvent, _, cx| {
+                                editor.code_lang_menu = None;
+                                cx.notify();
+                            }))
+                            .child(
+                                div()
+                                    .id("code-lang-list")
+                                    .max_h(px(MAX_H - 2.0 * PAD))
+                                    .overflow_y_scroll()
+                                    .track_scroll(&self.code_lang_scroll)
+                                    .children(langs.into_iter().enumerate().map(|(i, lang)| {
+                                        let is_current = *lang == current
+                                            || (current.is_empty() && *lang == *"text");
+                                        let label: SharedString = if is_current {
+                                            format!("{lang} ✓").into()
+                                        } else {
+                                            lang.clone()
+                                        };
+                                        div()
+                                            .id(("code-lang-row", i))
+                                            .flex_shrink_0()
+                                            .h(px(ROW_H))
+                                            .px(px(10.))
+                                            .py(px(2.))
+                                            .hover(move |s| s.bg(hover))
+                                            .child(label)
+                                            .on_mouse_down(
+                                                MouseButton::Left,
+                                                cx.listener(
+                                                    move |editor, _: &MouseDownEvent, _, cx| {
+                                                        cx.stop_propagation();
+                                                        editor.code_lang_menu = None;
+                                                        editor.set_code_lang(row, &lang, cx);
+                                                    },
+                                                ),
+                                            )
+                                            .into_any_element()
+                                    })),
+                            )
+                            .children(thumb),
+                    ),
+                )
+            }))
     }
 }
 
@@ -4736,6 +4918,30 @@ impl Block {
 /// full editor width). Each line carries the block color, the shared box width
 /// (back-patched once the block's extent is known), and whether it's the
 /// first/last visible line (to round the box's top/bottom corners).
+/// Last-frame hit rects for one code card's chrome (see `code_chip_rects`).
+#[derive(Clone)]
+struct CodeChipHit {
+    lang: Bounds<Pixels>,
+    copy: Bounds<Pixels>,
+    fence_row: usize,
+}
+
+/// A code card's top-right chrome, laid out in prepaint: the language tag and
+/// Copy button (Cditor-inspired, issue #16). Geometry is window-space; paint
+/// draws at these bounds and the hitboxes flip the cursor.
+struct CodeChip {
+    lang_text: SharedString,
+    lang_bounds: Bounds<Pixels>,
+    copy_bounds: Bounds<Pixels>,
+    fence_row: usize,
+    /// Card background — the labels sit on an opaque pill of it so they stay
+    /// readable over a long first line.
+    bg: Hsla,
+    fg: Hsla,
+    lang_hb: Hitbox,
+    copy_hb: Hitbox,
+}
+
 #[derive(Clone, Copy)]
 struct CodeBg {
     color: Hsla,
@@ -6981,6 +7187,9 @@ struct PrepaintState {
     /// and file chips, so the cursor flips to a hand over them (like the image
     /// grips' resize cursor). Set in paint via `set_cursor_style`.
     checkbox_grips: Vec<(usize, Hitbox)>,
+    /// Per-code-block chrome (lang tag + Copy), laid out here so paint and the
+    /// click rects agree.
+    code_chips: Vec<CodeChip>,
     chip_grips: Vec<(usize, Hitbox)>,
     /// Pointer-cursor hitboxes over foldable-callout chevrons, keyed by line.
     alert_fold_grips: Vec<(usize, Hitbox)>,
@@ -7329,6 +7538,82 @@ impl Element for EditorElement {
                     size(bounds.size.width, *lh),
                 );
                 chip_grips.push((i, window.insert_hitbox(hit, HitboxBehavior::Normal)));
+            }
+        }
+
+        // Code-card chrome (Cditor-inspired, issue #16): a language tag + Copy
+        // button at each code block's top-right, inside the padded box. Laid
+        // out here (paint draws at these bounds; hitboxes flip the cursor).
+        let mut code_chips = Vec::new();
+        if let Some(st) = editor
+            .markdown_style
+            .as_ref()
+            .filter(|_| !editor.content.is_empty())
+        {
+            let starts = editor.line_starts();
+            let chip_fs = px(11.);
+            let chip_h = px(16.);
+            let shape = |window: &mut Window, text: &SharedString, color: Hsla| {
+                let run = TextRun {
+                    len: text.len(),
+                    font: font.clone(),
+                    color,
+                    background_color: None,
+                    underline: None,
+                    strikethrough: None,
+                };
+                window
+                    .text_system()
+                    .shape_line(text.clone(), chip_fs, &[run], None)
+                    .width()
+            };
+            for (i, bg) in backgrounds.iter().enumerate() {
+                let Some(cb) = bg.as_ref().filter(|cb| cb.top) else {
+                    continue;
+                };
+                // The opening fence row: this row if the fence is revealed, else
+                // the nearest ``` row above (hidden fences collapse to height 0).
+                let Some(fence_row) = (0..=i).rev().find(|&r| {
+                    starts.get(r).is_some_and(|&s| {
+                        editor.content[s..editor.line_end(r)]
+                            .trim_start()
+                            .starts_with("```")
+                    })
+                }) else {
+                    continue;
+                };
+                let lang = editor
+                    .code_block_at(fence_row)
+                    .map(|(l, _)| l)
+                    .unwrap_or_default();
+                let lang_text: SharedString = if lang.is_empty() {
+                    "text ▾".into()
+                } else {
+                    format!("{lang} ▾").into()
+                };
+                let copy_text: SharedString = "Copy".into();
+                let lang_w = shape(window, &lang_text, st.quote) + px(12.);
+                let copy_w = shape(window, &copy_text, st.quote) + px(12.);
+                let (top_pad, _) = code_pads(Some(*cb));
+                let right = bounds.origin.x + cb.width - px(6.);
+                let y = bounds.origin.y + line_tops[i] - top_pad + px(3.);
+                let copy_bounds = Bounds::new(point(right - copy_w, y), size(copy_w, chip_h));
+                let lang_bounds = Bounds::new(
+                    point(right - copy_w - px(4.) - lang_w, y),
+                    size(lang_w, chip_h),
+                );
+                let lang_hb = window.insert_hitbox(lang_bounds, HitboxBehavior::Normal);
+                let copy_hb = window.insert_hitbox(copy_bounds, HitboxBehavior::Normal);
+                code_chips.push(CodeChip {
+                    lang_text,
+                    lang_bounds,
+                    copy_bounds,
+                    fence_row,
+                    bg: cb.color,
+                    fg: st.quote,
+                    lang_hb,
+                    copy_hb,
+                });
             }
         }
 
@@ -7818,6 +8103,7 @@ impl Element for EditorElement {
             inline_maths,
             image_grips,
             checkbox_grips,
+            code_chips,
             chip_grips,
             alert_fold_grips,
             heading_chevrons,
@@ -8421,6 +8707,56 @@ impl Element for EditorElement {
                 _ => None,
             })
             .collect();
+        // Code-card chrome: the language tag + Copy button laid out in prepaint.
+        // Each label sits on an opaque pill of the card color so it stays
+        // readable over a long first line; hover brightens it.
+        let mut code_chip_rects = Vec::new();
+        for chip in &prepaint.code_chips {
+            for (bounds_, text, hb) in [
+                (chip.lang_bounds, &chip.lang_text, &chip.lang_hb),
+                (chip.copy_bounds, &SharedString::from("Copy"), &chip.copy_hb),
+            ] {
+                let hovered = hb.is_hovered(window);
+                window.paint_quad(PaintQuad {
+                    bounds: bounds_,
+                    corner_radii: Corners::all(px(4.)),
+                    background: chip.bg.into(),
+                    border_widths: Edges::all(px(0.)),
+                    border_color: chip.fg,
+                    border_style: BorderStyle::Solid,
+                });
+                let color = if hovered { text_color } else { chip.fg };
+                let run = TextRun {
+                    len: text.len(),
+                    font: font.clone(),
+                    color,
+                    background_color: None,
+                    underline: None,
+                    strikethrough: None,
+                };
+                let shaped = window
+                    .text_system()
+                    .shape_line(text.clone(), px(11.), &[run], None);
+                let _ = shaped.paint(
+                    point(
+                        bounds_.origin.x + (bounds_.size.width - shaped.width()) / 2.,
+                        bounds_.origin.y + px(1.),
+                    ),
+                    bounds_.size.height - px(2.),
+                    gpui::TextAlign::Left,
+                    None,
+                    window,
+                    cx,
+                );
+                window.set_cursor_style(CursorStyle::PointingHand, hb);
+            }
+            code_chip_rects.push(CodeChipHit {
+                lang: chip.lang_bounds,
+                copy: chip.copy_bounds,
+                fence_row: chip.fence_row,
+            });
+        }
+
         // Hovering an inline link shows a hand, like the reading view (the
         // hitboxes come from prepaint; cursor styles must be set during paint).
         for hb in &prepaint.link_grips {
@@ -8446,6 +8782,7 @@ impl Element for EditorElement {
             editor.prop_pill_rects = prop_pill_rects;
             editor.prop_row_rects = prop_row_rects;
             editor.checkbox_rects = checkbox_rects;
+            editor.code_chip_rects = code_chip_rects;
             editor.alert_fold_rects = alert_fold_rects;
             editor.heading_fold_rects = heading_fold_rects;
             editor.heading_row_rects = std::mem::take(&mut prepaint.heading_row_rects);

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -647,13 +647,9 @@ pub struct EditorState {
     scan_cache: std::cell::RefCell<Option<(u64, std::rc::Rc<ScanData>)>>,
     /// See [`ScrollCompensatorFn`].
     scroll_compensator: Option<ScrollCompensatorFn>,
-    /// Cross-frame cache of each markdown line's `hidden_runs` output — the
-    /// residual per-frame cost after the scan cache (gpui's own layout cache
-    /// already absorbs glyph shaping): building every line's display string +
-    /// run list on every repaint. Keyed by a hash of the line + its reveal
-    /// state; edits miss only the lines they changed. Capacity-capped in
-    /// `shape_document`.
-    line_run_cache: std::cell::RefCell<std::collections::HashMap<u64, CachedLineRuns>>,
+    /// Cross-frame shaping caches — line runs, table column widths, and table
+    /// wrap rows (see [`ShapeCaches`]). Capacity-capped in `shape_document`.
+    shape_caches: ShapeCaches,
     /// `content_gen` as of the last paint — a measure with the SAME generation
     /// but different heights means an async (non-edit) height change, the
     /// scroll-anchoring trigger.
@@ -793,7 +789,7 @@ impl EditorState {
             scan_cache: std::cell::RefCell::new(None),
             scroll_compensator: None,
             last_paint_gen: 0,
-            line_run_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
+            shape_caches: ShapeCaches::default(),
             content_gen: 0,
             utf16_anchor: std::cell::Cell::new((0, 0, 0)),
             editing_block: None,
@@ -6148,8 +6144,8 @@ fn shape_document(
     col_resize: Option<TableColResize>,
     // The content's cached structural scans (see [`ScanData`]).
     scan: &ScanData,
-    // Cross-frame per-line run cache (see `EditorState::line_run_cache`).
-    line_cache: &std::cell::RefCell<std::collections::HashMap<u64, CachedLineRuns>>,
+    // Cross-frame shaping caches (see [`ShapeCaches`]).
+    caches: &ShapeCaches,
     // Collapsed headings (trimmed source lines) — their section lines fold to
     // height 0 like a folded callout's body.
     folded_headings: &std::collections::HashSet<String>,
@@ -6322,19 +6318,66 @@ fn shape_document(
     let regions: &[markdown_syntax::TableRegion] = if md.is_some() { &scan.tables } else { &[] };
     // Shared component of the per-line run-cache key (see `CachedLineRuns`).
     let run_epoch = line_run_epoch(base_font, md);
-    let mut region_cols: Vec<Vec<Pixels>> = Vec::with_capacity(regions.len());
-    for r in regions {
-        region_cols.push(table_column_widths(
-            &lines,
-            r,
-            window,
-            base_font,
-            base_font_size,
-            base_color,
-            wrap_width,
-            col_resize,
-        ));
-    }
+    // Measured column widths, cached across frames: rebuilt only when the
+    // tables' source text, the wrap width, the font epoch, or a live column
+    // drag changes — measuring shaped every cell of every table per call.
+    let region_cols: Vec<Vec<Pixels>> = {
+        let cols_key = {
+            use std::hash::{Hash, Hasher};
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            for r in regions {
+                for li in r.lines.clone() {
+                    lines[li].hash(&mut h);
+                }
+                if let Some(w) = &r.col_widths_attr {
+                    for v in w {
+                        v.to_bits().hash(&mut h);
+                    }
+                }
+            }
+            wrap_width
+                .map(f32::from)
+                .unwrap_or(-1.)
+                .to_bits()
+                .hash(&mut h);
+            f32::from(base_font_size).to_bits().hash(&mut h);
+            run_epoch.hash(&mut h);
+            if let Some(r) = col_resize {
+                r.header_row.hash(&mut h);
+                r.col.hash(&mut h);
+                r.width.to_bits().hash(&mut h);
+            }
+            h.finish()
+        };
+        let hit = caches
+            .region_cols
+            .borrow()
+            .as_ref()
+            .filter(|(k, cols)| *k == cols_key && cols.len() == regions.len())
+            .map(|(_, cols)| cols.clone());
+        match hit {
+            Some(cols) => cols,
+            None => {
+                let cols: Vec<Vec<Pixels>> = regions
+                    .iter()
+                    .map(|r| {
+                        table_column_widths(
+                            &lines,
+                            r,
+                            window,
+                            base_font,
+                            base_font_size,
+                            base_color,
+                            wrap_width,
+                            col_resize,
+                        )
+                    })
+                    .collect();
+                *caches.region_cols.borrow_mut() = Some((cols_key, cols.clone()));
+                cols
+            }
+        }
+    };
     let table_row_h = base_font_size * LINE_HEIGHT_RATIO + px(12.);
     // Fenced-code-block tracking: collect a block's line indices (so its box can
     // be sized to its widest line + the first/last line marked for rounding) and
@@ -7052,7 +7095,8 @@ fn shape_document(
                 run_epoch.hash(&mut h);
                 h.finish()
             };
-            let cached = line_cache
+            let cached = caches
+                .line_runs
                 .borrow()
                 .get(&key)
                 .filter(|c| c.src == line && c.line_base == line_base)
@@ -7071,7 +7115,7 @@ fn shape_document(
                         reveal_inline,
                         st,
                     );
-                    line_cache.borrow_mut().insert(
+                    caches.line_runs.borrow_mut().insert(
                         key,
                         CachedLineRuns {
                             src: line.to_string(),
@@ -7161,16 +7205,36 @@ fn shape_document(
                     // becomes the header/body border.
                     Some(t) if t.is_separator => px(0.),
                     // A drag-narrowed column wraps its cells — the row grows to
-                    // the tallest cell's wrap rows.
+                    // the tallest cell's wrap rows (memoized: this shaped every
+                    // cell per row per frame).
                     Some(t) => {
-                        let rows = table_row_wrap_rows(
-                            window,
-                            &t.cells,
-                            &t.col_widths,
-                            t.is_header,
-                            base_font,
-                            base_font_size,
-                        );
+                        let row_key = {
+                            use std::hash::{Hash, Hasher};
+                            let mut h = std::collections::hash_map::DefaultHasher::new();
+                            line.hash(&mut h);
+                            for w in &t.col_widths {
+                                f32::from(*w).to_bits().hash(&mut h);
+                            }
+                            t.is_header.hash(&mut h);
+                            run_epoch.hash(&mut h);
+                            h.finish()
+                        };
+                        let hit = caches.cell_rows.borrow().get(&row_key).copied();
+                        let rows = match hit {
+                            Some(r) => r,
+                            None => {
+                                let r = table_row_wrap_rows(
+                                    window,
+                                    &t.cells,
+                                    &t.col_widths,
+                                    t.is_header,
+                                    base_font,
+                                    base_font_size,
+                                );
+                                caches.cell_rows.borrow_mut().insert(row_key, r);
+                                r
+                            }
+                        };
                         table_row_h + base_font_size * LINE_HEIGHT_RATIO * (rows - 1) as f32
                     }
                     None => match widget.as_ref() {
@@ -7232,9 +7296,13 @@ fn shape_document(
     // is fine — the next frame rebuilds only what's visible… which is
     // everything today, but each rebuild re-primes the cache.
     {
-        let mut cache = line_cache.borrow_mut();
+        let mut cache = caches.line_runs.borrow_mut();
         if cache.len() > lines.len() * 2 + 64 {
             cache.clear();
+        }
+        let mut rows = caches.cell_rows.borrow_mut();
+        if rows.len() > lines.len() * 2 + 64 {
+            rows.clear();
         }
     }
     (
@@ -8127,6 +8195,20 @@ struct CachedLineRuns {
     map: Vec<usize>,
 }
 
+/// The editor-owned caches `shape_document` reads and writes (interior-
+/// mutable — shaping runs under a read borrow of the editor):
+/// - `line_runs`: each markdown line's built display + runs (cross-frame).
+/// - `region_cols`: the measured table column widths for the WHOLE document,
+///   one keyed entry — rebuilt when the tables' source, the wrap width, the
+///   font epoch, or a live column drag changes.
+/// - `cell_rows`: per table row, how many wrap rows its tallest cell needs.
+#[derive(Default)]
+struct ShapeCaches {
+    line_runs: std::cell::RefCell<std::collections::HashMap<u64, CachedLineRuns>>,
+    region_cols: std::cell::RefCell<Option<(u64, Vec<Vec<Pixels>>)>>,
+    cell_rows: std::cell::RefCell<std::collections::HashMap<u64, usize>>,
+}
+
 /// A hash of the inputs shared by every line's run build (font + palette) —
 /// part of the per-line cache key, so a theme or font change misses cleanly.
 fn line_run_epoch(font: &Font, st: Option<&SyntaxStyle>) -> u64 {
@@ -8369,7 +8451,7 @@ impl Element for EditorElement {
                     editor.image_resize,
                     editor.table_col_resize,
                     &scan,
-                    &editor.line_run_cache,
+                    &editor.shape_caches,
                     &editor.folded_headings,
                 );
                 // Mirror prepaint's `line_tops` walk exactly (same `line_pads`),
@@ -8543,7 +8625,7 @@ impl Element for EditorElement {
                     editor.image_resize,
                     editor.table_col_resize,
                     &editor.scan_data(),
-                    &editor.line_run_cache,
+                    &editor.shape_caches,
                     &editor.folded_headings,
                 )
             };

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -6515,24 +6515,63 @@ impl LineMark {
 /// source line, its row height, an optional inline-image widget, an optional
 /// fenced-code-block background, an optional table-row grid, the display→source
 /// map, and an optional gutter decoration (blockquote / list / checkbox).
-type ShapedLines = (
-    Vec<WrappedLine>,
-    Vec<Pixels>,
-    Vec<Option<Block>>,
-    Vec<Option<CodeBg>>,
-    Vec<Option<TableRow>>,
-    // Per-line display→source byte map for lines with markers hidden (W6); `None`
-    // when the displayed text equals the source (revealed / code / widget lines).
-    Vec<Option<Vec<usize>>>,
-    Vec<Option<LineMark>>,
-    // Per-line inline `$…$` formulas painted over spacers in the shaped text (empty for
-    // lines without any).
-    Vec<Vec<InlineMath>>,
-    // Per-line wrap-row count. Geometry (line tops, total height) reads THIS,
-    // not `wrap_boundaries()` — a windowed-out line's `WrappedLine` is an empty
-    // placeholder, but its cached count keeps the layout exact.
-    Vec<usize>,
-);
+/// One shaped document: per-line parallel channels, all the same length —
+/// the per-line loop's normal push and [`ShapedDoc::push_placeholder`] are
+/// the only writers, so the lockstep invariant lives here.
+#[derive(Default)]
+struct ShapedDoc {
+    wrapped: Vec<WrappedLine>,
+    heights: Vec<Pixels>,
+    widgets: Vec<Option<Block>>,
+    backgrounds: Vec<Option<CodeBg>>,
+    tables: Vec<Option<TableRow>>,
+    /// Per-line display→source byte map for lines with markers hidden (W6);
+    /// `None` when the displayed text equals the source.
+    maps: Vec<Option<Vec<usize>>>,
+    marks: Vec<Option<LineMark>>,
+    /// Per-line inline `$…$` formulas painted over spacers (empty when none).
+    inline_maths: Vec<Vec<InlineMath>>,
+    /// Per-line wrap-row count. Geometry (line tops, total height) reads THIS,
+    /// not `wrap_boundaries()` — a windowed-out line's `WrappedLine` is an
+    /// empty placeholder, but its cached count keeps the layout exact.
+    wrap_rows: Vec<usize>,
+}
+
+impl ShapedDoc {
+    /// Push one line that renders as something other than shaped text — a
+    /// widget/collapsed/windowed-out line: an empty placeholder `WrappedLine`,
+    /// the given height/widget/mark, and `rows` wrap rows.
+    fn push_placeholder(
+        &mut self,
+        window: &mut Window,
+        base_font_size: Pixels,
+        wrap_width: Option<Pixels>,
+        h: Pixels,
+        widget: Option<Block>,
+        mark: Option<LineMark>,
+        rows: usize,
+    ) {
+        let wl = shape_runs(
+            window,
+            &SharedString::default(),
+            base_font_size,
+            &[],
+            wrap_width,
+        )
+        .into_iter()
+        .next()
+        .expect("a line always shapes to one wrapped line");
+        self.wrapped.push(wl);
+        self.heights.push(h);
+        self.widgets.push(widget);
+        self.backgrounds.push(None);
+        self.tables.push(None);
+        self.maps.push(None);
+        self.marks.push(mark);
+        self.inline_maths.push(Vec::new());
+        self.wrap_rows.push(rows);
+    }
+}
 
 /// Fit-to-width display size for an inline image from its natural (device) size:
 /// cap to the content width (or an explicit `{width=N}`), preserving aspect.
@@ -6861,16 +6900,8 @@ fn shape_document(
     // Collapsed headings (trimmed source lines) — their section lines fold to
     // height 0 like a folded callout's body.
     folded_headings: &std::collections::HashSet<String>,
-) -> ShapedLines {
-    let mut wrapped: Vec<WrappedLine> = Vec::new();
-    let mut heights: Vec<Pixels> = Vec::new();
-    let mut wrap_rows: Vec<usize> = Vec::new();
-    let mut widgets = Vec::new();
-    let mut backgrounds: Vec<Option<CodeBg>> = Vec::new();
-    let mut tables: Vec<Option<TableRow>> = Vec::new();
-    let mut maps = Vec::new();
-    let mut marks: Vec<Option<LineMark>> = Vec::new();
-    let mut inline_maths: Vec<Vec<InlineMath>> = Vec::new();
+) -> ShapedDoc {
+    let mut out = ShapedDoc::default();
     let lines: Vec<&str> = content.split('\n').collect();
     // Ordered items paint their computed CommonMark position, not their
     // literal source digits (the reader renumbers the same way).
@@ -7155,8 +7186,8 @@ fn shape_document(
         // Running top of this line — mirrors the prepaint `line_tops` walk
         // (including `line_pads`) so the band test is exact.
         if idx > 0 {
-            let (tp, bp) = line_pads(backgrounds[idx - 1], tables[idx - 1].as_ref());
-            y_acc += tp + bp + heights[idx - 1] * wrap_rows[idx - 1] as f32;
+            let (tp, bp) = line_pads(out.backgrounds[idx - 1], out.tables[idx - 1].as_ref());
+            y_acc += tp + bp + out.heights[idx - 1] * out.wrap_rows[idx - 1] as f32;
         }
 
         // A ready mermaid block renders as its diagram (on the first line) with the
@@ -7171,25 +7202,7 @@ fn shape_document(
             } else {
                 (px(0.), None)
             };
-            let wl = shape_runs(
-                window,
-                &SharedString::default(),
-                base_font_size,
-                &[],
-                wrap_width,
-            )
-            .into_iter()
-            .next()
-            .expect("a line always shapes to one wrapped line");
-            wrapped.push(wl);
-            heights.push(h);
-            widgets.push(widget);
-            backgrounds.push(None);
-            tables.push(None);
-            maps.push(None);
-            marks.push(None);
-            inline_maths.push(Vec::new());
-            wrap_rows.push(1);
+            out.push_placeholder(window, base_font_size, wrap_width, h, widget, None, 1);
             line_start = line_end + 1;
             alert_run = None;
             continue;
@@ -7201,25 +7214,7 @@ fn shape_document(
             && (start_row..=end_row).contains(&idx)
         {
             let h = if idx == start_row { gap_h } else { px(0.) };
-            let wl = shape_runs(
-                window,
-                &SharedString::default(),
-                base_font_size,
-                &[],
-                wrap_width,
-            )
-            .into_iter()
-            .next()
-            .expect("a line always shapes to one wrapped line");
-            wrapped.push(wl);
-            heights.push(h);
-            widgets.push(None);
-            backgrounds.push(None);
-            tables.push(None);
-            maps.push(None);
-            marks.push(None);
-            inline_maths.push(Vec::new());
-            wrap_rows.push(1);
+            out.push_placeholder(window, base_font_size, wrap_width, h, None, None, 1);
             line_start = line_end + 1;
             alert_run = None;
             continue;
@@ -7233,25 +7228,7 @@ fn shape_document(
             } else {
                 (px(0.), None)
             };
-            let wl = shape_runs(
-                window,
-                &SharedString::default(),
-                base_font_size,
-                &[],
-                wrap_width,
-            )
-            .into_iter()
-            .next()
-            .expect("a line always shapes to one wrapped line");
-            wrapped.push(wl);
-            heights.push(h);
-            widgets.push(widget);
-            backgrounds.push(None);
-            tables.push(None);
-            maps.push(None);
-            marks.push(None);
-            inline_maths.push(Vec::new());
-            wrap_rows.push(1);
+            out.push_placeholder(window, base_font_size, wrap_width, h, widget, None, 1);
             line_start = line_end + 1;
             alert_run = None;
             continue;
@@ -7266,25 +7243,7 @@ fn shape_document(
             && let Some(inner) = gpui_markdown::syntax::embed_line(line)
             && let Some(h) = embed_view.and_then(|f| f(inner).map(|(_, h)| h))
         {
-            let wl = shape_runs(
-                window,
-                &SharedString::default(),
-                base_font_size,
-                &[],
-                wrap_width,
-            )
-            .into_iter()
-            .next()
-            .expect("a line always shapes to one wrapped line");
-            wrapped.push(wl);
-            heights.push(h);
-            widgets.push(None);
-            backgrounds.push(None);
-            tables.push(None);
-            maps.push(None);
-            marks.push(None);
-            inline_maths.push(Vec::new());
-            wrap_rows.push(1);
+            out.push_placeholder(window, base_font_size, wrap_width, h, None, None, 1);
             line_start = line_end + 1;
             continue;
         }
@@ -7296,25 +7255,7 @@ fn shape_document(
             .iter()
             .any(|r| r.contains(&idx) && idx != r.start)
         {
-            let wl = shape_runs(
-                window,
-                &SharedString::default(),
-                base_font_size,
-                &[],
-                wrap_width,
-            )
-            .into_iter()
-            .next()
-            .expect("a line always shapes to one wrapped line");
-            wrapped.push(wl);
-            heights.push(px(0.));
-            widgets.push(None);
-            backgrounds.push(None);
-            tables.push(None);
-            maps.push(None);
-            marks.push(None);
-            inline_maths.push(Vec::new());
-            wrap_rows.push(1);
+            out.push_placeholder(window, base_font_size, wrap_width, px(0.), None, None, 1);
             line_start = line_end + 1;
             continue;
         }
@@ -7328,25 +7269,7 @@ fn shape_document(
             } else {
                 (px(0.), None)
             };
-            let wl = shape_runs(
-                window,
-                &SharedString::default(),
-                base_font_size,
-                &[],
-                wrap_width,
-            )
-            .into_iter()
-            .next()
-            .expect("a line always shapes to one wrapped line");
-            wrapped.push(wl);
-            heights.push(h);
-            widgets.push(widget);
-            backgrounds.push(None);
-            tables.push(None);
-            maps.push(None);
-            marks.push(None);
-            inline_maths.push(Vec::new());
-            wrap_rows.push(1);
+            out.push_placeholder(window, base_font_size, wrap_width, h, widget, None, 1);
             line_start = line_end + 1;
             alert_run = None;
             continue;
@@ -7403,7 +7326,7 @@ fn shape_document(
             let bw = code_w + px(2. * CODE_INSET);
             let last = *code_block.last().unwrap();
             for &bi in &code_block {
-                if let Some(cb) = &mut backgrounds[bi] {
+                if let Some(cb) = &mut out.backgrounds[bi] {
                     cb.width = bw;
                     cb.bottom = bi == last;
                 }
@@ -7856,27 +7779,17 @@ fn shape_document(
                 if let Some((lh_c, wr_c)) = hit {
                     let total = lh_c * wr_c as f32;
                     if y_acc > hi || y_acc + total < lo {
-                        let wl = shape_runs(
-                            window,
-                            &SharedString::default(),
-                            base_font_size,
-                            &[],
-                            wrap_width,
-                        )
-                        .into_iter()
-                        .next()
-                        .expect("a line always shapes to one wrapped line");
-                        wrapped.push(wl);
-                        heights.push(lh_c);
-                        wrap_rows.push(wr_c);
-                        widgets.push(None);
-                        backgrounds.push(None);
-                        tables.push(None);
-                        maps.push(None);
                         // The REAL mark: paint's nesting-guide bookkeeping
                         // walks offscreen ancestors' marks.
-                        marks.push(mark);
-                        inline_maths.push(Vec::new());
+                        out.push_placeholder(
+                            window,
+                            base_font_size,
+                            wrap_width,
+                            lh_c,
+                            None,
+                            mark,
+                            wr_c,
+                        );
                         line_start = line_end + 1;
                         continue;
                     }
@@ -8062,19 +7975,19 @@ fn shape_document(
                     .borrow_mut()
                     .insert(hk, (h, wl.wrap_boundaries().len() + 1));
             }
-            wrap_rows.push(wl.wrap_boundaries().len() + 1);
-            wrapped.push(wl);
-            heights.push(h);
-            widgets.push(widget);
-            backgrounds.push(bg);
-            tables.push(table);
-            maps.push(map);
-            marks.push(mark);
-            inline_maths.push(line_inline_math);
+            out.wrap_rows.push(wl.wrap_boundaries().len() + 1);
+            out.wrapped.push(wl);
+            out.heights.push(h);
+            out.widgets.push(widget);
+            out.backgrounds.push(bg);
+            out.tables.push(table);
+            out.maps.push(map);
+            out.marks.push(mark);
+            out.inline_maths.push(line_inline_math);
             // Track a (visible) code line + its width so the block's box can be
             // sized to its widest line and its last line marked.
             if is_code && !collapse_fence {
-                code_block.push(backgrounds.len() - 1);
+                code_block.push(out.backgrounds.len() - 1);
                 code_w = code_w.max(line_w);
             }
         }
@@ -8086,7 +7999,7 @@ fn shape_document(
         let bw = code_w + px(2. * CODE_INSET);
         let last = *code_block.last().unwrap();
         for &bi in &code_block {
-            if let Some(cb) = &mut backgrounds[bi] {
+            if let Some(cb) = &mut out.backgrounds[bi] {
                 cb.width = bw;
                 cb.bottom = bi == last;
             }
@@ -8110,17 +8023,7 @@ fn shape_document(
             lh.clear();
         }
     }
-    (
-        wrapped,
-        heights,
-        widgets,
-        backgrounds,
-        tables,
-        maps,
-        marks,
-        inline_maths,
-        wrap_rows,
-    )
+    out
 }
 
 /// Measure a property region's rows into a [`PropPanel`] with content-fit
@@ -9117,7 +9020,7 @@ struct ShapeMemo {
     caret_row: Option<usize>,
     selection: (usize, usize),
     font_size: Pixels,
-    shaped: ShapedLines,
+    shaped: ShapedDoc,
 }
 
 struct PrepaintState {
@@ -9311,8 +9214,12 @@ impl Element for EditorElement {
                 );
                 // Mirror prepaint's `line_tops` walk exactly (same `line_pads`),
                 // or the element lays out shorter than it paints.
-                let (heights, backgrounds, tables, rows) =
-                    (&shaped.1, &shaped.3, &shaped.4, &shaped.8);
+                let (heights, backgrounds, tables, rows) = (
+                    &shaped.heights,
+                    &shaped.backgrounds,
+                    &shaped.tables,
+                    &shaped.wrap_rows,
+                );
                 let mut y = px(0.);
                 let mut needed = px(0.);
                 let mut new_tops: Vec<Pixels> = Vec::with_capacity(heights.len());
@@ -9454,9 +9361,9 @@ impl Element for EditorElement {
                 && m.selection == selection
                 && m.font_size == font_size
         });
-        let (
+        let ShapedDoc {
             wrapped,
-            line_heights,
+            heights: line_heights,
             widgets,
             backgrounds,
             tables,
@@ -9464,7 +9371,7 @@ impl Element for EditorElement {
             marks,
             inline_maths,
             wrap_rows,
-        ) = if let Some(m) = memo {
+        } = if let Some(m) = memo {
             m.shaped
         } else if editor.content.is_empty() {
             let w = shape_all(
@@ -9477,17 +9384,17 @@ impl Element for EditorElement {
             );
             let n = w.len();
             let rows: Vec<usize> = w.iter().map(|l| l.wrap_boundaries().len() + 1).collect();
-            (
-                w,
-                vec![base_lh; n],
-                vec![None; n],
-                vec![None; n],
-                vec![None; n],
-                vec![None; n],
-                vec![None; n],
-                vec![Vec::new(); n],
-                rows,
-            )
+            ShapedDoc {
+                wrapped: w,
+                heights: vec![base_lh; n],
+                widgets: vec![None; n],
+                backgrounds: vec![None; n],
+                tables: vec![None; n],
+                maps: vec![None; n],
+                marks: vec![None; n],
+                inline_maths: vec![Vec::new(); n],
+                wrap_rows: rows,
+            }
         } else {
             shape_document(
                 window,

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -5595,7 +5595,10 @@ fn shape_document(
                                 .iter()
                                 .filter_map(|(r, style)| {
                                     let (a, b) = (r.start.max(start), r.end.min(end));
-                                    (a < b).then_some((a - start..b - start, *style))
+                                    // `then` (lazy), not `then_some`: the arg is
+                                    // evaluated eagerly, and `b - start` underflows
+                                    // for a token wholly before this line.
+                                    (a < b).then(|| (a - start..b - start, *style))
                                 })
                                 .collect();
                             if !in_line.is_empty() {

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -3960,8 +3960,10 @@ impl EditorState {
             }
             cx += cw;
         }
+        // A click in a spanned trailing column lands in the short row's last cell.
+        let cell = cell.min(t.cells.len().saturating_sub(1));
         let content = t.cells.get(cell)?;
-        let cw = t.col_widths[cell];
+        let cw = cell_span_width(&t.col_widths, t.cells.len(), cell);
         let cf = cell_font(&font, t.is_header);
         let full_w = measure_width(window, content, &cf, font_size);
         let avail = (cw - pad * 2.).max(px(8.));
@@ -8064,7 +8066,18 @@ fn table_column_widths(
     wrap_width: Option<Pixels>,
     col_resize: Option<TableColResize>,
 ) -> Vec<Pixels> {
-    let cols = region.aligns.len().max(1);
+    // Reader parity: a row with MORE cells than the header widens the grid —
+    // extra columns render (the short rows' last cells span the remainder)
+    // instead of hiding the excess.
+    let cols = region
+        .lines
+        .clone()
+        .filter(|&li| li != region.lines.start + 1)
+        .map(|li| markdown_syntax::table_cells(lines[li]).len())
+        .max()
+        .unwrap_or(0)
+        .max(region.aligns.len())
+        .max(1);
     let pad = px(TABLE_CELL_PAD);
     let mut widths = vec![px(0.); cols];
     for li in region.lines.clone() {
@@ -8187,6 +8200,17 @@ fn shape_cell(
 
 /// How many wrap rows table row `cells` need at `col_widths` — 1 for content
 /// that fits; more once a drag-narrowed column forces its text to wrap.
+/// The width available to cell `c` of a row with `cells_len` cells: a short
+/// row's LAST cell spans the remaining columns (reader parity — e.g. a
+/// two-cell header over a wider body), otherwise its own column.
+fn cell_span_width(col_widths: &[Pixels], cells_len: usize, c: usize) -> Pixels {
+    if c + 1 == cells_len && cells_len < col_widths.len() {
+        col_widths[c..].iter().copied().sum()
+    } else {
+        col_widths.get(c).copied().unwrap_or(px(0.))
+    }
+}
+
 fn table_row_wrap_rows(
     window: &mut Window,
     cells: &[SharedString],
@@ -8202,9 +8226,10 @@ fn table_row_wrap_rows(
         if cell.is_empty() {
             continue;
         }
-        let Some(&cw) = col_widths.get(c) else {
+        let cw = cell_span_width(col_widths, cells.len(), c);
+        if cw == px(0.) {
             continue;
-        };
+        }
         let avail = (cw - pad * 2.).max(px(8.));
         if let Some(wl) = shape_cell(window, cell, &cf, font_size, Some(avail), Hsla::default()) {
             rows = rows.max(wl.wrap_boundaries().len() + 1);
@@ -8241,8 +8266,11 @@ fn table_caret_pos(
     let range = t.cell_ranges.get(cell)?;
     let content = t.cells.get(cell)?;
     let in_cell = col.saturating_sub(range.start).min(content.len());
-    let cell_x = left + t.col_widths[..cell].iter().sum::<Pixels>();
-    let cw = t.col_widths.get(cell).copied().unwrap_or(px(0.));
+    let cell_x = left
+        + t.col_widths[..cell.min(t.col_widths.len())]
+            .iter()
+            .sum::<Pixels>();
+    let cw = cell_span_width(&t.col_widths, t.cell_ranges.len(), cell);
     // The header is bold, so shape with the bold font or the caret lands left of
     // the (wider) bold glyphs; position_for_index gives the exact kerned x — and,
     // shaped at the cell's width, the wrap row's y for drag-narrowed columns.
@@ -8363,8 +8391,9 @@ fn paint_table_row(
     let mut x = origin.x;
     for (c, &cw) in t.col_widths.iter().enumerate() {
         // Inner cell separator at the left of every cell except the first (Grid
-        // only; the other styles drop vertical lines).
-        if vlines && c > 0 {
+        // only; the other styles drop vertical lines). A short row draws no
+        // dividers past its last cell — that cell spans the remaining columns.
+        if vlines && c > 0 && c < t.cells.len() {
             window.paint_quad(fill(
                 Bounds::new(point(x, origin.y), size(thick, row_h)),
                 t.border,
@@ -8373,7 +8402,9 @@ fn paint_table_row(
         if let Some(cell) = t.cells.get(c).filter(|s| !s.is_empty()) {
             // Shaped at the cell's width so a drag-narrowed column word-wraps
             // (the row height already reserves the wrap rows). Top-anchored at
-            // the single-line pad, not centered — wraps grow downward.
+            // the single-line pad, not centered — wraps grow downward. A short
+            // row's last cell spans the remaining columns.
+            let cw = cell_span_width(&t.col_widths, t.cells.len(), c);
             let avail = (cw - pad * 2.).max(px(8.));
             if let Some(shaped) =
                 shape_cell(window, cell, &cell_font, font_size, Some(avail), color)
@@ -9349,7 +9380,10 @@ impl Element for EditorElement {
                     let x: Pixels = left + rt.col_widths[..cc].iter().copied().sum::<Pixels>();
                     let rect = Bounds::new(
                         point(x, bounds.origin.y + line_tops[crow]),
-                        size(rt.col_widths[cc], line_heights[crow]),
+                        size(
+                            cell_span_width(&rt.col_widths, rt.cells.len(), cc),
+                            line_heights[crow],
+                        ),
                     );
                     caret_cell = Some((rect, accent));
                 }

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1529,6 +1529,7 @@ impl EditorState {
             }
         }
         let data = std::rc::Rc::new(ScanData {
+            generation: self.content_gen,
             ordered: markdown_syntax::ordered_numbers(&lines),
             tables: markdown_syntax::table_regions(&self.content),
             mermaid: markdown_syntax::mermaid_blocks(&self.content),
@@ -3337,8 +3338,8 @@ impl EditorState {
             // Callout if the caret's contiguous `>`-run carries a VALID
             // `[!KIND]` marker anywhere (marker line or body line).
             let (first, last) = self.quote_run_rows(row);
-            for r in first..=last {
-                let l = &self.content[starts[r]..self.line_end(r)];
+            for (r, &start) in starts.iter().enumerate().take(last + 1).skip(first) {
+                let l = &self.content[start..self.line_end(r)];
                 let p = markdown_syntax::blockquote_prefix(l).unwrap_or(0);
                 if markdown_syntax::alert_kind(&l[p..]).is_some() {
                     return TurnKind::Callout;
@@ -3505,6 +3506,8 @@ impl EditorState {
             || self.line_drag.is_some()
             || position.x < grip_left(bounds.origin.x, self.grip_inset) - px(4.)
             || position.x > bounds.origin.x + bounds.size.width
+            || position.y < bounds.origin.y
+            || position.y > bounds.origin.y + bounds.size.height
         {
             return None;
         }
@@ -4158,6 +4161,12 @@ impl EditorState {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Vertical scrolling is the overwhelmingly common case — bail before
+        // the O(lines) row walk when there's no horizontal delta.
+        let dx = f32::from(event.delta.pixel_delta(px(20.)).x);
+        if dx == 0. {
+            return;
+        }
         let Some(bounds) = self.last_bounds else {
             return;
         };
@@ -4177,10 +4186,6 @@ impl EditorState {
         let total: Pixels = t.col_widths.iter().copied().sum();
         let avail = bounds.size.width - px(TABLE_GUTTER);
         if total <= avail {
-            return;
-        }
-        let dx = f32::from(event.delta.pixel_delta(px(20.)).x);
-        if dx == 0. {
             return;
         }
         let header = table_header_row(t, row);
@@ -6541,6 +6546,7 @@ impl ShapedDoc {
     /// Push one line that renders as something other than shaped text — a
     /// widget/collapsed/windowed-out line: an empty placeholder `WrappedLine`,
     /// the given height/widget/mark, and `rows` wrap rows.
+    #[allow(clippy::too_many_arguments)]
     fn push_placeholder(
         &mut self,
         window: &mut Window,
@@ -7065,25 +7071,13 @@ fn shape_document(
     // Measured column widths, cached across frames: rebuilt only when the
     // tables' source text, the wrap width, the font epoch, or a live column
     // drag changes — measuring shaped every cell of every table per call.
-    let region_cols: Vec<Vec<Pixels>> = {
+    let region_cols: std::rc::Rc<Vec<Vec<Pixels>>> = {
         let cols_key = {
             use std::hash::{Hash, Hasher};
             let mut h = std::collections::hash_map::DefaultHasher::new();
-            for r in regions {
-                for li in r.lines.clone() {
-                    lines[li].hash(&mut h);
-                }
-                if let Some(w) = &r.col_widths_attr {
-                    for v in w {
-                        v.to_bits().hash(&mut h);
-                    }
-                }
-            }
-            wrap_width
-                .map(f32::from)
-                .unwrap_or(-1.)
-                .to_bits()
-                .hash(&mut h);
+            // The scan generation covers every table byte and the `cols=`
+            // attr — no need to rehash the table text per frame.
+            scan.generation.hash(&mut h);
             f32::from(base_font_size).to_bits().hash(&mut h);
             run_epoch.hash(&mut h);
             if let Some(r) = col_resize {
@@ -7102,20 +7096,22 @@ fn shape_document(
         match hit {
             Some(cols) => cols,
             None => {
-                let cols: Vec<Vec<Pixels>> = regions
-                    .iter()
-                    .map(|r| {
-                        table_column_widths(
-                            &lines,
-                            r,
-                            window,
-                            base_font,
-                            base_font_size,
-                            base_color,
-                            col_resize,
-                        )
-                    })
-                    .collect();
+                let cols: std::rc::Rc<Vec<Vec<Pixels>>> = std::rc::Rc::new(
+                    regions
+                        .iter()
+                        .map(|r| {
+                            table_column_widths(
+                                &lines,
+                                r,
+                                window,
+                                base_font,
+                                base_font_size,
+                                base_color,
+                                col_resize,
+                            )
+                        })
+                        .collect(),
+                );
                 *caches.region_cols.borrow_mut() = Some((cols_key, cols.clone()));
                 cols
             }
@@ -8953,7 +8949,7 @@ struct CachedLineRuns {
 #[derive(Default)]
 struct ShapeCaches {
     line_runs: std::cell::RefCell<std::collections::HashMap<u64, CachedLineRuns>>,
-    region_cols: std::cell::RefCell<Option<(u64, Vec<Vec<Pixels>>)>>,
+    region_cols: std::cell::RefCell<Option<(u64, std::rc::Rc<Vec<Vec<Pixels>>>)>>,
     cell_rows: std::cell::RefCell<std::collections::HashMap<u64, usize>>,
     /// Per-line (row height, wrap rows), keyed by the line-run key ⊕ font
     /// size ⊕ wrap width — the shaping window's exact heights for skipped
@@ -8998,6 +8994,9 @@ pub type ScrollCompensatorFn = std::rc::Rc<dyn Fn(Pixels, &mut Window, &mut App)
 /// memo); now they rebuild only when the content actually changes, and the
 /// caret-driven table ops + auto-replace reuse the same scan.
 pub(crate) struct ScanData {
+    /// The `content_gen` this scan was built for — cache keys use this
+    /// instead of rehashing content.
+    generation: u64,
     ordered: Vec<(u32, usize)>,
     tables: Vec<markdown_syntax::TableRegion>,
     mermaid: Vec<(Range<usize>, String)>,
@@ -10938,18 +10937,23 @@ impl Element for EditorElement {
         }
         // Track the hovered grip row from a window-level listener — the
         // gutter sits outside the div, so its own on_mouse_move never fires
-        // there. Notifies only when the hovered row changes.
-        {
+        // there. Every editor's listener sees every pointer move, so the
+        // common miss (pointer nowhere near this editor) must stay cheap: a
+        // read-only check first (grip_hover_row_at bails on the x band and
+        // y range in O(1)), entity update only on an actual change — and no
+        // listener at all for raw-view editors.
+        if self.editor.read(cx).markdown_style.is_some() {
             let editor = self.editor.clone();
             window.on_mouse_event(move |e: &MouseMoveEvent, phase, _w, cx| {
                 if phase == gpui::DispatchPhase::Bubble {
-                    editor.update(cx, |ed, cx| {
-                        let gr = ed.grip_hover_row_at(e.position);
-                        if gr != ed.grip_hover_row {
+                    let ed = editor.read(cx);
+                    let gr = ed.grip_hover_row_at(e.position);
+                    if gr != ed.grip_hover_row {
+                        editor.update(cx, |ed, cx| {
                             ed.grip_hover_row = gr;
                             cx.notify();
-                        }
-                    });
+                        });
+                    }
                 }
             });
         }

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -767,6 +767,11 @@ pub struct EditorState {
     /// The row whose gutter grip the pointer hovers (mirrors prepaint's
     /// computation) — tracked so hover changes repaint the grip.
     grip_hover_row: Option<usize>,
+    /// Horizontal scroll of each wide table, keyed by its header row — wide
+    /// tables keep natural column widths and scroll in place. Keys drift on
+    /// edits above a table; entries are clamped at use, so a stale one is a
+    /// harmless partial offset. (ponytail: no eviction, the map stays tiny)
+    table_scroll_x: std::collections::HashMap<usize, f32>,
     /// Extra left offset for the drag grip — the host sets its line-number
     /// gutter's width here so the grip sits beside the numbers, not on them.
     grip_inset: Pixels,
@@ -916,6 +921,7 @@ impl EditorState {
             compensated: std::cell::Cell::new(false),
             line_drag: None,
             grip_hover_row: None,
+            table_scroll_x: std::collections::HashMap::new(),
             grip_inset: px(0.),
             content_gen: 0,
             utf16_anchor: std::cell::Cell::new((0, 0, 0)),
@@ -4097,6 +4103,60 @@ impl EditorState {
     }
 
     /// The table cell `(row, col)` the pointer is over, or `None` off any table —
+    /// The clamped horizontal scroll of the table headed at `header_row`.
+    fn table_sx(&self, header_row: usize, total: Pixels, avail: Pixels) -> Pixels {
+        let max = f32::from((total - avail).max(px(0.)));
+        px(self
+            .table_scroll_x
+            .get(&header_row)
+            .copied()
+            .unwrap_or(0.)
+            .clamp(0., max))
+    }
+
+    /// Horizontal wheel/trackpad over a wide table scrolls IT, not the page —
+    /// vertical deltas fall through to the outer scroll container untouched.
+    fn on_scroll_wheel(
+        &mut self,
+        event: &gpui::ScrollWheelEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(bounds) = self.last_bounds else {
+            return;
+        };
+        let rel_y = event.position.y - bounds.top();
+        let Some(row) = (0..self.line_tops.len()).find(|&i| {
+            let h = self.line_h(i) * self.row_span(i) as f32;
+            h > px(0.5) && rel_y >= self.line_tops[i] && rel_y < self.line_tops[i] + h
+        }) else {
+            return;
+        };
+        let Some(t) = self.table_rows.get(row).and_then(Option::as_ref) else {
+            return;
+        };
+        if t.col_widths.is_empty() {
+            return;
+        }
+        let total: Pixels = t.col_widths.iter().copied().sum();
+        let avail = bounds.size.width - px(TABLE_GUTTER);
+        if total <= avail {
+            return;
+        }
+        let dx = f32::from(event.delta.pixel_delta(px(20.)).x);
+        if dx == 0. {
+            return;
+        }
+        let header = table_header_row(t, row);
+        let max = f32::from(total - avail);
+        let cur = self.table_scroll_x.get(&header).copied().unwrap_or(0.);
+        let new = (cur - dx).clamp(0., max);
+        if new != cur {
+            self.table_scroll_x.insert(header, new);
+            cx.notify();
+        }
+    }
+
     /// drives the delete-handle repaint + reveal.
     fn hovered_table_cell(&self, pos: Point<Pixels>) -> Option<(usize, usize)> {
         let bounds = self.last_bounds.as_ref()?;
@@ -4129,10 +4189,11 @@ impl EditorState {
         }
         let table_left = gutter_left + g;
         let table_w: Pixels = t.col_widths.iter().copied().sum();
-        if pos.x >= table_left + table_w {
+        let sx = self.table_sx(table_header_row(t, row), table_w, bounds.size.width - g);
+        if pos.x >= table_left + table_w - sx {
             return None;
         }
-        let rel_x = (pos.x - table_left).max(px(0.));
+        let rel_x = (pos.x - table_left + sx).max(px(0.));
         let mut colx = px(0.);
         for (col, &cw) in t.col_widths.iter().enumerate() {
             if rel_x < colx + cw {
@@ -4189,6 +4250,16 @@ impl EditorState {
         if t.is_separator || t.col_widths.is_empty() {
             return None;
         }
+        // A scrolled wide table: the pointer maps to content shifted by sx.
+        let rel = point(
+            rel.x
+                + self.table_sx(
+                    table_header_row(t, row),
+                    t.col_widths.iter().copied().sum(),
+                    bounds.size.width - px(TABLE_GUTTER),
+                ),
+            rel.y,
+        );
         // Measure at the last paint's size — the style stack is unwound during
         // event dispatch, so `text_style()` here reports the root size.
         let style = window.text_style();
@@ -5273,6 +5344,7 @@ impl Render for EditorState {
             .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
             .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_mouse_up))
             .on_mouse_move(cx.listener(Self::on_mouse_move))
+            .on_scroll_wheel(cx.listener(Self::on_scroll_wheel))
             .child(EditorElement {
                 editor: cx.entity(),
             })
@@ -6959,7 +7031,6 @@ fn shape_document(
                             base_font,
                             base_font_size,
                             base_color,
-                            wrap_width,
                             col_resize,
                         )
                     })
@@ -7847,8 +7918,13 @@ fn shape_document(
         };
 
         // Code lines are inset by CODE_INSET on each side; a gutter mark insets the
-        // left only. Either wraps at a correspondingly narrower width.
-        let line_wrap = if is_code {
+        // left only. Either wraps at a correspondingly narrower width. A table
+        // row's raw source never wraps — it renders as a grid row (a wide
+        // table scrolls instead), and a wrapped hidden source would multiply
+        // the row's advance by its wrap count.
+        let line_wrap = if table.is_some() {
+            None
+        } else if is_code {
             wrap_width.map(|w| (w - px(2. * CODE_INSET)).max(px(0.)))
         } else if let Some(m) = mark {
             wrap_width.map(|w| (w - m.inset()).max(px(0.)))
@@ -8396,8 +8472,8 @@ pub fn paint_doc_icon(
 }
 
 /// Content-fit column widths for a table region (W4c): each column sized to its
-/// widest cell (header measured bold) + padding, with a minimum, and the whole
-/// table scaled down proportionally to fit `wrap_width` if it would overflow.
+/// widest cell (header measured bold) + padding, with a minimum. A table wider
+/// than the viewport is NOT scaled down — it scrolls horizontally in place.
 #[allow(clippy::too_many_arguments)]
 fn table_column_widths(
     lines: &[&str],
@@ -8406,7 +8482,6 @@ fn table_column_widths(
     base_font: &Font,
     font_size: Pixels,
     color: Hsla,
-    wrap_width: Option<Pixels>,
     col_resize: Option<TableColResize>,
 ) -> Vec<Pixels> {
     // Reader parity: a row with MORE cells than the header widens the grid —
@@ -8476,15 +8551,9 @@ fn table_column_widths(
     {
         widths[r.col] = px(r.width.max(24.));
     }
-    if let Some(avail) = wrap_width {
-        let total = widths.iter().sum::<Pixels>();
-        if total > avail && total > px(0.) {
-            let scale = f32::from(avail) / f32::from(total);
-            for w in &mut widths {
-                *w *= scale;
-            }
-        }
-    }
+    // No scale-to-fit: a table wider than the viewport keeps its natural
+    // columns and scrolls horizontally in place (Cditor-style) — see
+    // `EditorState::table_scroll_x`.
     widths
 }
 
@@ -8543,6 +8612,16 @@ fn shape_cell(
 
 /// How many wrap rows table row `cells` need at `col_widths` — 1 for content
 /// that fits; more once a drag-narrowed column forces its text to wrap.
+/// The header row of the table that `t` (the grid row at line `row`) belongs
+/// to — the key of its horizontal-scroll entry.
+fn table_header_row(t: &TableRow, row: usize) -> usize {
+    match t.body_index {
+        Some(b) => row.saturating_sub(b + 2),
+        None if t.is_separator => row.saturating_sub(1),
+        None => row,
+    }
+}
+
 /// The width available to cell `c` of a row with `cells_len` cells: a short
 /// row's LAST cell spans the remaining columns (reader parity — e.g. a
 /// two-cell header over a wider body), otherwise its own column.
@@ -9802,8 +9881,10 @@ impl Element for EditorElement {
             if t.is_last && !t.col_widths.is_empty() {
                 let top = tbl_top.unwrap_or(bounds.origin.y + line_tops[i]);
                 let bottom = bounds.origin.y + line_tops[i] + line_heights[i];
-                let left = bounds.origin.x + px(TABLE_GUTTER);
                 let width: Pixels = t.col_widths.iter().copied().sum();
+                // A scrolled wide table shifts every affordance with its content.
+                let sx = editor.table_sx(tbl_header, width, bounds.size.width - px(TABLE_GUTTER));
+                let left = bounds.origin.x + px(TABLE_GUTTER) - sx;
                 let accent = editor.markdown_style.as_ref().map_or(t.border, |s| s.link);
                 let g = px(PILL_ACROSS);
                 let zone = Bounds::new(
@@ -9968,23 +10049,15 @@ impl Element for EditorElement {
                     // Table row: highlight between the cell positions of the selection
                     // ends (not raw-source geometry).
                     if let Some(t) = tables.get(row).and_then(Option::as_ref) {
+                        let tleft = bounds.left() + px(TABLE_GUTTER)
+                            - editor.table_sx(
+                                table_header_row(t, row),
+                                t.col_widths.iter().copied().sum(),
+                                bounds.size.width - px(TABLE_GUTTER),
+                            );
                         if let (Some((xa, ..)), Some((xb, ..))) = (
-                            table_caret_pos(
-                                t,
-                                a,
-                                bounds.left() + px(TABLE_GUTTER),
-                                &font,
-                                font_size,
-                                window,
-                            ),
-                            table_caret_pos(
-                                t,
-                                b,
-                                bounds.left() + px(TABLE_GUTTER),
-                                &font,
-                                font_size,
-                                window,
-                            ),
+                            table_caret_pos(t, a, tleft, &font, font_size, window),
+                            table_caret_pos(t, b, tleft, &font, font_size, window),
                         ) {
                             let (lo, hi) = (xa.min(xb), xa.max(xb));
                             let cy = bounds.top() + top + (lh - base_lh) / 2.;
@@ -10097,7 +10170,12 @@ impl Element for EditorElement {
                 && let Some((x, y_off, _, _)) = table_caret_pos(
                     t,
                     col,
-                    bounds.left() + px(TABLE_GUTTER),
+                    bounds.left() + px(TABLE_GUTTER)
+                        - editor.table_sx(
+                            table_header_row(t, row),
+                            t.col_widths.iter().copied().sum(),
+                            bounds.size.width - px(TABLE_GUTTER),
+                        ),
                     &font,
                     font_size,
                     window,
@@ -10235,6 +10313,8 @@ impl Element for EditorElement {
             .as_ref()
             .map_or(text_color, |s| s.link);
         let image_resize = self.editor.read(cx).image_resize;
+        // Wide-table horizontal scroll offsets, snapshotted for the paint loop.
+        let table_sx_map = self.editor.read(cx).table_scroll_x.clone();
         // Window-space bounds of each painted image + its logical line, collected
         // for the next frame's grip hit-testing (committed below).
         let mut image_rects: Vec<(usize, Bounds<Pixels>)> = Vec::new();
@@ -10554,10 +10634,28 @@ impl Element for EditorElement {
                 }
             }
             if let Some(t) = prepaint.tables.get(i).and_then(Option::as_ref) {
+                // A wide table keeps natural columns, scrolled by sx and
+                // clipped to the viewport — rows paint shifted under a mask.
+                let table_w: Pixels = t.col_widths.iter().copied().sum();
+                let avail = bounds.size.width - px(TABLE_GUTTER);
+                let sx = {
+                    let max = f32::from((table_w - avail).max(px(0.)));
+                    px(table_sx_map
+                        .get(&table_header_row(t, i))
+                        .copied()
+                        .unwrap_or(0.)
+                        .clamp(0., max))
+                };
+                let tleft = origin.x + px(TABLE_GUTTER);
+                let g = px(TABLE_GUTTER);
+                let mask = gpui::ContentMask {
+                    bounds: Bounds::new(point(tleft, origin.y - g), size(avail, *lh + g * 2.)),
+                };
                 // The header row paints the whole table's rounded outer border
-                // (one box around all its rows, matching the reading view) — for the
-                // Grid style only; the others are box-less. Each row then paints its
-                // shading, dividers, + cell text.
+                // (one box around all its rows, matching the reading view) — for
+                // the Grid style only; the others are box-less. It spans the
+                // WHOLE table's height, so it gets its own full-height mask
+                // (the per-row mask below would clip it to the header band).
                 if t.is_header && matches!(t.style, markdown_syntax::TableStyle::Grid) {
                     let mut total_h = px(0.);
                     for j in i..prepaint.tables.len() {
@@ -10571,30 +10669,55 @@ impl Element for EditorElement {
                             None => break,
                         }
                     }
-                    let table_w = t.col_widths.iter().sum();
-                    window.paint_quad(PaintQuad {
+                    let border_mask = gpui::ContentMask {
                         bounds: Bounds::new(
-                            point(origin.x + px(TABLE_GUTTER), origin.y),
-                            size(table_w, total_h),
+                            point(tleft, origin.y - g),
+                            size(avail, total_h + g * 2.),
                         ),
-                        corner_radii: Corners::all(px(6.)),
-                        background: hsla(0., 0., 0., 0.).into(),
-                        border_widths: Edges::all(px(1.)),
-                        border_color: t.border,
-                        border_style: BorderStyle::Solid,
+                    };
+                    window.with_content_mask(Some(border_mask), |window| {
+                        window.paint_quad(PaintQuad {
+                            bounds: Bounds::new(
+                                point(tleft - sx, origin.y),
+                                size(table_w, total_h),
+                            ),
+                            corner_radii: Corners::all(px(6.)),
+                            background: hsla(0., 0., 0., 0.).into(),
+                            border_widths: Edges::all(px(1.)),
+                            border_color: t.border,
+                            border_style: BorderStyle::Solid,
+                        });
                     });
                 }
-                paint_table_row(
-                    t,
-                    point(origin.x + px(TABLE_GUTTER), origin.y),
-                    *lh,
-                    &font,
-                    font_size,
-                    base_lh,
-                    text_color,
-                    window,
-                    cx,
-                );
+                window.with_content_mask(Some(mask), |window| {
+                    paint_table_row(
+                        t,
+                        point(tleft - sx, origin.y),
+                        *lh,
+                        &font,
+                        font_size,
+                        base_lh,
+                        text_color,
+                        window,
+                        cx,
+                    );
+                });
+                // A slim track thumb under the last row shows there's more
+                // table to the side (and how far along you are).
+                if t.is_last && table_w > avail {
+                    let th_w = (avail / f32::from(table_w) * f32::from(avail)).max(px(24.));
+                    let range = f32::from(table_w - avail);
+                    let th_x = tleft + (avail - th_w) * (f32::from(sx) / range);
+                    let mut th_c = t.border;
+                    th_c.a = (th_c.a * 1.5).min(0.8);
+                    window.paint_quad(
+                        fill(
+                            Bounds::new(point(th_x, origin.y + *lh - px(4.)), size(th_w, px(3.))),
+                            th_c,
+                        )
+                        .corner_radii(Corners::all(px(1.5))),
+                    );
+                }
             } else if let Some(Block::Image(w)) = prepaint.widgets.get(i).and_then(Option::as_ref) {
                 // Inline image (W4a): paint the decoded image instead of source,
                 // inset to the row's gutter so a list-item image sits past its

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -9025,6 +9025,12 @@ struct CachedLineRuns {
     map: std::rc::Rc<Vec<usize>>,
 }
 
+/// The validity marker + per-row content keys of the run-key memo.
+type RowKeys = (Option<u64>, Vec<Option<u64>>);
+
+/// The measured table column widths cache: one keyed entry for the doc.
+type RegionCols = Option<(u64, std::rc::Rc<Vec<Vec<Pixels>>>)>;
+
 /// The editor-owned caches `shape_document` reads and writes (interior-
 /// mutable — shaping runs under a read borrow of the editor):
 /// - `line_runs`: each markdown line's built display + runs (cross-frame).
@@ -9035,7 +9041,7 @@ struct CachedLineRuns {
 #[derive(Default)]
 struct ShapeCaches {
     line_runs: std::cell::RefCell<std::collections::HashMap<u64, CachedLineRuns>>,
-    region_cols: std::cell::RefCell<Option<(u64, std::rc::Rc<Vec<Vec<Pixels>>>)>>,
+    region_cols: std::cell::RefCell<RegionCols>,
     cell_rows: std::cell::RefCell<std::collections::HashMap<u64, usize>>,
     /// Per-line (row height, wrap rows), keyed by the line-run key ⊕ font
     /// size ⊕ wrap width — the shaping window's exact heights for skipped
@@ -9045,7 +9051,7 @@ struct ShapeCaches {
     /// valid for one (scan generation, epoch) pair — so a steady-state frame
     /// hashes three u64s per line instead of every line's bytes. Diagnostics
     /// changes invalidate explicitly (see `set_diagnostics`).
-    row_keys: std::cell::RefCell<(Option<u64>, Vec<Option<u64>>)>,
+    row_keys: std::cell::RefCell<RowKeys>,
 }
 
 /// A hash of the inputs shared by every line's run build (font + palette) —
@@ -10117,33 +10123,72 @@ impl Element for EditorElement {
                         // vacant trailing cells highlight too.
                         let first_start = t.cell_ranges.first().map_or(0, |r| r.start);
                         let last_end = t.cell_ranges.last().map_or(0, |r| r.end);
-                        let xa = if a <= first_start {
-                            tleft
-                        } else {
-                            table_caret_pos(t, a, tleft, &font, font_size, window)
-                                .map_or(tleft, |(x, ..)| x)
-                        };
-                        let xb = if b >= last_end {
-                            tleft + table_w
-                        } else {
-                            table_caret_pos(t, b, tleft, &font, font_size, window)
-                                .map_or(tleft + table_w, |(x, ..)| x)
-                        };
                         // Clamp to the table's visible band — a wide
                         // (scrolling) table's cells extend past the
-                        // viewport, but its highlight must not. Full row
-                        // height, so wrapped cells highlight every wrap row.
+                        // viewport, but its highlight must not.
                         let vis_l = bounds.left() + px(TABLE_GUTTER);
                         let vis_r = bounds.left() + bounds.size.width;
-                        let (lo, hi) = (xa.min(xb).max(vis_l), xa.max(xb).min(vis_r));
-                        if hi > lo {
-                            sels.push(fill(
-                                Bounds::from_corners(
-                                    point(lo, bounds.top() + top),
-                                    point(hi, bounds.top() + top + lh),
-                                ),
-                                color,
-                            ));
+                        let mut band = |lo: Pixels, hi: Pixels, y: Pixels, h: Pixels| {
+                            let (lo, hi) = (lo.max(vis_l), hi.min(vis_r));
+                            if hi > lo {
+                                sels.push(fill(
+                                    Bounds::from_corners(point(lo, y), point(hi, y + h)),
+                                    color,
+                                ));
+                            }
+                        };
+                        let pa = (a > first_start && a < last_end)
+                            .then(|| table_caret_pos(t, a, tleft, &font, font_size, window))
+                            .flatten();
+                        let pb = (b > first_start && b < last_end)
+                            .then(|| table_caret_pos(t, b, tleft, &font, font_size, window))
+                            .flatten();
+                        match (pa, pb) {
+                            // Both ends inside the SAME (possibly wrapped)
+                            // cell: per-wrap-row bands within that cell —
+                            // one full-height band would smear the whole row.
+                            (Some((xa, ya, ca, _)), Some((xb, yb, cb, _))) if ca == cb => {
+                                let pad = px(TABLE_CELL_PAD);
+                                let cell_x = tleft
+                                    + t.col_widths[..ca.min(t.col_widths.len())]
+                                        .iter()
+                                        .copied()
+                                        .sum::<Pixels>();
+                                let cw = cell_span_width(&t.col_widths, t.cells.len(), ca);
+                                let (cl, cr) = (cell_x + pad, cell_x + cw - pad);
+                                let y0 = bounds.top() + top + px(6.);
+                                if ya == yb {
+                                    band(
+                                        xa.min(xb),
+                                        xa.max(xb).max(xa.min(xb) + px(2.)),
+                                        y0 + ya,
+                                        base_lh,
+                                    );
+                                } else {
+                                    band(xa, cr, y0 + ya, base_lh);
+                                    let mut y = ya + base_lh;
+                                    while y < yb {
+                                        band(cl, cr, y0 + y, base_lh);
+                                        y += base_lh;
+                                    }
+                                    band(cl, xb, y0 + yb, base_lh);
+                                }
+                            }
+                            // Anything else: one full-height band between the
+                            // endpoint x's (row edges for out-of-span ends).
+                            _ => {
+                                let xa = if a <= first_start {
+                                    tleft
+                                } else {
+                                    pa.map_or(tleft, |(x, ..)| x)
+                                };
+                                let xb = if b >= last_end {
+                                    tleft + table_w
+                                } else {
+                                    pb.map_or(tleft + table_w, |(x, ..)| x)
+                                };
+                                band(xa.min(xb), xa.max(xb), bounds.top() + top, lh);
+                            }
                         }
                         continue;
                     }

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -4772,6 +4772,10 @@ struct TableRow {
 
 /// A per-line "gutter" decoration: a left-margin treatment that hides its source
 /// marker and renders something in its place, with the body text inset to make
+/// Task checkbox edge, as a fraction of the line's font size — shared by the
+/// shaping (body inset), the pointer hitbox, and the paint so they agree.
+const CHECKBOX_SCALE: f32 = 0.9;
+
 /// room. Covers blockquotes now; list bullets + task checkboxes reuse it.
 #[derive(Clone, Copy)]
 enum LineMark {
@@ -4816,6 +4820,8 @@ enum LineMark {
         text_inset: Pixels,
         checked: bool,
         color: Hsla,
+        /// Fill for a done box (the host's link/accent color; white check on top).
+        accent: Hsla,
     },
     /// Thematic break (`---`): a full-width muted divider painted in place of the
     /// source; the line has no body text (reveal-on-caret shows the raw `---`).
@@ -5859,7 +5865,7 @@ fn shape_document(
                 // Reader-style geometry: each nesting level advances by
                 // marker + gap + (spaces × 4.5), not the raw spaces' width.
                 let depth = indent as f32 / tab_indent.max(1) as f32;
-                let box_w = base_font_size * 0.78;
+                let box_w = base_font_size * CHECKBOX_SCALE;
                 let level =
                     box_w + px(LIST_TEXT_GAP) + px(LIST_LEVEL_PER_SPACE) * tab_indent as f32;
                 let bullet_x = level * depth;
@@ -5871,6 +5877,7 @@ fn shape_document(
                         text_inset,
                         checked,
                         color: st.quote,
+                        accent: st.link,
                     },
                 ))
             } else if let Some((plen, indent, ordered, _)) = markdown_syntax::list_prefix(line) {
@@ -6047,6 +6054,24 @@ fn shape_document(
                 reveal_inline,
                 st,
             );
+            // A checked task's body renders struck through + muted (the reader
+            // does the same) — a whole-line restyle over the finished runs.
+            let (disp, runs, m) = if matches!(mark, Some(LineMark::Check { checked: true, .. })) {
+                let runs = runs
+                    .into_iter()
+                    .map(|mut r| {
+                        r.strikethrough = Some(gpui::StrikethroughStyle {
+                            thickness: px(1.0),
+                            color: None,
+                        });
+                        r.color = st.quote;
+                        r
+                    })
+                    .collect();
+                (disp, runs, m)
+            } else {
+                (disp, runs, m)
+            };
             // Inline `$…$` math AND `![](src)` images: swap each ready one's
             // glyphs for a spacer to paint the raster over (shared machinery).
             let (disp, runs, m) = match (block_math, block_math_em) {
@@ -7268,7 +7293,7 @@ impl Element for EditorElement {
         let mut alert_fold_grips = Vec::new();
         for (i, lh) in line_heights.iter().enumerate() {
             if let Some(LineMark::Check { bullet_x, .. }) = marks.get(i).copied().flatten() {
-                let sz = font_size * 0.78;
+                let sz = font_size * CHECKBOX_SCALE;
                 let pad = px(4.);
                 let bx = bounds.origin.x + bullet_x;
                 let by = bounds.origin.y + line_tops[i] + (*lh - sz) / 2.;
@@ -8120,10 +8145,11 @@ impl Element for EditorElement {
                 bullet_x,
                 checked,
                 color,
+                accent,
                 ..
             }) = prepaint.marks.get(i).copied().flatten()
             {
-                let sz = font_size * 0.78; // ~cap height
+                let sz = font_size * CHECKBOX_SCALE;
                 let bx = origin.x + bullet_x;
                 let by = origin.y + (*lh - sz) / 2.; // vertically centered on the line
                 let box_bounds = Bounds::new(point(bx, by), size(sz, sz));
@@ -8135,12 +8161,18 @@ impl Element for EditorElement {
                 {
                     window.set_cursor_style(CursorStyle::PointingHand, hb);
                 }
+                // Done: a solid accent fill with a white check (Notion-style).
+                // Open: an empty outline.
                 window.paint_quad(PaintQuad {
                     bounds: box_bounds,
                     corner_radii: Corners::all(px(3.)),
-                    background: hsla(0., 0., 0., 0.).into(),
+                    background: if checked {
+                        accent.into()
+                    } else {
+                        hsla(0., 0., 0., 0.).into()
+                    },
                     border_widths: Edges::all(px(1.5)),
-                    border_color: color,
+                    border_color: if checked { accent } else { color },
                     border_style: BorderStyle::Solid,
                 });
                 if checked {
@@ -8150,7 +8182,7 @@ impl Element for EditorElement {
                     pb.line_to(point(bx + px(s * 0.42), by + px(s * 0.70)));
                     pb.line_to(point(bx + px(s * 0.76), by + px(s * 0.28)));
                     if let Ok(path) = pb.build() {
-                        window.paint_path(path, color);
+                        window.paint_path(path, gpui::white());
                     }
                 }
             }

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -2804,6 +2804,20 @@ impl EditorState {
                 orig: width,
                 width,
             });
+            // The press focuses the editor without moving the caret — if it
+            // was parked on this table's style-marker line (offset 0 right
+            // after a document loads), reveal-on-caret would flash the raw
+            // `<!-- table:… -->` mid-drag. Seat it in the header cell instead.
+            let caret_row = self.row_col(self.selected_range.start).0;
+            if self
+                .scan_data()
+                .tables
+                .iter()
+                .any(|r| r.lines.start == header_row && r.marker_line == Some(caret_row))
+            {
+                let caret = self.caret_pos_for_cell(header_row, 0, 0);
+                self.selected_range = caret..caret;
+            }
             self.is_selecting = false;
             cx.notify();
             return;
@@ -4739,7 +4753,8 @@ impl EditorState {
             ),
             (None, None) => return,
         };
-        let (row, cell, in_cell) = self.caret_table_cell_pos().unwrap_or((0, 0, 0));
+        let cell_pos = self.caret_table_cell_pos();
+        let old_caret = self.selected_range.start;
         // The marker edit adds/removes one line ABOVE the table (or replaces in
         // place) — shift the caret's row index to keep it in its cell.
         let row_shift: isize = match (region.marker_line, new.is_empty()) {
@@ -4750,8 +4765,26 @@ impl EditorState {
         self.record_edit(&range, &new);
         self.content.replace_range(range.clone(), &new);
         self.remap_diagnostics(&range, new.len());
-        let same_row = (row as isize + row_shift).max(0) as usize;
-        let caret = self.caret_pos_for_cell(same_row, cell, in_cell);
+        let caret = match cell_pos {
+            Some((row, cell, in_cell)) => {
+                let same_row = (row as isize + row_shift).max(0) as usize;
+                self.caret_pos_for_cell(same_row, cell, in_cell)
+            }
+            // Caret wasn't in this table (e.g. a border drag from elsewhere):
+            // keep it where it was, shifted by the edit's byte delta — seating
+            // it "in a cell" would land it on the marker line and reveal it.
+            None => {
+                let delta = new.len() as isize - (range.end - range.start) as isize;
+                if old_caret >= range.end {
+                    (old_caret as isize + delta).max(0) as usize
+                } else if old_caret > range.start {
+                    range.start + new.len()
+                } else {
+                    old_caret
+                }
+            }
+        };
+        let caret = caret.min(self.content.len());
         self.selected_range = caret..caret;
         self.table_menu = None;
         cx.emit(EditorEvent::Changed);

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -269,6 +269,7 @@ enum ColEdit {
 enum TableMenuAction {
     InsertRowAbove,
     InsertRowBelow,
+    DuplicateRow,
     InsertColLeft,
     InsertColRight,
     DeleteRow,
@@ -276,27 +277,19 @@ enum TableMenuAction {
     AlignLeft,
     AlignCenter,
     AlignRight,
+    /// Rewrite the table's `<!-- table:STYLE -->` marker (`None` = the
+    /// default Grid, which has no marker).
+    SetStyle(Option<&'static str>),
+    CopyTable,
     DeleteTable,
 }
 
 impl TableMenuAction {
-    const ITEMS: &'static [(&'static str, TableMenuAction)] = &[
-        ("Insert row above", TableMenuAction::InsertRowAbove),
-        ("Insert row below", TableMenuAction::InsertRowBelow),
-        ("Insert column left", TableMenuAction::InsertColLeft),
-        ("Insert column right", TableMenuAction::InsertColRight),
-        ("Delete row", TableMenuAction::DeleteRow),
-        ("Delete column", TableMenuAction::DeleteColumn),
-        ("Align left", TableMenuAction::AlignLeft),
-        ("Align center", TableMenuAction::AlignCenter),
-        ("Align right", TableMenuAction::AlignRight),
-        ("Delete table", TableMenuAction::DeleteTable),
-    ];
-
     fn apply(self, editor: &mut EditorState, cx: &mut Context<EditorState>) {
         match self {
             TableMenuAction::InsertRowAbove => editor.insert_table_row(false, cx),
             TableMenuAction::InsertRowBelow => editor.insert_table_row(true, cx),
+            TableMenuAction::DuplicateRow => editor.duplicate_table_row(cx),
             TableMenuAction::InsertColLeft => editor.insert_table_column(false, cx),
             TableMenuAction::InsertColRight => editor.insert_table_column(true, cx),
             TableMenuAction::DeleteRow => editor.delete_table_row(cx),
@@ -304,6 +297,8 @@ impl TableMenuAction {
             TableMenuAction::AlignLeft => editor.set_caret_table_align(CellAlign::Left, cx),
             TableMenuAction::AlignCenter => editor.set_caret_table_align(CellAlign::Center, cx),
             TableMenuAction::AlignRight => editor.set_caret_table_align(CellAlign::Right, cx),
+            TableMenuAction::SetStyle(name) => editor.set_table_style(name, cx),
+            TableMenuAction::CopyTable => editor.copy_table(cx),
             TableMenuAction::DeleteTable => editor.delete_table(cx),
         }
     }
@@ -3925,6 +3920,102 @@ impl EditorState {
         cx.notify();
     }
 
+    /// The caret row's table region, when inside one.
+    fn caret_table_region(&self) -> Option<markdown_syntax::TableRegion> {
+        let (row, _) = self.row_col(self.cursor_offset());
+        markdown_syntax::table_regions(&self.content)
+            .into_iter()
+            .find(|r| r.lines.contains(&row))
+    }
+
+    /// Duplicate the caret's row below itself (the header duplicates as the
+    /// first body row). The caret lands in the copy, same cell + offset.
+    pub fn duplicate_table_row(&mut self, cx: &mut Context<Self>) {
+        let Some((row, cell, in_cell)) = self.caret_table_cell_pos() else {
+            return;
+        };
+        let Some((_header, sep, _end, _cols)) = self.caret_table_block() else {
+            return;
+        };
+        if row == sep {
+            return;
+        }
+        let starts = self.line_starts();
+        let line = self.content[starts[row]..self.line_end(row)].to_string();
+        // A duplicated header lands below the separator (as a body row).
+        let after = if row + 1 == sep { sep } else { row };
+        let insert = format!("\n{line}");
+        let pos = self.line_end(after);
+        let range = pos..pos;
+        self.record_edit(&range, &insert);
+        self.content = self.content[..pos].to_owned() + &insert + &self.content[pos..];
+        self.remap_diagnostics(&range, insert.len());
+        let caret = self.caret_pos_for_cell(after + 1, cell, in_cell);
+        self.selected_range = caret..caret;
+        self.table_menu = None;
+        cx.emit(EditorEvent::Changed);
+        cx.notify();
+    }
+
+    /// Copy the caret's table — its grid source plus any `<!-- table:STYLE -->`
+    /// marker — to the clipboard (markdown, pasteable anywhere).
+    pub fn copy_table(&mut self, cx: &mut Context<Self>) {
+        let Some(region) = self.caret_table_region() else {
+            return;
+        };
+        let starts = self.line_starts();
+        let first = region.marker_line.unwrap_or(region.lines.start);
+        let Some(&start) = starts.get(first) else {
+            return;
+        };
+        let end = self.line_end(region.lines.end - 1);
+        let text = self.content[start..end].to_string();
+        self.table_menu = None;
+        self.write_clipboard(text, cx);
+        cx.notify();
+    }
+
+    /// Set the caret table's visual style by rewriting its
+    /// `<!-- table:STYLE -->` marker line: `Some(name)` writes/replaces the
+    /// marker, `None` (Grid, the default) removes it. One undo step.
+    pub fn set_table_style(&mut self, name: Option<&'static str>, cx: &mut Context<Self>) {
+        let Some(region) = self.caret_table_region() else {
+            return;
+        };
+        let starts = self.line_starts();
+        let (range, new) = match (region.marker_line, name) {
+            // Marker present → replace its line, or remove it (with the newline).
+            (Some(m), Some(name)) => (
+                starts[m]..self.line_end(m),
+                format!("<!-- table:{name} -->"),
+            ),
+            (Some(m), None) => (starts[m]..self.line_end(m) + 1, String::new()),
+            // No marker → insert one above the header; Grid is already implicit.
+            (None, Some(name)) => (
+                starts[region.lines.start]..starts[region.lines.start],
+                format!("<!-- table:{name} -->\n"),
+            ),
+            (None, None) => return,
+        };
+        let (row, cell, in_cell) = self.caret_table_cell_pos().unwrap_or((0, 0, 0));
+        // The marker edit adds/removes one line ABOVE the table (or replaces in
+        // place) — shift the caret's row index to keep it in its cell.
+        let row_shift: isize = match (region.marker_line, name) {
+            (Some(_), None) => -1,
+            (None, Some(_)) => 1,
+            _ => 0,
+        };
+        self.record_edit(&range, &new);
+        self.content.replace_range(range.clone(), &new);
+        self.remap_diagnostics(&range, new.len());
+        let same_row = (row as isize + row_shift).max(0) as usize;
+        let caret = self.caret_pos_for_cell(same_row, cell, in_cell);
+        self.selected_range = caret..caret;
+        self.table_menu = None;
+        cx.emit(EditorEvent::Changed);
+        cx.notify();
+    }
+
     /// The caret's table position as `(row, cell_index, offset_within_cell)`, or
     /// `None` outside a table. Lets structural edits keep the caret put.
     fn caret_table_cell_pos(&self) -> Option<(usize, usize, usize)> {
@@ -4628,13 +4719,125 @@ impl Render for EditorState {
                 const ROW_H: f32 = 24.0;
                 const DIV_H: f32 = 9.0;
                 const PAD: f32 = 4.0;
-                const MAX_H: f32 = 240.0;
-                // Rows in three groups (insert / delete / align) with a divider before
-                // the delete group (index 4) and the align group (index 6).
+                const MAX_H: f32 = 480.0;
+                // Cditor-style grouped rows: a glyph column, a checkmark on the
+                // current align/style, and the destructive group in red.
+                let danger = st.map_or(rgb(0xE5484D).into(), |s| s.popover_danger);
+                let cur_align = self.caret_table_align();
+                let cur_style = self
+                    .caret_table_region()
+                    .map(|r| r.style)
+                    .unwrap_or_default();
+                use markdown_syntax::TableStyle as TS;
+                enum Row {
+                    Div,
+                    Item {
+                        glyph: &'static str,
+                        label: &'static str,
+                        action: TableMenuAction,
+                        red: bool,
+                        checked: bool,
+                    },
+                }
+                let item = |glyph, label, action| Row::Item {
+                    glyph,
+                    label,
+                    action,
+                    red: false,
+                    checked: false,
+                };
+                let specs = [
+                    item("↑", "Insert row above", TableMenuAction::InsertRowAbove),
+                    item("↓", "Insert row below", TableMenuAction::InsertRowBelow),
+                    item("⧉", "Duplicate row", TableMenuAction::DuplicateRow),
+                    Row::Div,
+                    item("←", "Insert column left", TableMenuAction::InsertColLeft),
+                    item("→", "Insert column right", TableMenuAction::InsertColRight),
+                    Row::Div,
+                    Row::Item {
+                        glyph: "",
+                        label: "Align left",
+                        action: TableMenuAction::AlignLeft,
+                        red: false,
+                        checked: cur_align == Some(CellAlign::Left),
+                    },
+                    Row::Item {
+                        glyph: "",
+                        label: "Align center",
+                        action: TableMenuAction::AlignCenter,
+                        red: false,
+                        checked: cur_align == Some(CellAlign::Center),
+                    },
+                    Row::Item {
+                        glyph: "",
+                        label: "Align right",
+                        action: TableMenuAction::AlignRight,
+                        red: false,
+                        checked: cur_align == Some(CellAlign::Right),
+                    },
+                    Row::Div,
+                    Row::Item {
+                        glyph: "▦",
+                        label: "Grid style",
+                        action: TableMenuAction::SetStyle(None),
+                        red: false,
+                        checked: cur_style == TS::Grid,
+                    },
+                    Row::Item {
+                        glyph: "▤",
+                        label: "Striped style",
+                        action: TableMenuAction::SetStyle(Some("striped")),
+                        red: false,
+                        checked: cur_style == TS::Striped,
+                    },
+                    Row::Item {
+                        glyph: "▥",
+                        label: "Header style",
+                        action: TableMenuAction::SetStyle(Some("header")),
+                        red: false,
+                        checked: cur_style == TS::Header,
+                    },
+                    Row::Item {
+                        glyph: "─",
+                        label: "Minimal style",
+                        action: TableMenuAction::SetStyle(Some("minimal")),
+                        red: false,
+                        checked: cur_style == TS::Minimal,
+                    },
+                    Row::Div,
+                    item("⊞", "Copy as Markdown", TableMenuAction::CopyTable),
+                    Row::Div,
+                    Row::Item {
+                        glyph: "✕",
+                        label: "Delete row",
+                        action: TableMenuAction::DeleteRow,
+                        red: true,
+                        checked: false,
+                    },
+                    Row::Item {
+                        glyph: "✕",
+                        label: "Delete column",
+                        action: TableMenuAction::DeleteColumn,
+                        red: true,
+                        checked: false,
+                    },
+                    Row::Item {
+                        glyph: "✕",
+                        label: "Delete table",
+                        action: TableMenuAction::DeleteTable,
+                        red: true,
+                        checked: false,
+                    },
+                ];
+                let n_items = specs
+                    .iter()
+                    .filter(|r| matches!(r, Row::Item { .. }))
+                    .count();
+                let n_divs = specs.len() - n_items;
                 let mut rows: Vec<gpui::AnyElement> = Vec::new();
-                for (i, &(label, action)) in TableMenuAction::ITEMS.iter().enumerate() {
-                    if i == 4 || i == 6 || i == 9 {
-                        rows.push(
+                for (i, spec) in specs.into_iter().enumerate() {
+                    match spec {
+                        Row::Div => rows.push(
                             div()
                                 .flex_shrink_0()
                                 .h(px(1.))
@@ -4642,29 +4845,53 @@ impl Render for EditorState {
                                 .mx(px(8.))
                                 .bg(divider)
                                 .into_any_element(),
-                        );
+                        ),
+                        Row::Item {
+                            glyph,
+                            label,
+                            action,
+                            red,
+                            checked,
+                        } => {
+                            let fg = if red { danger } else { menu_fg };
+                            let mut glyph_c = fg;
+                            glyph_c.a *= 0.7;
+                            rows.push(
+                                div()
+                                    .id(("table-menu-row", i))
+                                    .flex_shrink_0()
+                                    .px(px(10.))
+                                    .py(px(3.))
+                                    .flex()
+                                    .flex_row()
+                                    .items_center()
+                                    .gap(px(6.))
+                                    .text_color(fg)
+                                    .hover(move |s| s.bg(hover))
+                                    .child(
+                                        div()
+                                            .w(px(16.))
+                                            .flex_none()
+                                            .text_color(glyph_c)
+                                            .child(glyph),
+                                    )
+                                    .child(div().flex_1().child(SharedString::from(label)))
+                                    .children(checked.then(|| div().text_color(glyph_c).child("✓")))
+                                    .on_mouse_down(
+                                        MouseButton::Left,
+                                        cx.listener(move |editor, _: &MouseDownEvent, _, cx| {
+                                            cx.stop_propagation();
+                                            action.apply(editor, cx);
+                                        }),
+                                    )
+                                    .into_any_element(),
+                            );
+                        }
                     }
-                    rows.push(
-                        div()
-                            .id(("table-menu-row", i))
-                            .flex_shrink_0()
-                            .px(px(10.))
-                            .py(px(3.))
-                            .hover(move |s| s.bg(hover))
-                            .child(SharedString::from(label))
-                            .on_mouse_down(
-                                MouseButton::Left,
-                                cx.listener(move |editor, _: &MouseDownEvent, _, cx| {
-                                    cx.stop_propagation();
-                                    action.apply(editor, cx);
-                                }),
-                            )
-                            .into_any_element(),
-                    );
                 }
                 // Scrollbar thumb, shown when the items overflow the cap — sized from
                 // the content height + positioned from the live scroll offset.
-                let rows_h = TableMenuAction::ITEMS.len() as f32 * ROW_H + 3.0 * DIV_H;
+                let rows_h = n_items as f32 * ROW_H + n_divs as f32 * DIV_H;
                 let view_h = MAX_H - 2.0 * PAD;
                 let thumb = (rows_h > view_h).then(|| {
                     let scrolled =
@@ -4685,7 +4912,7 @@ impl Render for EditorState {
                         div()
                             .relative()
                             .occlude()
-                            .min_w(px(170.))
+                            .min_w(px(190.))
                             .cursor(CursorStyle::Arrow)
                             .bg(menu_bg)
                             .border_1()

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1394,7 +1394,7 @@ impl EditorState {
             self.move_to(off, cx);
             return;
         }
-        let off = self.previous_boundary(self.cursor_offset());
+        let off = self.prev_visible_boundary(self.cursor_offset());
         if let Some((range, source)) = self.inline_math_span_at(off) {
             cx.emit(EditorEvent::EditMath {
                 range,
@@ -1437,7 +1437,7 @@ impl EditorState {
             self.move_to(off, cx);
             return;
         }
-        let off = self.next_boundary(self.cursor_offset());
+        let off = self.next_visible_boundary(self.cursor_offset());
         if let Some((range, source)) = self.inline_math_span_at(off) {
             cx.emit(EditorEvent::EditMath {
                 range,
@@ -1559,12 +1559,12 @@ impl EditorState {
 
     fn select_left(&mut self, _: &SelectLeft, _: &mut Window, cx: &mut Context<Self>) {
         self.goal_x = None;
-        self.select_to(self.previous_boundary(self.cursor_offset()), cx);
+        self.select_to(self.prev_visible_boundary(self.cursor_offset()), cx);
     }
 
     fn select_right(&mut self, _: &SelectRight, _: &mut Window, cx: &mut Context<Self>) {
         self.goal_x = None;
-        self.select_to(self.next_boundary(self.cursor_offset()), cx);
+        self.select_to(self.next_visible_boundary(self.cursor_offset()), cx);
     }
 
     fn select_up(&mut self, _: &SelectUp, _: &mut Window, cx: &mut Context<Self>) {
@@ -4323,6 +4323,49 @@ impl EditorState {
         self.offset_from_utf16(range.start)..self.offset_from_utf16(range.end)
     }
 
+    /// One VISIBLE position left of `offset`: a grapheme step, extended while
+    /// the display column doesn't change — always-hidden formatting markers
+    /// (`**`, `~~`, …) are zero-width on screen, so crossing one must not cost
+    /// extra keypresses. Rows without a display map (raw/code) step plainly.
+    fn prev_visible_boundary(&self, offset: usize) -> usize {
+        let (row0, col0) = self.row_col(offset);
+        let d0 = self.display_col(row0, col0);
+        let mut off = self.previous_boundary(offset);
+        loop {
+            if off == 0 {
+                return off;
+            }
+            let (row, col) = self.row_col(off);
+            if row != row0
+                || self.offset_maps.get(row).and_then(Option::as_ref).is_none()
+                || self.display_col(row, col) != d0
+            {
+                return off;
+            }
+            off = self.previous_boundary(off);
+        }
+    }
+
+    /// One VISIBLE position right of `offset` — see [`Self::prev_visible_boundary`].
+    fn next_visible_boundary(&self, offset: usize) -> usize {
+        let (row0, col0) = self.row_col(offset);
+        let d0 = self.display_col(row0, col0);
+        let mut off = self.next_boundary(offset);
+        loop {
+            if off >= self.content.len() {
+                return self.content.len();
+            }
+            let (row, col) = self.row_col(off);
+            if row != row0
+                || self.offset_maps.get(row).and_then(Option::as_ref).is_none()
+                || self.display_col(row, col) != d0
+            {
+                return off;
+            }
+            off = self.next_boundary(off);
+        }
+    }
+
     fn previous_boundary(&self, offset: usize) -> usize {
         self.content
             .grapheme_indices(true)
@@ -6505,7 +6548,10 @@ fn shape_document(
         let chip_line =
             md.is_some() && img_row.is_some() && !matches!(widget, Some(Block::Image(_)));
         let sel_touches = !sel_empty && selection.0 <= line_end && selection.1 >= line_start;
-        let full_source = sel_touches || (caret_col.is_some() && chip_line);
+        // A selection no longer reveals raw source (Cditor-style: formatting
+        // markers are hidden everywhere) — selected lines keep the hidden view;
+        // structural markers still come back via `reveal_inline`.
+        let full_source = caret_col.is_some() && chip_line;
         // This line's diagnostics, clipped + shifted to line-local byte offsets —
         // used as spell-check squiggles whether the line shows source or hides its
         // markers.
@@ -6664,7 +6710,7 @@ fn shape_document(
         // indent mid-select. The BODY still reveals its inline markers (see
         // `reveal_inline` below) so what's highlighted is what's copied.
         let full_source = full_source && gutter.is_none();
-        let reveal_inline = sel_touches && gutter.is_some();
+        let reveal_inline = sel_touches;
         let mark = if is_rule {
             md.map(|st| LineMark::Rule(st.rule))
         } else {

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -614,6 +614,11 @@ pub struct EditorState {
     /// code block, keyed by the opening-fence row) — clicks route here before
     /// caret placement.
     code_chip_rects: Vec<CodeChipHit>,
+    /// Full card bounds of each code block from the last paint (`(first body
+    /// line, rect)`), for hover tracking — the chrome is hover-revealed.
+    code_card_rects: Vec<(usize, Bounds<Pixels>)>,
+    /// The hovered code block's first body line, if any (chrome shows there).
+    code_chip_hover: Option<usize>,
     /// Open language picker for a code block: `(opening fence row, anchor)`.
     code_lang_menu: Option<(usize, Point<Pixels>)>,
     code_lang_scroll: ScrollHandle,
@@ -738,6 +743,8 @@ impl EditorState {
             image_rects: Vec::new(),
             checkbox_rects: Vec::new(),
             code_chip_rects: Vec::new(),
+            code_card_rects: Vec::new(),
+            code_chip_hover: None,
             code_lang_menu: None,
             code_lang_scroll: ScrollHandle::new(),
             code_langs: Vec::new(),
@@ -2667,6 +2674,16 @@ impl EditorState {
             self.heading_hover_row = hrow;
             cx.notify();
         }
+        // Repaint the code card's chrome (lang tag + Copy) when the pointer
+        // enters/leaves a card — it's hover-revealed.
+        let ccard = self
+            .code_card_rects
+            .iter()
+            .find_map(|(row, b)| b.contains(&event.position).then_some(*row));
+        if ccard != self.code_chip_hover {
+            self.code_chip_hover = ccard;
+            cx.notify();
+        }
     }
 
     /// Persist a finished grip drag: replace the resized image's source line with
@@ -3067,7 +3084,18 @@ impl EditorState {
         let total = self.line_tops[last]
             + self.line_h(last) * (self.wrapped[last].wrap_boundaries().len() + 1) as f32;
         if target_y >= total {
-            return self.content.len();
+            // Landing at the very end would park the caret on a trailing
+            // collapsed row (a hidden closing ``` fence) and reveal it — clamp
+            // to the end of the last VISIBLE row instead.
+            let mut r = last;
+            while r > 0 && self.line_h(r) <= px(0.) {
+                r -= 1;
+            }
+            return if r == last {
+                self.content.len()
+            } else {
+                self.line_end(r)
+            };
         }
         let mut trow = last;
         for i in 0..self.wrapped.len() {
@@ -3100,6 +3128,30 @@ impl EditorState {
             };
             if skip < self.wrapped.len() {
                 trow = skip;
+            }
+        }
+        // A collapsed row (a hidden ``` fence, a folded body line) has no visual
+        // height — landing there reveals it. Keep stepping in the direction of
+        // travel so the caret skips over it; if the document runs out that way,
+        // stay put.
+        if self.line_h(trow) <= px(0.) {
+            let step = |r: usize| {
+                if dir >= 0 {
+                    (r + 1 < self.wrapped.len()).then_some(r + 1)
+                } else {
+                    r.checked_sub(1)
+                }
+            };
+            let mut r = trow;
+            loop {
+                match step(r) {
+                    Some(n) if self.line_h(n) <= px(0.) => r = n,
+                    Some(n) => {
+                        trow = n;
+                        break;
+                    }
+                    None => return self.cursor_offset(),
+                }
             }
         }
         let rel = point(goal, (target_y - self.line_tops[trow]).max(px(0.)));
@@ -3291,6 +3343,11 @@ impl EditorState {
         let indent = &line[..line.len() - trimmed.len()];
         let new_line = format!("{indent}```{}", if lang == "text" { "" } else { lang });
         self.replace_range(start..end, &new_line, cx);
+        // replace_range parks the caret at the fence line's end, which reveals
+        // the raw ``` marker (reveal-on-caret). Step onto the body's first
+        // line instead so the fence stays hidden.
+        let caret = (start + new_line.len() + 1).min(self.content.len());
+        self.selected_range = caret..caret;
         cx.emit(EditorEvent::Changed);
     }
 
@@ -5395,11 +5452,6 @@ fn shape_document(
     // Ordered items paint their computed CommonMark position, not their
     // literal source digits (the reader renumbers the same way).
     let ordered_nums = markdown_syntax::ordered_numbers(&lines);
-    // Fenced-code-block regions; a block's ``` fence lines collapse (W6) unless
-    // the caret is inside that block (then they show, so they stay editable).
-    let code_regions = md
-        .map(|_| markdown_syntax::code_regions(content))
-        .unwrap_or_default();
     // Rows a (non-empty) selection touches. A selected block reveals its raw
     // source just like the caret's block does, so what's highlighted is what a
     // copy carries — the per-line pass below already reveals inline markers on
@@ -5842,10 +5894,10 @@ fn shape_document(
         // A ``` fence line collapses (height 0, no text) unless the caret is in
         // its block — so a code block reads as just its boxed body (W6), with the
         // fences re-appearing while you edit inside it.
-        let collapse_fence = is_fence
-            && !code_regions.iter().any(|r| {
-                r.contains(&idx) && (caret_row.is_some_and(|cr| r.contains(&cr)) || sel_hits(r))
-            });
+        // A fence stays hidden even while editing inside the block (the card's
+        // language tag shows/edits the language) — it reveals only with the
+        // caret or a selection on the fence line itself.
+        let collapse_fence = is_fence && caret_row != Some(idx) && !sel_hits(&(idx..idx + 1));
         // A `<!-- table:STYLE -->` or `<!-- math:ALIGN -->` marker line collapses (hidden)
         // too, unless the caret lands on it — so the marker stays out of the way but editable.
         let collapse_marker = caret_row != Some(idx)
@@ -7191,8 +7243,11 @@ struct PrepaintState {
     /// grips' resize cursor). Set in paint via `set_cursor_style`.
     checkbox_grips: Vec<(usize, Hitbox)>,
     /// Per-code-block chrome (lang tag + Copy), laid out here so paint and the
-    /// click rects agree.
+    /// click rects agree. Hover-revealed: only the hovered card's chips.
     code_chips: Vec<CodeChip>,
+    /// Every code card's full bounds (`(first body line, rect)`), committed for
+    /// the hover tracking in `on_mouse_move`.
+    code_card_rects: Vec<(usize, Bounds<Pixels>)>,
     chip_grips: Vec<(usize, Hitbox)>,
     /// Pointer-cursor hitboxes over foldable-callout chevrons, keyed by line.
     alert_fold_grips: Vec<(usize, Hitbox)>,
@@ -7548,14 +7603,15 @@ impl Element for EditorElement {
         // button at each code block's top-right, inside the padded box. Laid
         // out here (paint draws at these bounds; hitboxes flip the cursor).
         let mut code_chips = Vec::new();
+        let mut code_card_rects = Vec::new();
         if let Some(st) = editor
             .markdown_style
             .as_ref()
             .filter(|_| !editor.content.is_empty())
         {
             let starts = editor.line_starts();
-            let chip_fs = px(11.);
-            let chip_h = px(16.);
+            let chip_fs = px(13.);
+            let chip_h = px(20.);
             let shape = |window: &mut Window, text: &SharedString, color: Hsla| {
                 let run = TextRun {
                     len: text.len(),
@@ -7574,6 +7630,32 @@ impl Element for EditorElement {
                 let Some(cb) = bg.as_ref().filter(|cb| cb.top) else {
                     continue;
                 };
+                // The card's full bounds (for hover tracking): first body line's
+                // padded top through the last block line's padded bottom.
+                let mut last = i;
+                while last + 1 < backgrounds.len() && backgrounds[last + 1].is_some() {
+                    last += 1;
+                    if backgrounds[last].as_ref().is_some_and(|b| b.bottom) {
+                        break;
+                    }
+                }
+                let (top_pad, _) = code_pads(Some(*cb));
+                let (_, last_bot_pad) = code_pads(backgrounds[last]);
+                let card_top = bounds.origin.y + line_tops[i] - top_pad;
+                let card_bottom = bounds.origin.y
+                    + line_tops[last]
+                    + line_heights[last] * (wrapped[last].wrap_boundaries().len() + 1) as f32
+                    + last_bot_pad;
+                let card = Bounds::new(
+                    point(bounds.origin.x, card_top),
+                    size(cb.width, card_bottom - card_top),
+                );
+                code_card_rects.push((i, card));
+                // The chrome itself is hover-revealed: only the hovered card
+                // lays out (and hit-tests) its chips.
+                if editor.code_chip_hover != Some(i) {
+                    continue;
+                }
                 // The opening fence row: this row if the fence is revealed, else
                 // the nearest ``` row above (hidden fences collapse to height 0).
                 let Some(fence_row) = (0..=i).rev().find(|&r| {
@@ -7597,7 +7679,6 @@ impl Element for EditorElement {
                 let copy_text: SharedString = "Copy".into();
                 let lang_w = shape(window, &lang_text, st.quote) + px(12.);
                 let copy_w = shape(window, &copy_text, st.quote) + px(12.);
-                let (top_pad, _) = code_pads(Some(*cb));
                 let right = bounds.origin.x + cb.width - px(6.);
                 let y = bounds.origin.y + line_tops[i] - top_pad + px(3.);
                 let copy_bounds = Bounds::new(point(right - copy_w, y), size(copy_w, chip_h));
@@ -7612,7 +7693,9 @@ impl Element for EditorElement {
                     lang_bounds,
                     copy_bounds,
                     fence_row,
-                    bg: cb.color,
+                    // The popover surface (opaque) — the card tint is
+                    // translucent, and the labels must cover the code text.
+                    bg: st.popover_bg,
                     fg: st.quote,
                     lang_hb,
                     copy_hb,
@@ -8107,6 +8190,7 @@ impl Element for EditorElement {
             image_grips,
             checkbox_grips,
             code_chips,
+            code_card_rects,
             chip_grips,
             alert_fold_grips,
             heading_chevrons,
@@ -8739,7 +8823,7 @@ impl Element for EditorElement {
                 };
                 let shaped = window
                     .text_system()
-                    .shape_line(text.clone(), px(11.), &[run], None);
+                    .shape_line(text.clone(), px(13.), &[run], None);
                 let _ = shaped.paint(
                     point(
                         bounds_.origin.x + (bounds_.size.width - shaped.width()) / 2.,
@@ -8786,6 +8870,7 @@ impl Element for EditorElement {
             editor.prop_row_rects = prop_row_rects;
             editor.checkbox_rects = checkbox_rects;
             editor.code_chip_rects = code_chip_rects;
+            editor.code_card_rects = std::mem::take(&mut prepaint.code_card_rects);
             editor.alert_fold_rects = alert_fold_rects;
             editor.heading_fold_rects = heading_fold_rects;
             editor.heading_row_rects = std::mem::take(&mut prepaint.heading_row_rects);

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1672,6 +1672,14 @@ impl EditorState {
                 && row > 0
                 && self.property_block_at(row).is_none()
                 && self.property_block_at(row - 1).is_some();
+            // Cditor-style around hidden formatting markers: delete the
+            // previous VISIBLE character (never a marker byte), and take an
+            // emptied construct's marker pair with it.
+            if let Some(range) = self.fmt_delete_range(off, true) {
+                self.replace_range(range, "", cx);
+                cx.emit(EditorEvent::Changed);
+                return;
+            }
             let prev = self.previous_boundary(off);
             if off == prev {
                 return;
@@ -1726,6 +1734,12 @@ impl EditorState {
             let join_into_props = off == self.line_end(row)
                 && self.property_block_at(row).is_none()
                 && self.property_block_at(row + 1).is_some();
+            // Cditor-style around hidden formatting markers (see backspace).
+            if let Some(range) = self.fmt_delete_range(off, false) {
+                self.replace_range(range, "", cx);
+                cx.emit(EditorEvent::Changed);
+                return;
+            }
             let next = self.next_boundary(off);
             if off == next {
                 return;
@@ -4364,6 +4378,71 @@ impl EditorState {
             }
             off = self.next_boundary(off);
         }
+    }
+
+    /// Cditor-style deletion planning around hidden formatting markers: the
+    /// range a backspace (`back`) / forward delete should remove at `off`.
+    /// Skips the invisible marker bytes to the adjacent VISIBLE character —
+    /// and when removing it would empty its construct, the now-empty marker
+    /// pair goes too (deleting bold's last char deletes the bold). `None` =
+    /// no hidden markers involved (the plain grapheme deletion applies).
+    fn fmt_delete_range(&self, off: usize, back: bool) -> Option<Range<usize>> {
+        let st = self.markdown_style.as_ref()?;
+        let (row, col) = self.row_col(off);
+        let line_start = self.line_starts()[row];
+        let line_end = self.line_end(row);
+        let line = &self.content[line_start..line_end];
+        // Inside a fenced code block the text is verbatim — no markers there.
+        let fences = self.content[..line_start]
+            .lines()
+            .filter(|l| l.trim_start().starts_with("```"))
+            .count();
+        if fences % 2 == 1 || line.trim_start().starts_with("```") {
+            return None;
+        }
+        let pairs = markdown_syntax::fmt_marker_pairs(line, st);
+        if pairs.is_empty() {
+            return None;
+        }
+        let markers: Vec<&Range<usize>> = pairs.iter().flat_map(|(o, c)| [o, c]).collect();
+        // Skip marker bytes in the deletion direction to the visible char.
+        let mut edge = col;
+        if back {
+            while let Some(sp) = markers.iter().find(|sp| sp.end == edge) {
+                edge = sp.start;
+            }
+        } else {
+            while let Some(sp) = markers.iter().find(|sp| sp.start == edge) {
+                edge = sp.end;
+            }
+        }
+        // The visible grapheme adjacent to the (possibly skipped-to) edge —
+        // staying on this line; a line join takes the default path.
+        let (del_start, del_end) = if back {
+            if edge == 0 {
+                return None;
+            }
+            let p = self.previous_boundary(line_start + edge) - line_start;
+            (p, edge)
+        } else {
+            if edge >= line.len() {
+                return None;
+            }
+            let n = self.next_boundary(line_start + edge).min(line_end) - line_start;
+            (edge, n)
+        };
+        // Would this empty a construct? Only a real PAIR collapses: ITS opener
+        // ending at the deletion's start and ITS closer starting at the end
+        // (adjacent different constructs must not fuse).
+        let emptied = pairs
+            .iter()
+            .find(|(o, c)| o.end == del_start && c.start == del_end);
+        let range = match emptied {
+            Some((o, c)) => o.start..c.end,
+            None if edge == col => return None, // no markers were involved
+            None => del_start..del_end,
+        };
+        Some(line_start + range.start..line_start + range.end)
     }
 
     fn previous_boundary(&self, offset: usize) -> usize {

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -504,7 +504,7 @@ pub struct EditorState {
     /// the last paint, committed only while the table is hovered; hit-tested on
     /// mouse-down.
     table_row_add_rects: Vec<(Bounds<Pixels>, usize)>,
-    table_col_add_rects: Vec<(Bounds<Pixels>, usize)>,
+    table_col_add_rects: Vec<(Bounds<Pixels>, usize, usize)>,
     /// Each table's hover zone (grid + a thin margin), committed every paint so
     /// `on_mouse_move` can repaint when the pointer's table-affordance region
     /// changes (the editor otherwise only repaints on the caret blink).
@@ -2499,9 +2499,9 @@ impl EditorState {
             }
             return;
         }
-        if let Some(row) = self.table_add_col_at(event.position) {
+        if let Some((row, col)) = self.table_add_col_at(event.position) {
             let keep = self.caret_table_cell_pos();
-            if let Some(off) = self.last_cell_start_offset(row) {
+            if let Some(off) = self.cell_start_offset(row, col) {
                 self.selected_range = off..off;
                 self.insert_table_column(true, cx);
             }
@@ -3425,7 +3425,7 @@ impl EditorState {
         } else if self
             .table_col_add_rects
             .iter()
-            .any(|(b, _)| b.contains(&pos))
+            .any(|(b, _, _)| b.contains(&pos))
         {
             2
         } else {
@@ -3481,32 +3481,25 @@ impl EditorState {
         Some((row, t.col_widths.len() - 1))
     }
 
-    /// Hit-test the table add-row "+" strips → the row a new row lands after.
+    /// Hit-test the hovered row's border "+" → the row a new row lands after.
     fn table_add_row_at(&self, position: Point<Pixels>) -> Option<usize> {
         self.table_row_add_rects
             .iter()
             .find_map(|&(rect, row)| rect.contains(&position).then_some(row))
     }
 
-    /// Hit-test the table add-column "+" strips → a row of that table (to seat the
-    /// caret in its last cell).
-    fn table_add_col_at(&self, position: Point<Pixels>) -> Option<usize> {
+    /// Hit-test the hovered column's border "+" → `(header row, column)` — a new
+    /// column lands right of it.
+    fn table_add_col_at(&self, position: Point<Pixels>) -> Option<(usize, usize)> {
         self.table_col_add_rects
             .iter()
-            .find_map(|&(rect, row)| rect.contains(&position).then_some(row))
+            .find_map(|&(rect, row, col)| rect.contains(&position).then_some((row, col)))
     }
 
     /// Source offset at the start of `cell`'s content in table `row` (last paint).
     fn cell_start_offset(&self, row: usize, cell: usize) -> Option<usize> {
         let t = self.table_rows.get(row).and_then(Option::as_ref)?;
         Some(self.line_starts()[row] + t.cell_ranges.get(cell)?.start)
-    }
-
-    /// Source offset at the start of the last cell's content in table `row`.
-    fn last_cell_start_offset(&self, row: usize) -> Option<usize> {
-        let t = self.table_rows.get(row).and_then(Option::as_ref)?;
-        let last = t.cell_ranges.len().checked_sub(1)?;
-        Some(self.line_starts()[row] + t.cell_ranges.get(last)?.start)
     }
 
     /// If `position` lands on a table grid row (not the separator), the source
@@ -7492,42 +7485,66 @@ fn paint_table_row(
 /// "+". Subtle by default; on hover a faint fill + a brighter glyph.
 /// Paint a row/column delete handle: a small rounded button with a "−". Filled on
 /// hover, a muted glyph otherwise.
-fn paint_del_handle(bounds: Bounds<Pixels>, border: Hsla, hot: bool, window: &mut Window) {
-    let mut bg = border;
-    bg.a = if hot { 0.22 } else { 0.10 };
-    window.paint_quad(fill(bounds, bg).corner_radii(Corners::all(px(4.))));
-    let mut glyph = border;
-    glyph.a = if hot { 0.95 } else { 0.6 };
-    let cx = bounds.origin.x + bounds.size.width / 2.;
-    let cy = bounds.origin.y + bounds.size.height / 2.;
-    let arm = px(5.);
-    let th = px(1.5);
-    window.paint_quad(fill(
-        Bounds::new(point(cx - arm, cy - th / 2.), size(arm * 2., th)),
-        glyph,
-    ));
+/// An accent border (no fill) around a hovered row/column or the caret's cell
+/// (issue #16, Cditor-style).
+fn paint_table_outline(bounds: Bounds<Pixels>, accent: Hsla, window: &mut Window) {
+    window.paint_quad(PaintQuad {
+        bounds,
+        corner_radii: Corners::all(px(2.)),
+        background: hsla(0., 0., 0., 0.).into(),
+        border_widths: Edges::all(px(1.5)),
+        border_color: accent,
+        border_style: BorderStyle::Solid,
+    });
 }
 
-fn paint_add_strip(bounds: Bounds<Pixels>, border: Hsla, hot: bool, window: &mut Window) {
-    // A rounded box matching the delete handles — filled faintly, brighter on hover
-    // — with a centered "+".
-    let mut bg = border;
-    bg.a = if hot { 0.22 } else { 0.10 };
-    window.paint_quad(fill(bounds, bg).corner_radii(Corners::all(px(4.))));
-    let mut glyph = border;
-    glyph.a = if hot { 0.95 } else { 0.6 };
-    let cx = bounds.origin.x + bounds.size.width / 2.;
-    let cy = bounds.origin.y + bounds.size.height / 2.;
-    let arm = px(5.);
+/// The hovered row/column's border pill: an accent-filled capsule holding "+"
+/// and "−" halves (white glyphs; the hovered half full-strength). `sep_h` =
+/// true when the two halves sit side-by-side (a column's top-border pill).
+fn paint_table_pill(a: &TableAffordance, sep_h: bool, mouse: Point<Pixels>, window: &mut Window) {
+    let pill = a.plus.union(&a.minus);
+    window.paint_quad(fill(pill, a.accent).corner_radii(Corners::all(px(6.))));
+    let white = hsla(0., 0., 1., 1.);
+    let arm = px(4.);
     let th = px(1.5);
-    window.paint_quad(fill(
-        Bounds::new(point(cx - arm, cy - th / 2.), size(arm * 2., th)),
-        glyph,
-    ));
-    window.paint_quad(fill(
-        Bounds::new(point(cx - th / 2., cy - arm), size(th, arm * 2.)),
-        glyph,
-    ));
+    let glyph = |b: &Bounds<Pixels>, plus: bool, window: &mut Window| {
+        let mut c = white;
+        c.a = if b.contains(&mouse) { 1.0 } else { 0.75 };
+        let cx = b.origin.x + b.size.width / 2.;
+        let cy = b.origin.y + b.size.height / 2.;
+        window.paint_quad(fill(
+            Bounds::new(point(cx - arm, cy - th / 2.), size(arm * 2., th)),
+            c,
+        ));
+        if plus {
+            window.paint_quad(fill(
+                Bounds::new(point(cx - th / 2., cy - arm), size(th, arm * 2.)),
+                c,
+            ));
+        }
+    };
+    glyph(&a.plus, true, window);
+    glyph(&a.minus, false, window);
+    // A hairline between the halves so the two targets read separately.
+    let mut div_c = white;
+    div_c.a = 0.35;
+    if sep_h {
+        window.paint_quad(fill(
+            Bounds::new(
+                point(a.minus.origin.x, pill.origin.y + px(3.)),
+                size(px(1.), pill.size.height - px(6.)),
+            ),
+            div_c,
+        ));
+    } else {
+        window.paint_quad(fill(
+            Bounds::new(
+                point(pill.origin.x + px(3.), a.minus.origin.y),
+                size(pill.size.width - px(6.), px(1.)),
+            ),
+            div_c,
+        ));
+    }
 }
 
 /// The custom element that lays out + paints the editor's wrapped lines, cursor,
@@ -7537,33 +7554,21 @@ struct EditorElement {
     editor: Entity<EditorState>,
 }
 
-/// Per-table hover-revealed "+" affordances (issue #16): a hover zone (the table
-/// plus a thin margin) that gates visibility, plus the below/right "+" strips with
-/// their own hitboxes (hover cursor) and the table row to seat the caret in.
-struct TableAdds {
-    zone: Bounds<Pixels>,
-    below: Bounds<Pixels>,
-    below_hit: Hitbox,
-    below_row: usize,
-    right: Bounds<Pixels>,
-    right_hit: Hitbox,
-    right_row: usize,
-    border: Hsla,
-}
-
-/// A per-row or per-column delete handle for the hovered table cell (issue #16):
-/// where to paint the "−", its hover-cursor hitbox, and the row/column to remove.
-struct DelHandle {
-    bounds: Bounds<Pixels>,
-    /// The whole row's / column's cell rect, tinted on hover so the delete target
-    /// is obvious.
-    highlight: Bounds<Pixels>,
-    hit: Hitbox,
+/// The hovered row's / column's affordance (issue #16, Cditor-style): an accent
+/// OUTLINE around it (no fill) and a small pill sitting ON the table border —
+/// "+" (insert after) and "−" (delete) — instead of outside strips/handles.
+struct TableAffordance {
+    /// The whole row's / column's rect, outlined in the accent color.
+    outline: Bounds<Pixels>,
+    plus: Bounds<Pixels>,
+    minus: Bounds<Pixels>,
+    plus_hit: Hitbox,
+    minus_hit: Hitbox,
+    /// The hovered body row (rows) / the table's header line (columns) — where
+    /// the caret seats to run the caret-driven insert/delete APIs.
     row: usize,
     col: usize,
-    border: Hsla,
-    /// Paint the row/column tint (kept for borderless tables to show the grid).
-    show_highlight: bool,
+    accent: Hsla,
 }
 
 struct PrepaintState {
@@ -7622,11 +7627,13 @@ struct PrepaintState {
     /// Icon asset paths for alert marker lines, cloned from the style so the
     /// paint can draw them next to the labels.
     alert_icons: Option<markdown_syntax::AlertIcons>,
-    /// Per-table hover-revealed add-row/add-column "+" affordances (issue #16).
-    table_adds: Vec<TableAdds>,
-    /// Hovered-cell delete handles (issue #16): the "−" for the hovered row + column.
-    row_del: Option<DelHandle>,
-    col_del: Option<DelHandle>,
+    /// Per-table hover zones (the grid plus pill reach) — repaint gating.
+    table_zones: Vec<Bounds<Pixels>>,
+    /// Hovered-row / hovered-column border pills + outlines (issue #16).
+    row_aff: Option<TableAffordance>,
+    col_aff: Option<TableAffordance>,
+    /// The caret's cell, outlined in the accent color (Cditor-style).
+    caret_cell: Option<(Bounds<Pixels>, Hsla)>,
     cursor: Option<PaintQuad>,
     selections: Vec<PaintQuad>,
     /// Find-match highlight quads, painted beneath the selection.
@@ -8192,17 +8199,22 @@ impl Element for EditorElement {
             }
         }
 
-        // Per-table add-row / add-column "+" affordances (issue #16), revealed on
-        // hover. Each table contributes a hover zone (the grid + a thin margin) plus
-        // a "+" strip below (adds a row) and to the right (adds a column); bounds
-        // follow the painted rows. Paint shows/cursors them only while the zone is
-        // hovered; on_mouse_down hit-tests the committed strip rects.
+        // Table interaction (issue #16, Cditor-style): the hovered row/column
+        // gets an ACCENT OUTLINE (no fill) plus a small pill ON the table border
+        // — "+" inserts after it, "−" deletes it. The caret's cell is outlined
+        // too. Paint shows/cursors them only while hovered; on_mouse_down
+        // hit-tests the committed pill rects.
         let mouse = window.mouse_position();
-        let mut table_adds: Vec<TableAdds> = Vec::new();
-        let mut row_del: Option<DelHandle> = None;
-        let mut col_del: Option<DelHandle> = None;
+        let mut table_zones: Vec<Bounds<Pixels>> = Vec::new();
+        let mut row_aff: Option<TableAffordance> = None;
+        let mut col_aff: Option<TableAffordance> = None;
+        let mut caret_cell: Option<(Bounds<Pixels>, Hsla)> = None;
+        let caret_pos = editor.caret_table_cell_pos();
         let mut tbl_top: Option<Pixels> = None;
         let mut tbl_header = 0usize;
+        // Pill geometry: thickness across the border, length along it.
+        const PILL_ACROSS: f32 = 16.;
+        const PILL_ALONG: f32 = 36.;
         for (i, slot) in tables.iter().enumerate() {
             let Some(t) = slot else { continue };
             if t.is_header {
@@ -8214,35 +8226,32 @@ impl Element for EditorElement {
                 let bottom = bounds.origin.y + line_tops[i] + line_heights[i];
                 let left = bounds.origin.x + px(TABLE_GUTTER);
                 let width: Pixels = t.col_widths.iter().copied().sum();
-                // Full-edge "+" tabs: a strip along the bottom (adds a row) and the
-                // right (adds a column), each the table's full extent like the box.
-                // paint rounds the two outer corners so the edge bulging away from
-                // the table reads as a half-moon.
-                let r = (line_heights[i] * 0.75).max(px(12.));
-                let below = Bounds::new(point(left, bottom), size(width, r));
-                let right = Bounds::new(point(left + width, top), size(r, bottom - top));
-                let zone = Bounds::new(point(left, top), size(width + r, (bottom - top) + r));
-                table_adds.push(TableAdds {
-                    zone,
-                    below,
-                    below_hit: window.insert_hitbox(below, HitboxBehavior::Normal),
-                    below_row: i,
-                    right,
-                    right_hit: window.insert_hitbox(right, HitboxBehavior::Normal),
-                    right_row: tbl_header,
-                    border: t.border,
-                });
+                let accent = editor.markdown_style.as_ref().map_or(t.border, |s| s.link);
+                let g = px(PILL_ACROSS);
+                let zone = Bounds::new(
+                    point(left - g, top - g),
+                    size(width + g * 2., (bottom - top) + g * 2.),
+                );
+                table_zones.push(zone);
 
-                // Per-row + per-column delete "−" handles (issue #16): full-height in
-                // the left gutter, full-width in the top gutter. Hover bands reach
-                // into the gutters so moving onto a handle keeps it shown.
-                let g = px(TABLE_GUTTER);
-                // Always available on hover (people delete rows/columns while editing,
-                // too). The highlight stays for borderless (lineless) tables so the
-                // otherwise-invisible grid still shows.
-                let has_lines = matches!(t.style, markdown_syntax::TableStyle::Grid);
-                let show_highlight = !has_lines;
-                if mouse.x >= bounds.origin.x && mouse.x < left + width {
+                // The caret's cell (this table only), outlined like Cditor's.
+                if let Some((crow, ccell, _)) = caret_pos
+                    && crow >= tbl_header
+                    && crow <= i
+                    && let Some(rt) = tables.get(crow).and_then(Option::as_ref)
+                    && !rt.col_widths.is_empty()
+                {
+                    let cc = ccell.min(rt.col_widths.len() - 1);
+                    let x: Pixels = left + rt.col_widths[..cc].iter().copied().sum::<Pixels>();
+                    let rect = Bounds::new(
+                        point(x, bounds.origin.y + line_tops[crow]),
+                        size(rt.col_widths[cc], line_heights[crow]),
+                    );
+                    caret_cell = Some((rect, accent));
+                }
+
+                if zone.contains(&mouse) {
+                    // Hovered BODY row → outline + a vertical pill on its left border.
                     for line in tbl_header..=i {
                         let Some(rt) = tables.get(line).and_then(Option::as_ref) else {
                             continue;
@@ -8253,47 +8262,57 @@ impl Element for EditorElement {
                         let rtop = bounds.origin.y + line_tops[line];
                         let rh = line_heights[line];
                         if mouse.y >= rtop && mouse.y < rtop + rh {
-                            let rb = Bounds::new(
-                                point(bounds.origin.x + px(2.), rtop + px(1.)),
-                                size((g - px(5.)).max(px(12.)), (rh - px(2.)).max(px(8.))),
-                            );
-                            row_del = Some(DelHandle {
-                                bounds: rb,
-                                highlight: Bounds::new(point(left, rtop), size(width, rh)),
-                                hit: window.insert_hitbox(rb, HitboxBehavior::Normal),
+                            let ph = px(PILL_ALONG).min(rh - px(2.));
+                            let py0 = rtop + (rh - ph) / 2.;
+                            let pill = Bounds::new(point(left - g / 2., py0), size(g, ph));
+                            let plus = Bounds::new(pill.origin, size(g, ph / 2.));
+                            let minus =
+                                Bounds::new(point(pill.origin.x, py0 + ph / 2.), size(g, ph / 2.));
+                            row_aff = Some(TableAffordance {
+                                outline: Bounds::new(point(left, rtop), size(width, rh)),
+                                plus,
+                                minus,
+                                plus_hit: window.insert_hitbox(plus, HitboxBehavior::Normal),
+                                minus_hit: window.insert_hitbox(minus, HitboxBehavior::Normal),
                                 row: line,
                                 col: 0,
-                                border: rt.border,
-                                show_highlight,
+                                accent,
                             });
                             break;
                         }
                     }
-                }
-                if mouse.y >= top - g
-                    && mouse.y < bottom
-                    && mouse.x >= left
-                    && mouse.x < left + width
-                {
-                    let mut colx = left;
-                    for (col, &cw) in t.col_widths.iter().enumerate() {
-                        if mouse.x < colx + cw || col + 1 == t.col_widths.len() {
-                            let cb = Bounds::new(
-                                point(colx + px(2.), top - g + px(2.)),
-                                size((cw - px(4.)).max(px(12.)), (g - px(4.)).max(px(8.))),
-                            );
-                            col_del = Some(DelHandle {
-                                bounds: cb,
-                                highlight: Bounds::new(point(colx, top), size(cw, bottom - top)),
-                                hit: window.insert_hitbox(cb, HitboxBehavior::Normal),
-                                row: tbl_header,
-                                col,
-                                border: t.border,
-                                show_highlight,
-                            });
-                            break;
+                    // Hovered column → outline + a horizontal pill on the top border.
+                    // Not while the pointer is ON the row's pill — the column
+                    // highlight under it is noise when you're about to click.
+                    let on_row_pill = row_aff
+                        .as_ref()
+                        .is_some_and(|a| a.plus.contains(&mouse) || a.minus.contains(&mouse));
+                    if !on_row_pill && mouse.x >= left && mouse.x < left + width {
+                        let mut colx = left;
+                        for (col, &cw) in t.col_widths.iter().enumerate() {
+                            if mouse.x < colx + cw || col + 1 == t.col_widths.len() {
+                                let pw = px(PILL_ALONG).min(cw - px(2.));
+                                let px0 = colx + (cw - pw) / 2.;
+                                let pill = Bounds::new(point(px0, top - g / 2.), size(pw, g));
+                                let plus = Bounds::new(pill.origin, size(pw / 2., g));
+                                let minus = Bounds::new(
+                                    point(px0 + pw / 2., pill.origin.y),
+                                    size(pw / 2., g),
+                                );
+                                col_aff = Some(TableAffordance {
+                                    outline: Bounds::new(point(colx, top), size(cw, bottom - top)),
+                                    plus,
+                                    minus,
+                                    plus_hit: window.insert_hitbox(plus, HitboxBehavior::Normal),
+                                    minus_hit: window.insert_hitbox(minus, HitboxBehavior::Normal),
+                                    row: tbl_header,
+                                    col,
+                                    accent,
+                                });
+                                break;
+                            }
+                            colx += cw;
                         }
-                        colx += cw;
                     }
                 }
                 tbl_top = None;
@@ -8554,9 +8573,10 @@ impl Element for EditorElement {
                 .markdown_style
                 .as_ref()
                 .and_then(|st| st.alert_icons.clone()),
-            table_adds,
-            row_del,
-            col_del,
+            table_zones,
+            row_aff,
+            col_aff,
+            caret_cell,
             cursor,
             selections,
             search,
@@ -9077,47 +9097,35 @@ impl Element for EditorElement {
         // otherwise only repaints on the caret blink). Zones are committed every
         // frame so on_mouse_move knows where the tables are.
         let mouse = window.mouse_position();
-        let mut table_hover_zones: Vec<Bounds<Pixels>> = Vec::new();
+        let table_hover_zones: Vec<Bounds<Pixels>> = prepaint.table_zones.clone();
         let mut table_row_add_rects: Vec<(Bounds<Pixels>, usize)> = Vec::new();
-        let mut table_col_add_rects: Vec<(Bounds<Pixels>, usize)> = Vec::new();
-        for ta in &prepaint.table_adds {
-            table_hover_zones.push(ta.zone);
-            // Commit the strip rects EVERY frame — a click can land before any
-            // hovered paint ran (a fast flick-click), and on_mouse_down checks
-            // these rects. Only the visuals below stay hover-gated.
-            table_row_add_rects.push((ta.below, ta.below_row));
-            table_col_add_rects.push((ta.right, ta.right_row));
-            if !ta.zone.contains(&mouse) {
-                continue;
-            }
-            paint_add_strip(ta.below, ta.border, ta.below.contains(&mouse), window);
-            window.set_cursor_style(CursorStyle::PointingHand, &ta.below_hit);
-            paint_add_strip(ta.right, ta.border, ta.right.contains(&mouse), window);
-            window.set_cursor_style(CursorStyle::PointingHand, &ta.right_hit);
-        }
-
-        // Per-row / per-column delete "−" handles for the hovered cell (issue #16).
+        let mut table_col_add_rects: Vec<(Bounds<Pixels>, usize, usize)> = Vec::new();
         let mut table_row_del = None;
-        if let Some(d) = &prepaint.row_del {
-            if d.show_highlight {
-                let mut hi = d.border;
-                hi.a = 0.10;
-                window.paint_quad(fill(d.highlight, hi));
-            }
-            paint_del_handle(d.bounds, d.border, d.bounds.contains(&mouse), window);
-            window.set_cursor_style(CursorStyle::PointingHand, &d.hit);
-            table_row_del = Some((d.bounds, d.row));
-        }
         let mut table_col_del = None;
-        if let Some(d) = &prepaint.col_del {
-            if d.show_highlight {
-                let mut hi = d.border;
-                hi.a = 0.10;
-                window.paint_quad(fill(d.highlight, hi));
-            }
-            paint_del_handle(d.bounds, d.border, d.bounds.contains(&mouse), window);
-            window.set_cursor_style(CursorStyle::PointingHand, &d.hit);
-            table_col_del = Some((d.bounds, d.row, d.col));
+        // The caret's cell: a quiet accent outline (under the hover outlines).
+        if let Some((rect, accent)) = prepaint.caret_cell {
+            let mut c = accent;
+            c.a *= 0.55;
+            paint_table_outline(rect, c, window);
+        }
+        // Hovered row/column: accent outline + a border pill with "+" / "−"
+        // (Cditor-style — no fill highlight). Rects are committed for
+        // on_mouse_down's hit-tests.
+        if let Some(a) = &prepaint.row_aff {
+            paint_table_outline(a.outline, a.accent, window);
+            paint_table_pill(a, false, mouse, window);
+            window.set_cursor_style(CursorStyle::PointingHand, &a.plus_hit);
+            window.set_cursor_style(CursorStyle::PointingHand, &a.minus_hit);
+            table_row_add_rects.push((a.plus, a.row));
+            table_row_del = Some((a.minus, a.row));
+        }
+        if let Some(a) = &prepaint.col_aff {
+            paint_table_outline(a.outline, a.accent, window);
+            paint_table_pill(a, true, mouse, window);
+            window.set_cursor_style(CursorStyle::PointingHand, &a.plus_hit);
+            window.set_cursor_style(CursorStyle::PointingHand, &a.minus_hit);
+            table_col_add_rects.push((a.plus, a.row, a.col));
+            table_col_del = Some((a.minus, a.row, a.col));
         }
 
         let wrapped = std::mem::take(&mut prepaint.wrapped);

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -255,6 +255,8 @@ struct DiagMenu {
     suggestions: Vec<SharedString>,
     /// Scroll state of the (capped-height) list, so a thumb can track it.
     scroll: ScrollHandle,
+    /// Whether the "Turn into" flyout is open (hover-opened; dies with the menu).
+    turn_into: bool,
 }
 
 /// A block kind the right-click "Turn into" menu converts between —
@@ -677,9 +679,6 @@ pub struct EditorState {
     markdown_style: Option<SyntaxStyle>,
     /// The open right-click suggestions menu, if any.
     menu: Option<DiagMenu>,
-    /// Whether the menu's "Turn into" flyout is open (hover-opened, lives
-    /// until the menu closes).
-    menu_turn_into: bool,
     /// The open table right-click menu's anchor (window space), if any. Its actions
     /// operate on the caret's table cell.
     table_menu: Option<Point<Pixels>>,
@@ -902,7 +901,6 @@ impl EditorState {
             diagnostics: Vec::new(),
             markdown_style: None,
             menu: None,
-            menu_turn_into: false,
             table_menu: None,
             table_menu_scroll: ScrollHandle::new(),
             image_menu: None,
@@ -3220,12 +3218,12 @@ impl EditorState {
             }
             None => (offset..offset, Vec::new()),
         };
-        self.menu_turn_into = false;
         self.menu = Some(DiagMenu {
             anchor,
             range,
             suggestions: suggestions.into_iter().map(SharedString::from).collect(),
             scroll: ScrollHandle::new(),
+            turn_into: false,
         });
         cx.notify();
     }
@@ -3261,6 +3259,44 @@ impl EditorState {
         self.selected_range = range;
         self.selection_reversed = false;
         self.replace_text_in_range(None, text, window, cx);
+    }
+
+    /// The fenced code block containing `row`: its opening fence row plus the
+    /// closing fence row (`None` when the block runs unclosed to the end).
+    /// The single source for turn-into, block drag, and drop snapping.
+    fn fence_block_rows(&self, row: usize) -> (usize, Option<usize>) {
+        let scan = self.scan_data();
+        let starts = self.line_starts();
+        let last_row = starts.len().saturating_sub(1);
+        let open = (0..=row)
+            .rev()
+            .find(|&r| !scan.fence_odd.get(r).copied().unwrap_or(false))
+            .unwrap_or(0);
+        let close = ((open + 1)..=last_row).find(|&r| {
+            self.content[starts[r]..self.line_end(r)]
+                .trim_start()
+                .starts_with("```")
+        });
+        (open, close)
+    }
+
+    /// The contiguous blockquote run containing `row` (first row..=last row),
+    /// by the renderer's `blockquote_prefix` test.
+    fn quote_run_rows(&self, row: usize) -> (usize, usize) {
+        let starts = self.line_starts();
+        let last_row = starts.len().saturating_sub(1);
+        let is_q = |r: usize| {
+            markdown_syntax::blockquote_prefix(&self.content[starts[r]..self.line_end(r)]).is_some()
+        };
+        let mut first = row;
+        while first > 0 && is_q(first - 1) {
+            first -= 1;
+        }
+        let mut last = row;
+        while last < last_row && is_q(last + 1) {
+            last += 1;
+        }
+        (first, last)
     }
 
     /// The "Turn into" kind of the block containing `row` — what the flyout
@@ -3300,20 +3336,13 @@ impl EditorState {
         if markdown_syntax::blockquote_prefix(line).is_some() {
             // Callout if the caret's contiguous `>`-run carries a VALID
             // `[!KIND]` marker anywhere (marker line or body line).
-            let line_at = |r: usize| &self.content[starts[r]..self.line_end(r)];
-            let is_q = |r: usize| markdown_syntax::blockquote_prefix(line_at(r)).is_some();
-            let mut first = row;
-            while first > 0 && is_q(first - 1) {
-                first -= 1;
-            }
-            let mut r = first;
-            while r < starts.len() && is_q(r) {
-                let l = line_at(r);
+            let (first, last) = self.quote_run_rows(row);
+            for r in first..=last {
+                let l = &self.content[starts[r]..self.line_end(r)];
                 let p = markdown_syntax::blockquote_prefix(l).unwrap_or(0);
                 if markdown_syntax::alert_kind(&l[p..]).is_some() {
                     return TurnKind::Callout;
                 }
-                r += 1;
             }
             return TurnKind::Quote;
         }
@@ -3336,14 +3365,9 @@ impl EditorState {
         // The block's line span + its content with the current dressing removed.
         let (first, last, mut body): (usize, usize, Vec<String>) = match cur {
             TurnKind::Code => {
-                let open = (0..=row)
-                    .rev()
-                    .find(|&r| !scan.fence_odd.get(r).copied().unwrap_or(false))
-                    .unwrap_or(0);
-                let close =
-                    ((open + 1)..=last_row).find(|&r| line_at(r).trim_start().starts_with("```"));
+                let (open, close) = self.fence_block_rows(row);
                 let last = close.unwrap_or(last_row);
-                let body_end = close.map(|c| c - 1).unwrap_or(last_row);
+                let body_end = close.map(|c| c.saturating_sub(1)).unwrap_or(last_row);
                 let body = ((open + 1)..=body_end).map(line_at).collect();
                 (open, last, body)
             }
@@ -3357,15 +3381,7 @@ impl EditorState {
                 (first, last, body)
             }
             TurnKind::Quote | TurnKind::Callout => {
-                let is_q = |r: usize| markdown_syntax::blockquote_prefix(&line_at(r)).is_some();
-                let mut first = row;
-                while first > 0 && is_q(first - 1) {
-                    first -= 1;
-                }
-                let mut last = row;
-                while last < last_row && is_q(last + 1) {
-                    last += 1;
-                }
+                let (first, last) = self.quote_run_rows(row);
                 let body = (first..=last)
                     .filter_map(|r| {
                         let line = line_at(r);
@@ -3459,26 +3475,11 @@ impl EditorState {
         if scan.fence_odd.get(row).copied().unwrap_or(false)
             || line_at(row).trim_start().starts_with("```")
         {
-            let open = (0..=row)
-                .rev()
-                .find(|&r| !scan.fence_odd.get(r).copied().unwrap_or(false))
-                .unwrap_or(0);
-            let close = ((open + 1)..=last_row)
-                .find(|&r| line_at(r).trim_start().starts_with("```"))
-                .unwrap_or(last_row);
-            return (open, close);
+            let (open, close) = self.fence_block_rows(row);
+            return (open, close.unwrap_or(last_row));
         }
         if markdown_syntax::blockquote_prefix(line_at(row)).is_some() {
-            let is_q = |r: usize| markdown_syntax::blockquote_prefix(line_at(r)).is_some();
-            let mut first = row;
-            while first > 0 && is_q(first - 1) {
-                first -= 1;
-            }
-            let mut last = row;
-            while last < last_row && is_q(last + 1) {
-                last += 1;
-            }
-            return (first, last);
+            return self.quote_run_rows(row);
         }
         if markdown_syntax::list_prefix(line_at(row)).is_some() {
             let indent = |r: usize| {
@@ -3502,7 +3503,7 @@ impl EditorState {
         let bounds = self.last_bounds?;
         if self.markdown_style.is_none()
             || self.line_drag.is_some()
-            || position.x < bounds.origin.x - px(26.) - self.grip_inset
+            || position.x < grip_left(bounds.origin.x, self.grip_inset) - px(4.)
             || position.x > bounds.origin.x + bounds.size.width
         {
             return None;
@@ -3557,16 +3558,8 @@ impl EditorState {
         }
         // Inside a code fence: snap to the opening fence or past the close.
         if scan.fence_odd.get(b).copied().unwrap_or(false) {
-            let starts = self.line_starts();
-            let line_at = |r: usize| &self.content[starts[r]..self.line_end(r)];
-            let open = (0..b)
-                .rev()
-                .find(|&r| !scan.fence_odd.get(r).copied().unwrap_or(false))
-                .unwrap_or(0);
-            let close = (b..starts.len())
-                .find(|&r| line_at(r).trim_start().starts_with("```"))
-                .map(|c| c + 1)
-                .unwrap_or(starts.len());
+            let (open, close) = self.fence_block_rows(b);
+            let close = close.map(|c| c + 1).unwrap_or(self.line_starts().len());
             b = if b - open <= close - b { open } else { close };
         }
         b
@@ -4133,6 +4126,19 @@ impl EditorState {
     }
 
     /// The table cell `(row, col)` the pointer is over, or `None` off any table —
+    /// The table's content LEFT edge in window space, horizontal scroll
+    /// applied — THE single source for every x mapping on a table (paint,
+    /// hit-tests, caret, selection, affordances).
+    fn table_left(&self, t: &TableRow, row: usize, bounds: &Bounds<Pixels>) -> Pixels {
+        let total: Pixels = t.col_widths.iter().copied().sum();
+        bounds.origin.x + px(TABLE_GUTTER)
+            - self.table_sx(
+                table_header_row(t, row),
+                total,
+                bounds.size.width - px(TABLE_GUTTER),
+            )
+    }
+
     /// The clamped horizontal scroll of the table headed at `header_row`.
     fn table_sx(&self, header_row: usize, total: Pixels, avail: Pixels) -> Pixels {
         let max = f32::from((total - avail).max(px(0.)));
@@ -4217,13 +4223,12 @@ impl EditorState {
         if t.col_widths.is_empty() {
             return None;
         }
-        let table_left = gutter_left + g;
+        let table_left = self.table_left(t, row, bounds);
         let table_w: Pixels = t.col_widths.iter().copied().sum();
-        let sx = self.table_sx(table_header_row(t, row), table_w, bounds.size.width - g);
-        if pos.x >= table_left + table_w - sx {
+        if pos.x >= table_left + table_w {
             return None;
         }
-        let rel_x = (pos.x - table_left + sx).max(px(0.));
+        let rel_x = (pos.x - table_left).max(px(0.));
         let mut colx = px(0.);
         for (col, &cw) in t.col_widths.iter().enumerate() {
             if rel_x < colx + cw {
@@ -4280,16 +4285,8 @@ impl EditorState {
         if t.is_separator || t.col_widths.is_empty() {
             return None;
         }
-        // A scrolled wide table: the pointer maps to content shifted by sx.
-        let rel = point(
-            rel.x
-                + self.table_sx(
-                    table_header_row(t, row),
-                    t.col_widths.iter().copied().sum(),
-                    bounds.size.width - px(TABLE_GUTTER),
-                ),
-            rel.y,
-        );
+        // A scrolled wide table: the pointer maps to content shifted left.
+        let rel = point(position.x - self.table_left(t, row, bounds), rel.y);
         // Measure at the last paint's size — the style stack is unwound during
         // event dispatch, so `text_style()` here reports the root size.
         let style = window.text_style();
@@ -5409,6 +5406,7 @@ impl Render for EditorState {
                     range,
                     suggestions,
                     scroll,
+                    turn_into: menu_turn_into,
                 } = menu;
                 let count = suggestions.len();
                 // Menu chrome from the host's theme (fallbacks match the former
@@ -5646,12 +5644,15 @@ impl Render for EditorState {
                     .child("Turn into")
                     .child(div().text_size(px(10.)).child("\u{25b8}"))
                     .on_hover(cx.listener(|editor, hovered: &bool, _, cx| {
-                        if *hovered && !editor.menu_turn_into {
-                            editor.menu_turn_into = true;
+                        if *hovered
+                            && let Some(m) = editor.menu.as_mut()
+                            && !m.turn_into
+                        {
+                            m.turn_into = true;
                             cx.notify();
                         }
                     }));
-                let turn_flyout = self.menu_turn_into.then(|| {
+                let turn_flyout = menu_turn_into.then(|| {
                     let rows: Vec<_> = TurnKind::ALL
                         .iter()
                         .enumerate()
@@ -8662,6 +8663,13 @@ fn shape_cell(
 
 /// How many wrap rows table row `cells` need at `col_widths` — 1 for content
 /// that fits; more once a drag-narrowed column forces its text to wrap.
+/// The gutter grip's left edge for an editor whose content starts at
+/// `bounds_left` — THE grip x formula, shared by prepaint (fresh geometry)
+/// and the event-time hover mirror so the two can't drift.
+fn grip_left(bounds_left: Pixels, inset: Pixels) -> Pixels {
+    bounds_left - px(22.) - inset
+}
+
 /// The header row of the table that `t` (the grid row at line `row`) belongs
 /// to — the key of its horizontal-scroll entry.
 fn table_header_row(t: &TableRow, row: usize) -> usize {
@@ -9880,10 +9888,10 @@ impl Element for EditorElement {
             let all = Bounds::new(gpui::Point::default(), window.viewport_size());
             grip_hb = Some(window.insert_hitbox(all, HitboxBehavior::Normal));
         }
-        let grip_left = bounds.origin.x - px(22.) - editor.grip_inset;
+        let gl = grip_left(bounds.origin.x, editor.grip_inset);
         if editor.markdown_style.is_some()
             && editor.line_drag.is_none()
-            && mouse.x >= grip_left - px(4.)
+            && mouse.x >= gl - px(4.)
             && mouse.x <= bounds.origin.x + bounds.size.width
         {
             let y = mouse.y - bounds.origin.y;
@@ -9895,7 +9903,7 @@ impl Element for EditorElement {
                 let sz = px(14.);
                 let rect = Bounds::new(
                     point(
-                        grip_left,
+                        gl,
                         bounds.origin.y + line_tops[row] + (line_heights[row] - sz) / 2.,
                     ),
                     size(sz, sz),
@@ -9933,8 +9941,7 @@ impl Element for EditorElement {
                 let bottom = bounds.origin.y + line_tops[i] + line_heights[i];
                 let width: Pixels = t.col_widths.iter().copied().sum();
                 // A scrolled wide table shifts every affordance with its content.
-                let sx = editor.table_sx(tbl_header, width, bounds.size.width - px(TABLE_GUTTER));
-                let left = bounds.origin.x + px(TABLE_GUTTER) - sx;
+                let left = editor.table_left(t, i, &bounds);
                 let accent = editor.markdown_style.as_ref().map_or(t.border, |s| s.link);
                 let g = px(PILL_ACROSS);
                 let zone = Bounds::new(
@@ -10106,12 +10113,7 @@ impl Element for EditorElement {
                     // ends (not raw-source geometry).
                     if let Some(t) = tables.get(row).and_then(Option::as_ref) {
                         let table_w: Pixels = t.col_widths.iter().copied().sum();
-                        let tleft = bounds.left() + px(TABLE_GUTTER)
-                            - editor.table_sx(
-                                table_header_row(t, row),
-                                table_w,
-                                bounds.size.width - px(TABLE_GUTTER),
-                            );
+                        let tleft = editor.table_left(t, row, &bounds);
                         // Endpoint x's: inside a cell, the exact caret x; at
                         // or past the row's cell span — or in an empty cell
                         // the shaper can't position — the table's edge, so
@@ -10247,12 +10249,7 @@ impl Element for EditorElement {
                 && let Some((x, y_off, _, _)) = table_caret_pos(
                     t,
                     col,
-                    bounds.left() + px(TABLE_GUTTER)
-                        - editor.table_sx(
-                            table_header_row(t, row),
-                            t.col_widths.iter().copied().sum(),
-                            bounds.size.width - px(TABLE_GUTTER),
-                        ),
+                    editor.table_left(t, row, &bounds),
                     &font,
                     font_size,
                     window,
@@ -10390,8 +10387,6 @@ impl Element for EditorElement {
             .as_ref()
             .map_or(text_color, |s| s.link);
         let image_resize = self.editor.read(cx).image_resize;
-        // Wide-table horizontal scroll offsets, snapshotted for the paint loop.
-        let table_sx_map = self.editor.read(cx).table_scroll_x.clone();
         // Window-space bounds of each painted image + its logical line, collected
         // for the next frame's grip hit-testing (committed below).
         let mut image_rects: Vec<(usize, Bounds<Pixels>)> = Vec::new();
@@ -10715,15 +10710,9 @@ impl Element for EditorElement {
                 // clipped to the viewport — rows paint shifted under a mask.
                 let table_w: Pixels = t.col_widths.iter().copied().sum();
                 let avail = bounds.size.width - px(TABLE_GUTTER);
-                let sx = {
-                    let max = f32::from((table_w - avail).max(px(0.)));
-                    px(table_sx_map
-                        .get(&table_header_row(t, i))
-                        .copied()
-                        .unwrap_or(0.)
-                        .clamp(0., max))
-                };
                 let tleft = origin.x + px(TABLE_GUTTER);
+                let content_left = self.editor.read(cx).table_left(t, i, &bounds);
+                let sx = tleft - content_left;
                 let g = px(TABLE_GUTTER);
                 let mask = gpui::ContentMask {
                     bounds: Bounds::new(point(tleft, origin.y - g), size(avail, *lh + g * 2.)),
@@ -10755,7 +10744,7 @@ impl Element for EditorElement {
                     window.with_content_mask(Some(border_mask), |window| {
                         window.paint_quad(PaintQuad {
                             bounds: Bounds::new(
-                                point(tleft - sx, origin.y),
+                                point(content_left, origin.y),
                                 size(table_w, total_h),
                             ),
                             corner_radii: Corners::all(px(6.)),
@@ -10769,7 +10758,7 @@ impl Element for EditorElement {
                 window.with_content_mask(Some(mask), |window| {
                     paint_table_row(
                         t,
-                        point(tleft - sx, origin.y),
+                        point(content_left, origin.y),
                         *lh,
                         &font,
                         font_size,

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -83,6 +83,8 @@ actions!(
         Outdent,
         Bold,
         Italic,
+        Underline,
+        Strike,
         Code,
         Dismiss,
     ]
@@ -132,6 +134,10 @@ pub fn bind_keys(cx: &mut App) {
         KeyBinding::new("ctrl-i", Italic, ctx),
         KeyBinding::new("cmd-e", Code, ctx),
         KeyBinding::new("ctrl-e", Code, ctx),
+        KeyBinding::new("cmd-shift-x", Strike, ctx),
+        KeyBinding::new("ctrl-shift-x", Strike, ctx),
+        KeyBinding::new("cmd-u", Underline, ctx),
+        KeyBinding::new("ctrl-u", Underline, ctx),
         KeyBinding::new("escape", Dismiss, ctx),
     ]);
 }
@@ -1813,40 +1819,45 @@ impl EditorState {
     }
 
     /// Toggle an inline wrapping marker (`**` bold, `*` italic, `` ` `` code)
+    /// around the selection — the symmetric case of [`Self::toggle_wrap_pair`].
+    fn toggle_wrap(&mut self, marker: &str, cx: &mut Context<Self>) {
+        self.toggle_wrap_pair(marker, marker, cx);
+    }
+
+    /// Toggle an open/close marker pair (`<u>`/`</u>`, or a symmetric `**`)
     /// around the selection. No-op on an empty selection. Unwraps when the
     /// selection is already wrapped (markers just inside or just outside it),
     /// otherwise wraps — keeping the same text selected so presses toggle.
-    fn toggle_wrap(&mut self, marker: &str, cx: &mut Context<Self>) {
+    fn toggle_wrap_pair(&mut self, open: &str, close: &str, cx: &mut Context<Self>) {
         let sel = self.selected_range.clone();
         if sel.start >= sel.end {
             return;
         }
-        let ml = marker.len();
+        let (ol, cl) = (open.len(), close.len());
         let sel_text = &self.content[sel.clone()];
-        let (range, new, new_sel) = if sel_text.len() >= 2 * ml
-            && sel_text.starts_with(marker)
-            && sel_text.ends_with(marker)
-        {
-            // `**foo**` selected → strip the markers inside the selection.
-            let inner = self.content[sel.start + ml..sel.end - ml].to_string();
-            (sel.clone(), inner, sel.start..sel.end - 2 * ml)
-        } else if self.content[..sel.start].ends_with(marker)
-            && self.content[sel.end..].starts_with(marker)
-        {
-            // `foo` selected with the markers just outside → strip them.
-            (
-                sel.start - ml..sel.end + ml,
-                sel_text.to_string(),
-                sel.start - ml..sel.end - ml,
-            )
-        } else {
-            // Plain → wrap.
-            (
-                sel.clone(),
-                format!("{marker}{sel_text}{marker}"),
-                sel.start + ml..sel.end + ml,
-            )
-        };
+        let (range, new, new_sel) =
+            if sel_text.len() >= ol + cl && sel_text.starts_with(open) && sel_text.ends_with(close)
+            {
+                // `**foo**` selected → strip the markers inside the selection.
+                let inner = self.content[sel.start + ol..sel.end - cl].to_string();
+                (sel.clone(), inner, sel.start..sel.end - ol - cl)
+            } else if self.content[..sel.start].ends_with(open)
+                && self.content[sel.end..].starts_with(close)
+            {
+                // `foo` selected with the markers just outside → strip them.
+                (
+                    sel.start - ol..sel.end + cl,
+                    sel_text.to_string(),
+                    sel.start - ol..sel.end - ol,
+                )
+            } else {
+                // Plain → wrap.
+                (
+                    sel.clone(),
+                    format!("{open}{sel_text}{close}"),
+                    sel.start + ol..sel.end + ol,
+                )
+            };
         self.record_edit(&range, &new);
         self.content.replace_range(range.clone(), &new);
         self.selected_range = new_sel;
@@ -1867,6 +1878,15 @@ impl EditorState {
 
     fn code(&mut self, _: &Code, _: &mut Window, cx: &mut Context<Self>) {
         self.toggle_wrap("`", cx);
+    }
+
+    fn strike(&mut self, _: &Strike, _: &mut Window, cx: &mut Context<Self>) {
+        self.toggle_wrap("~~", cx);
+    }
+
+    fn underline(&mut self, _: &Underline, _: &mut Window, cx: &mut Context<Self>) {
+        // Markdown has no underline — the `<u>` tag, which both views honor.
+        self.toggle_wrap_pair("<u>", "</u>", cx);
     }
 
     /// Tab: on a list/quote item, indent the whole item one level (`tab_indent`
@@ -4295,6 +4315,8 @@ impl Render for EditorState {
             .on_action(cx.listener(Self::newline))
             .on_action(cx.listener(Self::bold))
             .on_action(cx.listener(Self::italic))
+            .on_action(cx.listener(Self::underline))
+            .on_action(cx.listener(Self::strike))
             .on_action(cx.listener(Self::code))
             .on_action(cx.listener(Self::indent))
             .on_action(cx.listener(Self::outdent))
@@ -4449,6 +4471,101 @@ impl Render for EditorState {
                     }),
                 ));
 
+                // Inline-format bar (Cditor-style): with a selection, a strip of
+                // B / I / S / <> buttons across the menu's top — each toggles its
+                // markdown wrap on the selection and closes the menu.
+                let fmt_btn = |id: &'static str| {
+                    div()
+                        .id(id)
+                        .w(px(28.))
+                        .h(px(24.))
+                        .rounded(px(4.))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .hover(move |s| s.bg(hover))
+                };
+                let format_bar = has_sel.then(|| {
+                    div()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap(px(2.))
+                        .px(px(6.))
+                        .py(px(4.))
+                        .child(
+                            fmt_btn("menu-fmt-bold")
+                                .font_weight(FontWeight::BOLD)
+                                .child("B")
+                                .on_mouse_down(
+                                    MouseButton::Left,
+                                    cx.listener(|editor, _: &MouseDownEvent, window, cx| {
+                                        cx.stop_propagation();
+                                        editor.menu = None;
+                                        editor.bold(&Bold, window, cx);
+                                    }),
+                                ),
+                        )
+                        .child(
+                            fmt_btn("menu-fmt-italic")
+                                .italic()
+                                .child("I")
+                                .on_mouse_down(
+                                    MouseButton::Left,
+                                    cx.listener(|editor, _: &MouseDownEvent, window, cx| {
+                                        cx.stop_propagation();
+                                        editor.menu = None;
+                                        editor.italic(&Italic, window, cx);
+                                    }),
+                                ),
+                        )
+                        .child(
+                            fmt_btn("menu-fmt-underline")
+                                .underline()
+                                .child("U")
+                                .on_mouse_down(
+                                    MouseButton::Left,
+                                    cx.listener(|editor, _: &MouseDownEvent, window, cx| {
+                                        cx.stop_propagation();
+                                        editor.menu = None;
+                                        editor.underline(&Underline, window, cx);
+                                    }),
+                                ),
+                        )
+                        .child(
+                            fmt_btn("menu-fmt-strike")
+                                .line_through()
+                                .child("S")
+                                .on_mouse_down(
+                                    MouseButton::Left,
+                                    cx.listener(|editor, _: &MouseDownEvent, window, cx| {
+                                        cx.stop_propagation();
+                                        editor.menu = None;
+                                        editor.strike(&Strike, window, cx);
+                                    }),
+                                ),
+                        )
+                        .child(
+                            fmt_btn("menu-fmt-code")
+                                .font_family(
+                                    self.markdown_style
+                                        .as_ref()
+                                        .map(|s| s.mono.family.clone())
+                                        .unwrap_or_else(|| "monospace".into()),
+                                )
+                                .text_size(px(12.))
+                                .child("<>")
+                                .on_mouse_down(
+                                    MouseButton::Left,
+                                    cx.listener(|editor, _: &MouseDownEvent, window, cx| {
+                                        cx.stop_propagation();
+                                        editor.menu = None;
+                                        editor.code(&Code, window, cx);
+                                    }),
+                                ),
+                        )
+                });
+
                 // Deferred + anchored to a window-space top layer with `.occlude()`,
                 // so it renders above the page chrome and captures the wheel — else a
                 // scroll over the popup scrolls the page behind it.
@@ -4465,6 +4582,7 @@ impl Render for EditorState {
                             .border_1()
                             .border_color(menu_border)
                             .rounded(px(6.))
+                            .shadow_md()
                             // Clip rows + thumb to the rounded box.
                             .overflow_hidden()
                             .text_color(menu_fg)
@@ -4474,6 +4592,8 @@ impl Render for EditorState {
                                 editor.menu = None;
                                 cx.notify();
                             }))
+                            .children(format_bar)
+                            .children(has_sel.then(|| div().h(px(1.)).bg(menu_border)))
                             .children((count > 0).then(|| {
                                 // The scroll viewport: shows ~6 rows, the rest scroll.
                                 div()
@@ -4571,6 +4691,7 @@ impl Render for EditorState {
                             .border_1()
                             .border_color(menu_border)
                             .rounded(px(6.))
+                            .shadow_md()
                             .overflow_hidden()
                             .text_color(menu_fg)
                             .text_size(px(13.))
@@ -4623,6 +4744,7 @@ impl Render for EditorState {
                             .border_1()
                             .border_color(menu_border)
                             .rounded(px(6.))
+                            .shadow_md()
                             .overflow_hidden()
                             .text_color(menu_fg)
                             .text_size(px(13.))
@@ -4674,6 +4796,7 @@ impl Render for EditorState {
                             .border_1()
                             .border_color(menu_border)
                             .rounded(px(6.))
+                            .shadow_md()
                             .overflow_hidden()
                             .text_color(menu_fg)
                             .text_size(px(13.))
@@ -4744,6 +4867,7 @@ impl Render for EditorState {
                             .border_1()
                             .border_color(menu_border)
                             .rounded(px(6.))
+                            .shadow_md()
                             .overflow_hidden()
                             .text_color(menu_fg)
                             .text_size(px(13.))

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -643,6 +643,8 @@ pub struct EditorState {
     /// See [`ShapeMemo`] — `RefCell` because the measure closure holds only a
     /// read borrow of the editor.
     shape_memo: std::cell::RefCell<Option<ShapeMemo>>,
+    /// See [`ScanData`].
+    scan_cache: std::cell::RefCell<Option<(u64, std::rc::Rc<ScanData>)>>,
     /// Bumped on every content mutation — cheap staleness key for caches
     /// (the UTF-16 conversion anchor below; a shape cache later).
     content_gen: u64,
@@ -775,6 +777,7 @@ impl EditorState {
             table_col_resize_rects: Vec::new(),
             table_resize_hover: None,
             shape_memo: std::cell::RefCell::new(None),
+            scan_cache: std::cell::RefCell::new(None),
             content_gen: 0,
             utf16_anchor: std::cell::Cell::new((0, 0, 0)),
             editing_block: None,
@@ -1023,13 +1026,13 @@ impl EditorState {
         if line.is_empty() {
             return;
         }
-        // Inside a fenced code block (odd count of ``` fences above), the
-        // text is verbatim — never rewrite it.
-        let fences = self.content[..line_start]
-            .lines()
-            .filter(|l| l.trim_start().starts_with("```"))
-            .count();
-        if fences % 2 == 1 || line.trim_start().starts_with("```") {
+        // Inside a fenced code block, the text is verbatim — never rewrite it.
+        // Fence parity comes from the cached scan (this runs on every boundary
+        // keystroke; the per-line rescan grew with the document).
+        let (row, _) = self.row_col(boundary);
+        if *self.scan_data().fence_odd.get(row).unwrap_or(&false)
+            || line.trim_start().starts_with("```")
+        {
             return;
         }
         let Some((r, replacement)) = f(line) else {
@@ -1331,6 +1334,36 @@ impl EditorState {
             .enumerate()
             .map(|(row, &top)| (top, self.line_h(row)))
             .collect()
+    }
+
+    /// The cached [`ScanData`] for the current content, rebuilding on a
+    /// generation mismatch.
+    fn scan_data(&self) -> std::rc::Rc<ScanData> {
+        if let Some((generation, data)) = self.scan_cache.borrow().as_ref()
+            && *generation == self.content_gen
+        {
+            return data.clone();
+        }
+        let lines: Vec<&str> = self.content.split('\n').collect();
+        let mut fence_odd = Vec::with_capacity(lines.len());
+        let mut odd = false;
+        for l in &lines {
+            fence_odd.push(odd);
+            if l.trim_start().starts_with("```") {
+                odd = !odd;
+            }
+        }
+        let data = std::rc::Rc::new(ScanData {
+            ordered: markdown_syntax::ordered_numbers(&lines),
+            tables: markdown_syntax::table_regions(&self.content),
+            mermaid: markdown_syntax::mermaid_blocks(&self.content),
+            math: markdown_syntax::math_regions(&self.content),
+            props: markdown_syntax::property_regions(&self.content),
+            alert_folds: markdown_syntax::alert_fold_regions(&self.content),
+            fence_odd,
+        });
+        *self.scan_cache.borrow_mut() = Some((self.content_gen, data.clone()));
+        data
     }
 
     /// The wrap-row height of logical line `row` (a heading is taller). Falls
@@ -3852,8 +3885,8 @@ impl EditorState {
             return None;
         }
         let cell = table_cell_at(t, col);
-        let regions = markdown_syntax::table_regions(&self.content);
-        let region = regions.iter().find(|r| r.lines.contains(&row))?;
+        let scan = self.scan_data();
+        let region = scan.tables.iter().find(|r| r.lines.contains(&row))?;
         Some(match region.aligns.get(cell) {
             Some(markdown_syntax::Align::Center) => CellAlign::Center,
             Some(markdown_syntax::Align::Right) => CellAlign::Right,
@@ -3874,8 +3907,8 @@ impl EditorState {
         let cell = table_cell_at(t, col);
         // Read the table's columns from the current content (fresh), so repeated
         // clicks build on the latest alignment, not a stale painted snapshot.
-        let regions = markdown_syntax::table_regions(&self.content);
-        let Some(region) = regions.iter().find(|r| r.lines.contains(&row)) else {
+        let scan = self.scan_data();
+        let Some(region) = scan.tables.iter().find(|r| r.lines.contains(&row)) else {
             return;
         };
         let mut aligns = region.aligns.clone();
@@ -3921,9 +3954,8 @@ impl EditorState {
     /// columns)`, or `None` outside a table.
     fn caret_table_block(&self) -> Option<(usize, usize, usize, usize)> {
         let (row, _) = self.row_col(self.cursor_offset());
-        let region = markdown_syntax::table_regions(&self.content)
-            .into_iter()
-            .find(|r| r.lines.contains(&row))?;
+        let scan = self.scan_data();
+        let region = scan.tables.iter().find(|r| r.lines.contains(&row))?;
         Some((
             region.lines.start,
             region.lines.start + 1,
@@ -4041,9 +4073,11 @@ impl EditorState {
     /// The caret row's table region, when inside one.
     fn caret_table_region(&self) -> Option<markdown_syntax::TableRegion> {
         let (row, _) = self.row_col(self.cursor_offset());
-        markdown_syntax::table_regions(&self.content)
-            .into_iter()
+        self.scan_data()
+            .tables
+            .iter()
             .find(|r| r.lines.contains(&row))
+            .cloned()
     }
 
     /// Duplicate the caret's row below itself (the header duplicates as the
@@ -4152,9 +4186,12 @@ impl EditorState {
     /// Persist a finished column-border drag: every column's current display
     /// width goes into the marker's `cols=` list (style preserved).
     fn commit_table_col_widths(&mut self, resize: TableColResize, cx: &mut Context<Self>) {
-        let Some(region) = markdown_syntax::table_regions(&self.content)
-            .into_iter()
+        let Some(region) = self
+            .scan_data()
+            .tables
+            .iter()
             .find(|r| r.lines.start == resize.header_row)
+            .cloned()
         else {
             return;
         };
@@ -4450,11 +4487,9 @@ impl EditorState {
         let line_end = self.line_end(row);
         let line = &self.content[line_start..line_end];
         // Inside a fenced code block the text is verbatim — no markers there.
-        let fences = self.content[..line_start]
-            .lines()
-            .filter(|l| l.trim_start().starts_with("```"))
-            .count();
-        if fences % 2 == 1 || line.trim_start().starts_with("```") {
+        if *self.scan_data().fence_odd.get(row).unwrap_or(&false)
+            || line.trim_start().starts_with("```")
+        {
             return None;
         }
         let pairs = markdown_syntax::fmt_marker_pairs(line, st);
@@ -6087,6 +6122,8 @@ fn shape_document(
     resize: Option<ImageResize>,
     // An in-progress column-border drag: that column takes the live width.
     col_resize: Option<TableColResize>,
+    // The content's cached structural scans (see [`ScanData`]).
+    scan: &ScanData,
     // Collapsed headings (trimmed source lines) — their section lines fold to
     // height 0 like a folded callout's body.
     folded_headings: &std::collections::HashSet<String>,
@@ -6102,7 +6139,7 @@ fn shape_document(
     let lines: Vec<&str> = content.split('\n').collect();
     // Ordered items paint their computed CommonMark position, not their
     // literal source digits (the reader renumbers the same way).
-    let ordered_nums = markdown_syntax::ordered_numbers(&lines);
+    let ordered_nums = &scan.ordered;
     // Rows a (non-empty) selection touches. A selected block reveals its raw
     // source just like the caret's block does, so what's highlighted is what a
     // copy carries — the per-line pass below already reveals inline markers on
@@ -6125,11 +6162,13 @@ fn shape_document(
     // block and the host has a rendered bitmap. The diagram paints on the block's
     // first line; the rest collapse. Caret inside / still rendering → raw code.
     let mermaid: Vec<(Range<usize>, BlockImg)> = match block_mermaid.filter(|_| md.is_some()) {
-        Some(f) => markdown_syntax::mermaid_blocks(content)
-            .into_iter()
+        Some(f) => scan
+            .mermaid
+            .iter()
             .filter(|(range, _)| {
                 caret_row.is_none_or(|cr| !range.contains(&cr)) && !sel_hits(range)
             })
+            .cloned()
             .filter_map(|(range, source)| {
                 // Sized by the provider's logical dimensions, like math below —
                 // never texture pixels ÷ window scale factor.
@@ -6157,9 +6196,11 @@ fn shape_document(
     // $$…$$ math blocks ready to render: caret outside + a typeset bitmap ready. Like
     // mermaid, the equation paints on the block's first line, the rest collapse.
     let math: Vec<(Range<usize>, BlockImg)> = match block_math.filter(|_| md.is_some()) {
-        Some(f) => markdown_syntax::math_regions(content)
-            .into_iter()
+        Some(f) => scan
+            .math
+            .iter()
             .filter(|r| caret_row.is_none_or(|cr| !r.range.contains(&cr)) && !sel_hits(&r.range))
+            .cloned()
             .filter_map(|r| {
                 // Sized by the provider's logical dimensions — NOT texture pixels
                 // ÷ window scale factor (see [`BlockMathFn`]: the raster's density
@@ -6191,9 +6232,11 @@ fn shape_document(
     // its lines collapse; the caret entering the region is filtered out here so
     // the raw source shows for editing.
     let props: Vec<(Range<usize>, PropPanel)> = match md {
-        Some(st) => markdown_syntax::property_regions(content)
-            .into_iter()
+        Some(st) => scan
+            .props
+            .iter()
             .filter(|r| caret_row.is_none_or(|cr| !r.contains(&cr)) && !sel_hits(r))
+            .cloned()
             .map(|r| {
                 let panel = build_prop_panel(
                     &lines,
@@ -6215,13 +6258,15 @@ fn shape_document(
     // Folded callouts (`> [!NOTE]-`): each region's BODY lines collapse (the
     // marker line stays, painting the label + chevron) unless the caret is
     // inside the region — reveal-on-caret, so arrowing in unfolds for editing.
-    let mut alert_folds: Vec<Range<usize>> = md
-        .map(|_| markdown_syntax::alert_fold_regions(content))
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|(r, folded)| *folded && caret_row.is_none_or(|cr| !r.contains(&cr)))
-        .map(|(r, _)| r)
-        .collect();
+    let mut alert_folds: Vec<Range<usize>> = if md.is_some() {
+        scan.alert_folds
+            .iter()
+            .filter(|(r, folded)| *folded && caret_row.is_none_or(|cr| !r.contains(&cr)))
+            .map(|(r, _)| r.clone())
+            .collect()
+    } else {
+        Vec::new()
+    };
     // Collapsed heading sections fold the same way: the heading line stays
     // (its chevron paints there), the section's lines go to height 0, and the
     // caret STRICTLY INSIDE THE BODY reveals — the fold state itself is
@@ -6248,11 +6293,9 @@ fn shape_document(
         Vec::new()
     };
     // Table regions (W4c); content-fit column widths shared by each region's rows.
-    let regions = md
-        .map(|_| markdown_syntax::table_regions(content))
-        .unwrap_or_default();
+    let regions: &[markdown_syntax::TableRegion] = if md.is_some() { &scan.tables } else { &[] };
     let mut region_cols: Vec<Vec<Pixels>> = Vec::with_capacity(regions.len());
-    for r in &regions {
+    for r in regions {
         region_cols.push(table_column_widths(
             &lines,
             r,
@@ -7992,6 +8035,24 @@ struct TableAffordance {
     accent: Hsla,
 }
 
+/// Content-derived structural scans — tables, ordered-list numbering,
+/// mermaid/math regions, property runs, foldable callouts, and per-line
+/// fence parity — cached per [`EditorState::content_gen`]. `shape_document`
+/// recomputed all of these on every call (twice a frame before the shape
+/// memo); now they rebuild only when the content actually changes, and the
+/// caret-driven table ops + auto-replace reuse the same scan.
+pub(crate) struct ScanData {
+    ordered: Vec<(u32, usize)>,
+    tables: Vec<markdown_syntax::TableRegion>,
+    mermaid: Vec<(Range<usize>, String)>,
+    math: Vec<markdown_syntax::MathRegion>,
+    props: Vec<Range<usize>>,
+    alert_folds: Vec<(Range<usize>, bool)>,
+    /// Whether each line STARTS inside a fenced code block (odd count of ```
+    /// fences above it).
+    fence_odd: Vec<bool>,
+}
+
 /// One frame's shaping, memoized between the measure pass and prepaint —
 /// both shape the IDENTICAL inputs, so the measure's result is handed to
 /// prepaint instead of shaping the whole document twice per frame. Consumed
@@ -8151,6 +8212,7 @@ impl Element for EditorElement {
                     (usize::MAX, usize::MAX)
                 };
                 let sf = window.scale_factor();
+                let scan = editor.scan_data();
                 let shaped = shape_document(
                     window,
                     &editor.content,
@@ -8180,6 +8242,7 @@ impl Element for EditorElement {
                     selection,
                     editor.image_resize,
                     editor.table_col_resize,
+                    &scan,
                     &editor.folded_headings,
                 );
                 // Mirror prepaint's `line_tops` walk exactly (same `line_pads`),
@@ -8319,6 +8382,7 @@ impl Element for EditorElement {
                     selection,
                     editor.image_resize,
                     editor.table_col_resize,
+                    &editor.scan_data(),
                     &editor.folded_headings,
                 )
             };

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -760,6 +760,16 @@ pub struct EditorState {
     /// run several times before a paint commits fresh `line_tops`; without
     /// this, one async height change compensates once per measure call.
     compensated: std::cell::Cell<bool>,
+    /// An active gutter block drag (Notion/Cditor-style reorder): the grabbed
+    /// block's first + last rows and the current drop boundary (a row index;
+    /// `== rows` drops at the document end).
+    line_drag: Option<(usize, usize, usize)>,
+    /// The row whose gutter grip the pointer hovers (mirrors prepaint's
+    /// computation) — tracked so hover changes repaint the grip.
+    grip_hover_row: Option<usize>,
+    /// Extra left offset for the drag grip — the host sets its line-number
+    /// gutter's width here so the grip sits beside the numbers, not on them.
+    grip_inset: Pixels,
     /// `content_gen` as of the last paint — a measure with the SAME generation
     /// but different heights means an async (non-edit) height change, the
     /// scroll-anchoring trigger.
@@ -904,6 +914,9 @@ impl EditorState {
             shape_caches: ShapeCaches::default(),
             shape_band: std::cell::Cell::new(None),
             compensated: std::cell::Cell::new(false),
+            line_drag: None,
+            grip_hover_row: None,
+            grip_inset: px(0.),
             content_gen: 0,
             utf16_anchor: std::cell::Cell::new((0, 0, 0)),
             editing_block: None,
@@ -2866,6 +2879,12 @@ impl EditorState {
     }
 
     fn on_mouse_up(&mut self, _: &MouseUpEvent, _: &mut Window, cx: &mut Context<Self>) {
+        // End a gutter block drag: splice the block at the drop boundary.
+        if let Some((bs, be, t)) = self.line_drag.take() {
+            self.apply_line_drag(bs, be, t, cx);
+            cx.notify();
+            return;
+        }
         // End an image-resize drag by persisting the rounded width as `{width=N}`
         // in that image's source line (through the normal mutation path, so it
         // joins the undo history + emits Changed); the next paint shows the saved
@@ -2897,6 +2916,16 @@ impl EditorState {
         // matches `block_img`, no snap-back on release, and it can't run off the
         // page). The paint reads this live width for the dragged image (aspect
         // preserved).
+        // While dragging a block by its gutter grip, track the drop boundary
+        // (snapped out of rendered regions); paint draws the indicator there.
+        if let Some((bs, be, t)) = self.line_drag {
+            let b = self.snap_drop_boundary(self.drop_boundary_at(event.position));
+            if b != t {
+                self.line_drag = Some((bs, be, b));
+                cx.notify();
+            }
+            return;
+        }
         // While dragging a table column's border, track the pointer: the new
         // width is the grab width plus the travel, floored so the column can't
         // vanish. Shaping applies it live (see `table_column_widths`).
@@ -3352,6 +3381,203 @@ impl EditorState {
                 (range_start + text.find('\n').map_or(0, |i| i + 1)).min(self.content.len());
             self.selected_range = caret..caret;
         }
+    }
+
+    /// Extra left offset for the gutter drag grip (e.g. the host's
+    /// line-number gutter width), so the grip clears other gutter chrome.
+    pub fn set_grip_inset(&mut self, inset: Pixels) {
+        self.grip_inset = inset;
+    }
+
+    /// The line span the gutter grip drags as one unit: whole fenced/rendered
+    /// regions (code, math, mermaid, tables incl. their style marker,
+    /// property panels), a quote/callout run, a list item with its
+    /// deeper-indented children — otherwise the single line.
+    fn drag_block_rows(&self, row: usize) -> (usize, usize) {
+        let scan = self.scan_data();
+        let starts = self.line_starts();
+        let last_row = starts.len().saturating_sub(1);
+        let line_at = |r: usize| &self.content[starts[r]..self.line_end(r)];
+        if let Some(m) = scan
+            .math
+            .iter()
+            .find(|m| m.range.contains(&row) || m.marker_line == Some(row))
+        {
+            let first = m.marker_line.unwrap_or(m.range.start).min(m.range.start);
+            return (first, m.range.end.saturating_sub(1).max(m.range.start));
+        }
+        if let Some((r, _)) = scan.mermaid.iter().find(|(r, _)| r.contains(&row)) {
+            return (r.start, r.end.saturating_sub(1).max(r.start));
+        }
+        if let Some(t) = scan
+            .tables
+            .iter()
+            .find(|t| t.lines.contains(&row) || t.marker_line == Some(row))
+        {
+            let first = t.marker_line.unwrap_or(t.lines.start).min(t.lines.start);
+            return (first, t.lines.end.saturating_sub(1).max(t.lines.start));
+        }
+        if let Some(p) = scan.props.iter().find(|r| r.contains(&row)) {
+            return (p.start, p.end.saturating_sub(1).max(p.start));
+        }
+        if scan.fence_odd.get(row).copied().unwrap_or(false)
+            || line_at(row).trim_start().starts_with("```")
+        {
+            let open = (0..=row)
+                .rev()
+                .find(|&r| !scan.fence_odd.get(r).copied().unwrap_or(false))
+                .unwrap_or(0);
+            let close = ((open + 1)..=last_row)
+                .find(|&r| line_at(r).trim_start().starts_with("```"))
+                .unwrap_or(last_row);
+            return (open, close);
+        }
+        if line_at(row).trim_start().starts_with('>') {
+            let is_q = |r: usize| line_at(r).trim_start().starts_with('>');
+            let mut first = row;
+            while first > 0 && is_q(first - 1) {
+                first -= 1;
+            }
+            let mut last = row;
+            while last < last_row && is_q(last + 1) {
+                last += 1;
+            }
+            return (first, last);
+        }
+        if markdown_syntax::list_prefix(line_at(row)).is_some() {
+            let indent = |r: usize| {
+                let l = line_at(r);
+                l.len() - l.trim_start().len()
+            };
+            let base = indent(row);
+            let mut last = row;
+            while last < last_row && !line_at(last + 1).trim().is_empty() && indent(last + 1) > base
+            {
+                last += 1;
+            }
+            return (row, last);
+        }
+        (row, row)
+    }
+
+    /// The row whose gutter grip the pointer would hover (the event-time
+    /// mirror of prepaint's grip computation, for repaint change-detection).
+    fn grip_hover_row_at(&self, position: Point<Pixels>) -> Option<usize> {
+        let bounds = self.last_bounds?;
+        if self.markdown_style.is_none()
+            || self.line_drag.is_some()
+            || position.x < bounds.origin.x - px(26.) - self.grip_inset
+            || position.x > bounds.origin.x + bounds.size.width
+        {
+            return None;
+        }
+        let y = position.y - bounds.origin.y;
+        (0..self.line_tops.len()).find(|&i| {
+            let h = self.line_h(i) * self.row_span(i) as f32;
+            h > px(0.5) && y >= self.line_tops[i] && y < self.line_tops[i] + h
+        })
+    }
+
+    /// The drop boundary (a between-rows index) nearest the pointer, from the
+    /// last paint's committed geometry.
+    fn drop_boundary_at(&self, position: Point<Pixels>) -> usize {
+        let Some(bounds) = self.last_bounds else {
+            return 0;
+        };
+        let y = position.y - bounds.origin.y;
+        for i in 0..self.line_tops.len() {
+            let mid = self.line_tops[i] + self.line_h(i) * self.row_span(i) as f32 / 2.;
+            if y < mid {
+                return i;
+            }
+        }
+        self.line_tops.len()
+    }
+
+    /// Clamp a drop boundary out of the interior of any rendered region — a
+    /// block can't land inside a table, fence, math block, or property panel.
+    fn snap_drop_boundary(&self, mut b: usize) -> usize {
+        let scan = self.scan_data();
+        let snap = |b: usize, s: usize, e: usize| {
+            if b > s && b < e {
+                if b - s <= e - b { s } else { e }
+            } else {
+                b
+            }
+        };
+        for m in scan.math.iter() {
+            let s = m.marker_line.unwrap_or(m.range.start).min(m.range.start);
+            b = snap(b, s, m.range.end);
+        }
+        for (r, _) in scan.mermaid.iter() {
+            b = snap(b, r.start, r.end);
+        }
+        for t in scan.tables.iter() {
+            let s = t.marker_line.unwrap_or(t.lines.start).min(t.lines.start);
+            b = snap(b, s, t.lines.end);
+        }
+        for p in scan.props.iter() {
+            b = snap(b, p.start, p.end);
+        }
+        // Inside a code fence: snap to the opening fence or past the close.
+        if scan.fence_odd.get(b).copied().unwrap_or(false) {
+            let starts = self.line_starts();
+            let line_at = |r: usize| &self.content[starts[r]..self.line_end(r)];
+            let open = (0..b)
+                .rev()
+                .find(|&r| !scan.fence_odd.get(r).copied().unwrap_or(false))
+                .unwrap_or(0);
+            let close = (b..starts.len())
+                .find(|&r| line_at(r).trim_start().starts_with("```"))
+                .map(|c| c + 1)
+                .unwrap_or(starts.len());
+            b = if b - open <= close - b { open } else { close };
+        }
+        b
+    }
+
+    /// Land the grabbed block at boundary `t` — one undoable splice of the
+    /// span between the block and the target, caret seated on the block.
+    fn apply_line_drag(&mut self, bs: usize, be: usize, t: usize, cx: &mut Context<Self>) {
+        let starts = self.line_starts();
+        let n = starts.len();
+        if bs >= n || be >= n || (t >= bs && t <= be + 1) {
+            return; // dropped onto itself (or stale rows) — no-op
+        }
+        let block_start = starts[bs];
+        let block_end = self.line_end(be);
+        let block_text = self.content[block_start..block_end].to_string();
+        if t > be {
+            // Down: [block \n between...] → [between... block (\n)]
+            let target_off = if t >= n {
+                self.content.len()
+            } else {
+                starts[t]
+            };
+            let after_block = (block_end + 1).min(self.content.len());
+            let mut new = self.content[after_block..target_off].to_string();
+            if !new.is_empty() && !new.ends_with('\n') {
+                new.push('\n');
+            }
+            let rest_len = new.len();
+            new.push_str(&block_text);
+            if t < n {
+                new.push('\n');
+            }
+            self.replace_range(block_start..target_off, &new, cx);
+            let caret = block_start + rest_len;
+            self.selected_range = caret..caret;
+        } else {
+            // Up: [between... block] → [block \n between...]
+            let target_off = starts[t];
+            let between = &self.content[target_off..block_start];
+            let mut new = block_text.clone();
+            new.push('\n');
+            new.push_str(&between[..between.len().saturating_sub(1)]);
+            self.replace_range(target_off..block_end, &new, cx);
+            self.selected_range = target_off..target_off;
+        }
+        cx.emit(EditorEvent::Changed);
     }
 
     // --- Selection helpers ---------------------------------------------------
@@ -8761,6 +8987,9 @@ struct PrepaintState {
     wrapped: Vec<WrappedLine>,
     /// Per-line wrap-row count (see [`EditorState::wrap_rows`]).
     wrap_rows: Vec<usize>,
+    /// The hovered line's gutter drag grip (line, rect) + its cursor hitbox.
+    grip: Option<(usize, Bounds<Pixels>)>,
+    grip_hb: Option<Hitbox>,
     /// Top offset of each logical line relative to the editor's top.
     line_tops: Vec<Pixels>,
     /// Per-logical-line wrap-row height (variable for headings + images).
@@ -9508,12 +9737,43 @@ impl Element for EditorElement {
             }
         }
 
+        // Gutter drag grip (Cditor/Notion-style block reorder): hovering a
+        // line reveals a six-dot handle in the left margin; pressing it grabs
+        // the line's block (see `drag_block_rows`). Skipped while a drag is
+        // live — the grip would chase the pointer.
+        let mouse = window.mouse_position();
+        let mut grip: Option<(usize, Bounds<Pixels>)> = None;
+        let mut grip_hb: Option<Hitbox> = None;
+        let grip_left = bounds.origin.x - px(22.) - editor.grip_inset;
+        if editor.markdown_style.is_some()
+            && editor.line_drag.is_none()
+            && mouse.x >= grip_left - px(4.)
+            && mouse.x <= bounds.origin.x + bounds.size.width
+        {
+            let y = mouse.y - bounds.origin.y;
+            let row = (0..line_tops.len()).find(|&i| {
+                let h = line_heights[i] * wrap_rows[i] as f32;
+                h > px(0.5) && y >= line_tops[i] && y < line_tops[i] + h
+            });
+            if let Some(row) = row {
+                let sz = px(14.);
+                let rect = Bounds::new(
+                    point(
+                        grip_left,
+                        bounds.origin.y + line_tops[row] + (line_heights[row] - sz) / 2.,
+                    ),
+                    size(sz, sz),
+                );
+                grip_hb = Some(window.insert_hitbox(rect, HitboxBehavior::Normal));
+                grip = Some((row, rect));
+            }
+        }
+
         // Table interaction (issue #16, Cditor-style): the hovered row/column
         // gets an ACCENT OUTLINE (no fill) plus a small pill ON the table border
         // — "+" inserts after it, "−" deletes it. The caret's cell is outlined
         // too. Paint shows/cursors them only while hovered; on_mouse_down
         // hit-tests the committed pill rects.
-        let mouse = window.mouse_position();
         let mut table_zones: Vec<Bounds<Pixels>> = Vec::new();
         let mut row_aff: Option<TableAffordance> = None;
         let mut col_aff: Option<TableAffordance> = None;
@@ -9893,6 +10153,8 @@ impl Element for EditorElement {
         PrepaintState {
             wrapped,
             wrap_rows,
+            grip,
+            grip_hb,
             line_tops,
             line_heights,
             widgets,
@@ -10499,6 +10761,124 @@ impl Element for EditorElement {
                     gr.accent,
                 ));
             }
+        }
+
+        // Gutter drag grip: six muted dots on the hovered line; while a drag
+        // is live, a full-width accent bar marks the drop boundary instead.
+        {
+            let ed = self.editor.read(cx);
+            let accent = ed.markdown_style.as_ref().map_or(text_color, |s| s.link);
+            let mut dot_c = ed.markdown_style.as_ref().map_or(text_color, |s| s.marker);
+            dot_c.a = (dot_c.a * 1.6).min(0.9);
+            if let Some((bs, be, t)) = ed.line_drag {
+                let y = prepaint.line_tops.get(t).copied().unwrap_or_else(|| {
+                    let i = prepaint.line_tops.len().saturating_sub(1);
+                    prepaint.line_tops.last().copied().unwrap_or(px(0.))
+                        + prepaint.line_heights.get(i).copied().unwrap_or(px(0.))
+                            * prepaint.wrap_rows.get(i).copied().unwrap_or(1) as f32
+                });
+                // No bar when the boundary is a no-op (inside the block).
+                if !(t >= bs && t <= be + 1) {
+                    window.paint_quad(fill(
+                        Bounds::new(
+                            point(bounds.origin.x, bounds.origin.y + y - px(1.)),
+                            size(bounds.size.width, px(2.)),
+                        ),
+                        accent,
+                    ));
+                }
+                if let Some(hb) = &prepaint.grip_hb {
+                    window.set_cursor_style(CursorStyle::ClosedHand, hb);
+                }
+            } else if let Some((_, rect)) = prepaint.grip {
+                let d = px(2.5);
+                let gap = px(4.5);
+                for col in 0..2 {
+                    for dr in 0..3 {
+                        let dot = Bounds::new(
+                            point(
+                                rect.origin.x + px(2.) + gap * col as f32,
+                                rect.origin.y + px(1.) + gap * dr as f32,
+                            ),
+                            size(d, d),
+                        );
+                        window.paint_quad(fill(dot, dot_c).corner_radii(Corners::all(px(1.25))));
+                    }
+                }
+                if let Some(hb) = &prepaint.grip_hb {
+                    window.set_cursor_style(CursorStyle::OpenHand, hb);
+                }
+            }
+        }
+        // The grip sits OUTSIDE the editor div's bounds, so the div's own
+        // mouse listeners never see a press on it — start the drag from a
+        // window-level listener gated on the grip's rect instead.
+        if let Some((row, rect)) = prepaint.grip {
+            let editor = self.editor.clone();
+            window.on_mouse_event(move |e: &MouseDownEvent, phase, _window, cx| {
+                if phase == gpui::DispatchPhase::Bubble
+                    && e.button == MouseButton::Left
+                    && rect.contains(&e.position)
+                {
+                    editor.update(cx, |ed, cx| {
+                        let (bs, be) = ed.drag_block_rows(row);
+                        ed.line_drag = Some((bs, be, bs));
+                        ed.is_selecting = false;
+                        ed.menu = None;
+                        cx.notify();
+                    });
+                    cx.stop_propagation();
+                }
+            });
+        }
+        // Track the hovered grip row from a window-level listener — the
+        // gutter sits outside the div, so its own on_mouse_move never fires
+        // there. Notifies only when the hovered row changes.
+        {
+            let editor = self.editor.clone();
+            window.on_mouse_event(move |e: &MouseMoveEvent, phase, _w, cx| {
+                if phase == gpui::DispatchPhase::Bubble {
+                    editor.update(cx, |ed, cx| {
+                        let gr = ed.grip_hover_row_at(e.position);
+                        if gr != ed.grip_hover_row {
+                            ed.grip_hover_row = gr;
+                            cx.notify();
+                        }
+                    });
+                }
+            });
+        }
+        // While a drag is live the pointer usually travels down the GUTTER —
+        // still outside the div, where its on_mouse_move / on_mouse_up never
+        // fire — so track the boundary and land the drop from window-level
+        // listeners too (the div's own handlers cover in-bounds travel; both
+        // paths take/compare the same state, so double delivery is a no-op).
+        if self.editor.read(cx).line_drag.is_some() {
+            let editor = self.editor.clone();
+            window.on_mouse_event(move |e: &MouseMoveEvent, phase, _w, cx| {
+                if phase == gpui::DispatchPhase::Bubble {
+                    editor.update(cx, |ed, cx| {
+                        if let Some((bs, be, t)) = ed.line_drag {
+                            let b = ed.snap_drop_boundary(ed.drop_boundary_at(e.position));
+                            if b != t {
+                                ed.line_drag = Some((bs, be, b));
+                                cx.notify();
+                            }
+                        }
+                    });
+                }
+            });
+            let editor = self.editor.clone();
+            window.on_mouse_event(move |e: &MouseUpEvent, phase, _w, cx| {
+                if phase == gpui::DispatchPhase::Bubble && e.button == MouseButton::Left {
+                    editor.update(cx, |ed, cx| {
+                        if let Some((bs, be, t)) = ed.line_drag.take() {
+                            ed.apply_line_drag(bs, be, t, cx);
+                            cx.notify();
+                        }
+                    });
+                }
+            });
         }
 
         let wrapped = std::mem::take(&mut prepaint.wrapped);

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -10075,6 +10075,12 @@ impl Element for EditorElement {
                         continue;
                     };
                     let lh = line_heights.get(row).copied().unwrap_or(base_lh);
+                    // A collapsed row (hidden marker/fence line, the table's
+                    // `|---|` separator, a folded body) has no visible text —
+                    // painting its quad would smear a band over its neighbors.
+                    if lh <= px(0.5) {
+                        continue;
+                    }
                     let top = line_tops[row];
                     let line_start = starts[row];
                     let a = s.max(line_start) - line_start;
@@ -10082,22 +10088,43 @@ impl Element for EditorElement {
                     // Table row: highlight between the cell positions of the selection
                     // ends (not raw-source geometry).
                     if let Some(t) = tables.get(row).and_then(Option::as_ref) {
+                        let table_w: Pixels = t.col_widths.iter().copied().sum();
                         let tleft = bounds.left() + px(TABLE_GUTTER)
                             - editor.table_sx(
                                 table_header_row(t, row),
-                                t.col_widths.iter().copied().sum(),
+                                table_w,
                                 bounds.size.width - px(TABLE_GUTTER),
                             );
-                        if let (Some((xa, ..)), Some((xb, ..))) = (
-                            table_caret_pos(t, a, tleft, &font, font_size, window),
-                            table_caret_pos(t, b, tleft, &font, font_size, window),
-                        ) {
-                            let (lo, hi) = (xa.min(xb), xa.max(xb));
-                            let cy = bounds.top() + top + (lh - base_lh) / 2.;
+                        // Endpoint x's: inside a cell, the exact caret x; at
+                        // or past the row's cell span — or in an empty cell
+                        // the shaper can't position — the table's edge, so
+                        // vacant trailing cells highlight too.
+                        let first_start = t.cell_ranges.first().map_or(0, |r| r.start);
+                        let last_end = t.cell_ranges.last().map_or(0, |r| r.end);
+                        let xa = if a <= first_start {
+                            tleft
+                        } else {
+                            table_caret_pos(t, a, tleft, &font, font_size, window)
+                                .map_or(tleft, |(x, ..)| x)
+                        };
+                        let xb = if b >= last_end {
+                            tleft + table_w
+                        } else {
+                            table_caret_pos(t, b, tleft, &font, font_size, window)
+                                .map_or(tleft + table_w, |(x, ..)| x)
+                        };
+                        // Clamp to the table's visible band — a wide
+                        // (scrolling) table's cells extend past the
+                        // viewport, but its highlight must not. Full row
+                        // height, so wrapped cells highlight every wrap row.
+                        let vis_l = bounds.left() + px(TABLE_GUTTER);
+                        let vis_r = bounds.left() + bounds.size.width;
+                        let (lo, hi) = (xa.min(xb).max(vis_l), xa.max(xb).min(vis_r));
+                        if hi > lo {
                             sels.push(fill(
                                 Bounds::from_corners(
-                                    point(lo, cy),
-                                    point(hi.max(lo + px(2.)), cy + base_lh),
+                                    point(lo, bounds.top() + top),
+                                    point(hi, bounds.top() + top + lh),
                                 ),
                                 color,
                             ));

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -7952,10 +7952,11 @@ fn shape_document(
 
         // Code lines are inset by CODE_INSET on each side; a gutter mark insets the
         // left only. Either wraps at a correspondingly narrower width. A table
-        // row's raw source never wraps — it renders as a grid row (a wide
-        // table scrolls instead), and a wrapped hidden source would multiply
-        // the row's advance by its wrap count.
-        let line_wrap = if table.is_some() {
+        // row or widget line (image, chip) never wraps its raw source — a
+        // grid row / the widget renders instead, and a wrapped hidden source
+        // would multiply the row's advance by its wrap count. (Revealed-on-
+        // caret lines have `table`/`widget` = None here and wrap normally.)
+        let line_wrap = if table.is_some() || widget.is_some() {
             None
         } else if is_code {
             wrap_width.map(|w| (w - px(2. * CODE_INSET)).max(px(0.)))

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -640,6 +640,18 @@ pub struct EditorState {
     table_col_resize_rects: Vec<(Bounds<Pixels>, usize, usize, f32)>,
     /// The band index the pointer is on (repaint-on-change for its accent line).
     table_resize_hover: Option<usize>,
+    /// See [`ShapeMemo`] — `RefCell` because the measure closure holds only a
+    /// read borrow of the editor.
+    shape_memo: std::cell::RefCell<Option<ShapeMemo>>,
+    /// Bumped on every content mutation — cheap staleness key for caches
+    /// (the UTF-16 conversion anchor below; a shape cache later).
+    content_gen: u64,
+    /// Resume point for UTF-8↔UTF-16 conversion: `(generation, utf8, utf16)`
+    /// of the last converted offset. IME composition fires conversions many
+    /// times per keystroke, clustered near the caret — resuming from the
+    /// anchor makes them O(distance) instead of O(document) (CJK latency
+    /// grew with note size; found auditing against Cditor's per-block IME).
+    utf16_anchor: std::cell::Cell<(u64, usize, usize)>,
     /// A `$$…$$` block being edited in-line: its byte range + the host-supplied view (the
     /// structural editor) painted in a reserved gap at the block's spot. `None` = none.
     editing_block: Option<EditingBlock>,
@@ -762,6 +774,9 @@ impl EditorState {
             table_col_resize: None,
             table_col_resize_rects: Vec::new(),
             table_resize_hover: None,
+            shape_memo: std::cell::RefCell::new(None),
+            content_gen: 0,
+            utf16_anchor: std::cell::Cell::new((0, 0, 0)),
             editing_block: None,
             inline_math_rects: Vec::new(),
             editing_inline: None,
@@ -824,6 +839,7 @@ impl EditorState {
 
     /// Replace the whole document; resets the caret to the start.
     pub fn set_text(&mut self, text: impl Into<String>, cx: &mut Context<Self>) {
+        self.content_gen += 1;
         self.content = text.into();
         self.selected_range = 0..0;
         self.selection_reversed = false;
@@ -2148,6 +2164,7 @@ impl EditorState {
     }
 
     fn restore(&mut self, s: Snapshot) {
+        self.content_gen += 1;
         self.content = s.content;
         let caret = s.caret.min(self.content.len());
         self.selected_range = caret..caret;
@@ -2159,6 +2176,7 @@ impl EditorState {
     /// inserts (or a run of deletes) into one undo step so typing isn't undone
     /// one character at a time.
     fn record_edit(&mut self, range: &Range<usize>, new_text: &str) {
+        self.content_gen += 1;
         let kind = if new_text.is_empty() {
             EditKind::Delete
         } else if range.start == range.end
@@ -4328,29 +4346,44 @@ impl EditorState {
     // --- UTF-16 + grapheme boundaries (IME / cursor movement) ----------------
 
     fn offset_from_utf16(&self, offset: usize) -> usize {
-        let mut utf8 = 0;
-        let mut utf16 = 0;
-        for ch in self.content.chars() {
+        let (mut utf8, mut utf16) = self.utf16_resume(offset, false);
+        for ch in self.content[utf8..].chars() {
             if utf16 >= offset {
                 break;
             }
             utf16 += ch.len_utf16();
             utf8 += ch.len_utf8();
         }
+        self.utf16_anchor.set((self.content_gen, utf8, utf16));
         utf8
     }
 
     fn offset_to_utf16(&self, offset: usize) -> usize {
-        let mut utf16 = 0;
-        let mut utf8 = 0;
-        for ch in self.content.chars() {
+        let (mut utf8, mut utf16) = self.utf16_resume(offset, true);
+        for ch in self.content[utf8..].chars() {
             if utf8 >= offset {
                 break;
             }
             utf8 += ch.len_utf8();
             utf16 += ch.len_utf16();
         }
+        self.utf16_anchor.set((self.content_gen, utf8, utf16));
         utf16
+    }
+
+    /// Where a conversion can start: the saved anchor when it's from the
+    /// current content generation and at/before the target (`by_utf8` picks
+    /// which unit the target is in), else the document start. IME composition
+    /// converts monotonically-close offsets many times per keystroke, so this
+    /// turns O(document) scans into O(distance-from-anchor).
+    fn utf16_resume(&self, target: usize, by_utf8: bool) -> (usize, usize) {
+        let (generation, utf8, utf16) = self.utf16_anchor.get();
+        let anchor_pos = if by_utf8 { utf8 } else { utf16 };
+        if generation == self.content_gen && anchor_pos <= target && utf8 <= self.content.len() {
+            (utf8, utf16)
+        } else {
+            (0, 0)
+        }
     }
 
     fn range_to_utf16(&self, range: &Range<usize>) -> Range<usize> {
@@ -4565,6 +4598,7 @@ impl EntityInputHandler for EditorState {
             .map(|r| self.range_from_utf16(r))
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
+        self.content_gen += 1;
         self.content =
             self.content[0..range.start].to_owned() + new_text + &self.content[range.end..];
         self.marked_range =
@@ -4596,7 +4630,23 @@ impl EntityInputHandler for EditorState {
         let p = line.position_for_index(self.display_col(row, col), lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
         let x = bounds.left() + p.x + self.line_inset(row);
-        Some(Bounds::from_corners(point(x, top), point(x, top + lh)))
+        // Span the whole range when it stays on one wrap row (the common IME
+        // composition), so the candidate window anchors under the marked TEXT
+        // rather than a zero-width bar at its start. Multi-row ranges keep the
+        // start-anchored bar.
+        let (erow, ecol) = self.row_col(range.end);
+        let x2 = if erow == row && range.end > range.start {
+            line.position_for_index(self.display_col(row, ecol), lh)
+                .filter(|e| e.y == p.y)
+                .map(|e| bounds.left() + e.x + self.line_inset(row))
+                .unwrap_or(x)
+        } else {
+            x
+        };
+        Some(Bounds::from_corners(
+            point(x, top),
+            point(x2.max(x), top + lh),
+        ))
     }
 
     fn character_index_for_point(
@@ -7942,6 +7992,20 @@ struct TableAffordance {
     accent: Hsla,
 }
 
+/// One frame's shaping, memoized between the measure pass and prepaint —
+/// both shape the IDENTICAL inputs, so the measure's result is handed to
+/// prepaint instead of shaping the whole document twice per frame. Consumed
+/// (taken) by prepaint, so it can never go stale across frames; a key
+/// mismatch (e.g. the resolved width differs from the available width)
+/// falls back to shaping.
+struct ShapeMemo {
+    wrap_width: Option<Pixels>,
+    caret_row: Option<usize>,
+    selection: (usize, usize),
+    font_size: Pixels,
+    shaped: ShapedLines,
+}
+
 struct PrepaintState {
     wrapped: Vec<WrappedLine>,
     /// Top offset of each logical line relative to the editor's top.
@@ -8087,7 +8151,7 @@ impl Element for EditorElement {
                     (usize::MAX, usize::MAX)
                 };
                 let sf = window.scale_factor();
-                let (wrapped, heights, _, backgrounds, tables, _, _, _) = shape_document(
+                let shaped = shape_document(
                     window,
                     &editor.content,
                     &text_style.font(),
@@ -8120,9 +8184,11 @@ impl Element for EditorElement {
                 );
                 // Mirror prepaint's `line_tops` walk exactly (same `line_pads`),
                 // or the element lays out shorter than it paints.
+                let (wrapped, heights, backgrounds, tables) =
+                    (&shaped.0, &shaped.1, &shaped.3, &shaped.4);
                 let mut y = px(0.);
                 let mut needed = px(0.);
-                for (i, (line, h)) in wrapped.iter().zip(&heights).enumerate() {
+                for (i, (line, h)) in wrapped.iter().zip(heights).enumerate() {
                     let tbl = tables.get(i).and_then(Option::as_ref);
                     let (top, bot) = line_pads(backgrounds[i], tbl);
                     y += top;
@@ -8142,6 +8208,14 @@ impl Element for EditorElement {
                     }
                     y += row_h + bot;
                 }
+                // Hand the shaping to this frame's prepaint (see ShapeMemo).
+                *editor.shape_memo.borrow_mut() = Some(ShapeMemo {
+                    wrap_width,
+                    caret_row,
+                    selection,
+                    font_size,
+                    shaped,
+                });
                 y.max(base_lh).max(needed)
             };
             let width = wrap_width.or(known.width).unwrap_or(px(0.));
@@ -8184,8 +8258,18 @@ impl Element for EditorElement {
             (usize::MAX, usize::MAX)
         };
         let sf = window.scale_factor();
+        // The measure pass already shaped these exact inputs this frame — use
+        // its result instead of shaping the whole document a second time.
+        let memo = editor.shape_memo.borrow_mut().take().filter(|m| {
+            m.wrap_width == wrap_width
+                && m.caret_row == caret_row
+                && m.selection == selection
+                && m.font_size == font_size
+        });
         let (wrapped, line_heights, widgets, backgrounds, tables, maps, marks, inline_maths) =
-            if editor.content.is_empty() {
+            if let Some(m) = memo {
+                m.shaped
+            } else if editor.content.is_empty() {
                 let w = shape_all(
                     window,
                     &editor.placeholder,

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -540,29 +540,61 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
     while i < end {
         let c = b[i];
         // Inline code: `code` — backticks are hideable markers, the body a
-        // highlight (code color on a tint, body font) matching the reading view.
-        if c == b'`'
-            && let Some(close) = find1(b, i + 1, end, b'`')
-        {
-            fmt_marker(out, i..i + 1, st.marker);
-            push(
-                out,
-                i + 1..close,
-                Style {
-                    color: Some(st.code),
-                    bg: Some(st.code_bg),
-                    ..Default::default()
-                },
-            );
-            fmt_marker(out, close..close + 1, st.marker);
-            i = close + 1;
+        // highlight (code color on a tint, body font) matching the reading
+        // view. CommonMark run matching: an opening run of N backticks closes
+        // at the next run of EXACTLY N, so ``a`b`` keeps its inner backtick
+        // (backslashes are literal INSIDE a span; only the opener can be
+        // escaped).
+        if c == b'`' && !is_backslash_escaped(b, i) {
+            let mut n = 1;
+            while i + n < end && b[i + n] == b'`' {
+                n += 1;
+            }
+            let mut j = i + n;
+            let mut close = None;
+            while j < end {
+                if b[j] == b'`' {
+                    let mut m = 1;
+                    while j + m < end && b[j + m] == b'`' {
+                        m += 1;
+                    }
+                    if m == n {
+                        close = Some(j);
+                        break;
+                    }
+                    j += m;
+                } else {
+                    j += 1;
+                }
+            }
+            if let Some(close) = close {
+                fmt_marker(out, i..i + n, st.marker);
+                push(
+                    out,
+                    i + n..close,
+                    Style {
+                        color: Some(st.code),
+                        bg: Some(st.code_bg),
+                        ..Default::default()
+                    },
+                );
+                fmt_marker(out, close..close + n, st.marker);
+                i = close + n;
+                continue;
+            }
+            // No matching run: the whole backtick STRING is one token
+            // (CommonMark) — skip past it so a shorter run inside it can't
+            // start a span the reader wouldn't.
+            i += n;
             continue;
         }
-        // Bold: **text** (check before single-* italic).
+        // Bold: **text** (check before single-* italic). A `\*` (escaped)
+        // opener or closer is literal text, matching the reader's CommonMark.
         if c == b'*'
+            && !is_backslash_escaped(b, i)
             && i + 1 < end
             && b[i + 1] == b'*'
-            && let Some(close) = find2(b, i + 2, end, b'*', b'*')
+            && let Some(close) = find2_unescaped(b, i + 2, end, b'*', b'*')
         {
             fmt_marker(out, i..i + 2, st.marker);
             push(
@@ -577,9 +609,10 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             i = close + 2;
             continue;
         }
-        // Italic: *text*.
+        // Italic: *text* — escaped `\*` stays literal.
         if c == b'*'
-            && let Some(close) = find1(b, i + 1, end, b'*')
+            && !is_backslash_escaped(b, i)
+            && let Some(close) = find1_unescaped(b, i + 1, end, b'*')
             && close > i + 1
         {
             fmt_marker(out, i..i + 1, st.marker);
@@ -643,9 +676,10 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         }
         // Strikethrough: ~~text~~
         if c == b'~'
+            && !is_backslash_escaped(b, i)
             && i + 1 < end
             && b[i + 1] == b'~'
-            && let Some(close) = find2(b, i + 2, end, b'~', b'~')
+            && let Some(close) = find2_unescaped(b, i + 2, end, b'~', b'~')
         {
             fmt_marker(out, i..i + 2, st.marker);
             push(
@@ -663,6 +697,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         // Footnote reference: [^label] — rendered `[label]` in link color (the
         // `^` hidden), matching the reading view's resolved marker.
         if c == b'['
+            && !is_backslash_escaped(b, i)
             && i + 1 < end
             && b[i + 1] == b'^'
             && let Some(rb) = find1(b, i + 2, end, b']')
@@ -690,6 +725,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         }
         // Wiki-link: [[Page]] (check before single-[ link).
         if c == b'['
+            && !is_backslash_escaped(b, i)
             && i + 1 < end
             && b[i + 1] == b'['
             && let Some(close) = find2(b, i + 2, end, b']', b']')
@@ -745,6 +781,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         // image, so an empty-alt `![](src)` hides cleanly instead of leaving a
         // bare unhidden `!`.
         if c == b'['
+            && !is_backslash_escaped(b, i)
             && let Some(rb) = find1(b, i + 1, end, b']')
             && rb + 1 < end
             && b[rb + 1] == b'('
@@ -771,6 +808,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         // Reference link: [text][id] — `text` colored, brackets + `[id]` dimmed.
         // (Inline `[text](url)` is handled just above; this is the `][` form.)
         if c == b'['
+            && !is_backslash_escaped(b, i)
             && let Some(rb) = find1(b, i + 1, end, b']')
             && rb + 1 < end
             && b[rb + 1] == b'['
@@ -884,9 +922,21 @@ fn find1(b: &[u8], from: usize, end: usize, c: u8) -> Option<usize> {
     (from..end).find(|&k| b[k] == c)
 }
 
+/// First UNESCAPED index of byte `c` — a `\`-escaped occurrence (odd
+/// preceding backslash run) is literal text, not a marker (CommonMark).
+fn find1_unescaped(b: &[u8], from: usize, end: usize, c: u8) -> Option<usize> {
+    (from..end).find(|&k| b[k] == c && !is_backslash_escaped(b, k))
+}
+
 /// First index of the pair `c1 c2` in `b[from..end]`.
 fn find2(b: &[u8], from: usize, end: usize, c1: u8, c2: u8) -> Option<usize> {
     (from..end.saturating_sub(1)).find(|&k| b[k] == c1 && b[k + 1] == c2)
+}
+
+/// First UNESCAPED index of the pair — see [`find1_unescaped`].
+fn find2_unescaped(b: &[u8], from: usize, end: usize, c1: u8, c2: u8) -> Option<usize> {
+    (from..end.saturating_sub(1))
+        .find(|&k| b[k] == c1 && b[k + 1] == c2 && !is_backslash_escaped(b, k))
 }
 
 /// A "word" byte for `_`-emphasis flanking: ASCII alphanumerics, plus any
@@ -2481,6 +2531,55 @@ mod tests {
         // the caret isn't in it; inline markers still hide unless under the caret.
         let (disp, _, _) = hidden_runs("> a **b**", &font, c, &[], Some(3), 2, 0, false, &st);
         assert_eq!(disp, "> a b");
+    }
+
+    #[test]
+    fn backtick_runs_match_commonmark() {
+        let st = test_style();
+        // ``a`b`` — a double-backtick span keeps its inner backtick as body.
+        let line = "``a`b`` x";
+        let mut out = Vec::new();
+        scan_line(line, 0, line.len(), &st, &mut out);
+        assert!(
+            out.iter()
+                .any(|s| s.range == (2..5) && s.style.bg.is_some()),
+            "body a`b styled as code"
+        );
+        // An unclosed run stays plain (no half-matched span).
+        let mut out = Vec::new();
+        scan_line("``a` x", 0, 6, &st, &mut out);
+        assert!(out.iter().all(|s| s.style.bg.is_none()));
+    }
+
+    #[test]
+    fn backslash_escapes_stay_literal() {
+        let st = test_style();
+        // \*text\* must NOT style — the reader shows literal asterisks.
+        for line in [
+            r"\*text\*",
+            r"a \`x\` b",
+            r"\~~s\~~",
+            r"\[[Page]]",
+            r"\[t](u)",
+        ] {
+            let mut out = Vec::new();
+            scan_line(line, 0, line.len(), &st, &mut out);
+            assert!(
+                out.iter().all(|s| !s.style.bold
+                    && !s.style.italic
+                    && !s.style.strike
+                    && s.style.bg.is_none()
+                    && s.style.color.is_none()),
+                "{line:?} styled: {:?}",
+                out.iter().map(|s| s.range.clone()).collect::<Vec<_>>()
+            );
+        }
+        // An escaped closer doesn't close: **a \** stays unstyled (no pair),
+        // while the reader treats it the same.
+        let mut out = Vec::new();
+        let line = r"**a \** x";
+        scan_line(line, 0, line.len(), &st, &mut out);
+        assert!(out.iter().all(|s| !s.style.bold), "escaped closer ignored");
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -1767,7 +1767,33 @@ pub(crate) fn table_cells(line: &str) -> Vec<&str> {
     let t = line.trim();
     let t = t.strip_prefix('|').unwrap_or(t);
     let t = t.strip_suffix('|').unwrap_or(t);
-    t.split('|').map(str::trim).collect()
+    split_unescaped_pipes(t).map(str::trim).collect()
+}
+
+/// Split `s` at its UNESCAPED `|` bytes — a `\|` (odd run of preceding
+/// backslashes) is literal cell content per GFM, not a cell separator. The
+/// escape stays in the returned slices (cells are verbatim source), so cell
+/// ranges and caret math keep their exact source mapping, and a rewrite that
+/// re-joins the cells round-trips the escape.
+fn split_unescaped_pipes(s: &str) -> impl Iterator<Item = &str> {
+    let b = s.as_bytes();
+    let mut cuts = vec![0usize];
+    for (i, &c) in b.iter().enumerate() {
+        if c == b'|' && !is_backslash_escaped(b, i) {
+            cuts.push(i + 1);
+        }
+    }
+    cuts.push(s.len() + 1);
+    (0..cuts.len() - 1).map(move |k| &s[cuts[k]..cuts[k + 1] - 1])
+}
+
+/// Whether the byte at `i` is escaped: preceded by an ODD number of `\`s.
+fn is_backslash_escaped(b: &[u8], i: usize) -> bool {
+    let mut n = 0;
+    while n < i && b[i - 1 - n] == b'\\' {
+        n += 1;
+    }
+    n % 2 == 1
 }
 
 /// The byte range of each cell's *trimmed content* within `line` (line-local), in
@@ -1785,7 +1811,7 @@ pub(crate) fn table_cell_ranges(line: &str) -> Vec<Range<usize>> {
     let inner = &line[base..last];
     let mut out = Vec::new();
     let mut seg = 0; // offset of the current cell within `inner`
-    for piece in inner.split('|') {
+    for piece in split_unescaped_pipes(inner) {
         let lead = piece.len() - piece.trim_start().len();
         let trail = piece.len() - piece.trim_end().len();
         let start = base + seg + lead;
@@ -2112,6 +2138,25 @@ mod tests {
     fn cells_split_and_trim() {
         assert_eq!(table_cells("| a | b |"), vec!["a", "b"]);
         assert_eq!(table_cells("|  |  |"), vec!["", ""]);
+    }
+
+    #[test]
+    fn escaped_pipes_are_cell_content() {
+        // GFM: `\|` is a literal pipe in the cell, not a separator — the
+        // reader (GFM parser) agrees; a blind split miscounted cells and
+        // column rewrites then corrupted the row.
+        assert_eq!(
+            table_cells(r"| left \| right | ok |"),
+            vec![r"left \| right", "ok"]
+        );
+        // A double backslash escapes the backslash — that pipe IS a separator.
+        assert_eq!(table_cells(r"| a \\| b |"), vec![r"a \\", "b"]);
+        // Ranges walk the same split: two ranges, first spans the escape.
+        let line = r"| left \| right | ok |";
+        let ranges = table_cell_ranges(line);
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(&line[ranges[0].clone()], r"left \| right");
+        assert_eq!(&line[ranges[1].clone()], "ok");
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -1665,16 +1665,6 @@ pub(crate) fn math_regions(content: &str) -> Vec<MathRegion> {
     out
 }
 
-/// Whether the byte at `idx` is escaped by an odd run of immediately-preceding backslashes
-/// (`\$` is a literal dollar, `\\$` is an escaped backslash then a live `$`).
-fn is_escaped(bytes: &[u8], idx: usize) -> bool {
-    let mut n = 0;
-    while idx > n && bytes[idx - 1 - n] == b'\\' {
-        n += 1;
-    }
-    n % 2 == 1
-}
-
 /// Inline `$…$` math spans within a single text line (NOT block `$$` fences) — byte ranges
 /// covering the whole span, both `$` delimiters included. Follows the common (pandoc) rule so
 /// prose like "it cost $5 and $10" isn't mistaken for math: the opening `$` is followed by a
@@ -1713,7 +1703,7 @@ pub(crate) fn inline_math_spans(line: &str) -> Vec<Range<usize>> {
     let mut out = Vec::new();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] != b'$' || is_escaped(bytes, i) {
+        if bytes[i] != b'$' || is_backslash_escaped(bytes, i) {
             i += 1;
             continue;
         }
@@ -1735,7 +1725,7 @@ pub(crate) fn inline_math_spans(line: &str) -> Vec<Range<usize>> {
         let mut j = i + 1;
         let mut close = None;
         while j < bytes.len() {
-            if bytes[j] == b'$' && !is_escaped(bytes, j) {
+            if bytes[j] == b'$' && !is_backslash_escaped(bytes, j) {
                 let space_before = bytes[j - 1].is_ascii_whitespace();
                 let digit_after = bytes.get(j + 1).is_some_and(|c| c.is_ascii_digit());
                 if !space_before && !digit_after {

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -80,6 +80,7 @@ struct Style {
     bold: bool,
     italic: bool,
     strike: bool,
+    underline: bool,
     mono: bool,
     color: Option<Hsla>,
     bg: Option<Hsla>,
@@ -164,7 +165,15 @@ pub(crate) fn styled_runs(
             font,
             color: style.and_then(|s| s.color).unwrap_or(base_color),
             background_color: style.and_then(|s| s.bg),
-            underline: underline.then_some(squiggle),
+            underline: if underline {
+                Some(squiggle)
+            } else {
+                style.filter(|s| s.underline).map(|_| UnderlineStyle {
+                    thickness: px(1.0),
+                    color: None,
+                    wavy: false,
+                })
+            },
             strikethrough: style.filter(|s| s.strike).map(|_| StrikethroughStyle {
                 thickness: px(1.5),
                 color: None,
@@ -201,7 +210,13 @@ fn run_for(
         font,
         color: style.and_then(|s| s.color).unwrap_or(base_color),
         background_color: style.and_then(|s| s.bg),
-        underline,
+        underline: underline.or_else(|| {
+            style.filter(|s| s.underline).map(|_| UnderlineStyle {
+                thickness: px(1.0),
+                color: None,
+                wavy: false,
+            })
+        }),
         strikethrough: style.filter(|s| s.strike).map(|_| StrikethroughStyle {
             thickness: px(1.5),
             color: None,
@@ -710,7 +725,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             i = rb2 + 1;
             continue;
         }
-        // <mark>…</mark>: a highlight — the one safe inline-HTML tag the reading
+        // <mark>…</mark>: a highlight — a safe inline-HTML tag the reading
         // view honors. Tags hidden, body gets a highlight background.
         if c == b'<'
             && b[i..end].starts_with(b"<mark>")
@@ -729,6 +744,27 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             );
             marker(out, close..close + 7, st.marker);
             i = close + 7;
+            continue;
+        }
+        // <u>…</u>: underline (markdown has none natively) — the other safe
+        // inline-HTML tag, same treatment as <mark>.
+        if c == b'<'
+            && b[i..end].starts_with(b"<u>")
+            && let Some(rel) = text[i + 3..end].find("</u>")
+        {
+            let body = i + 3;
+            let close = body + rel;
+            marker(out, i..body, st.marker);
+            push(
+                out,
+                body..close,
+                Style {
+                    underline: true,
+                    ..Default::default()
+                },
+            );
+            marker(out, close..close + 4, st.marker);
+            i = close + 4;
             continue;
         }
         // Bare URL: colored like a link (it clicks like one — see the shared
@@ -1846,6 +1882,22 @@ mod tests {
         // The shruggie's arms are backslash-escaped underscores.
         assert_eq!(emphasis_spans(r"¯\_(ツ)_/¯"), vec![]);
         assert_eq!(emphasis_spans(r"\_not italic\_"), vec![]);
+    }
+
+    #[test]
+    fn underline_tags_hide_and_style_the_body() {
+        let text = "an <u>underlined</u> word";
+        let st = test_style();
+        let mut out = Vec::new();
+        scan_line(text, 0, text.len(), &st, &mut out);
+        // Tags are hidden markers; the body span carries the underline.
+        let open = text.find("<u>").unwrap();
+        let body = open + 3;
+        assert!(out.iter().any(|s| s.range == (open..body) && s.style.hide));
+        assert!(
+            out.iter()
+                .any(|s| s.range.start == body && s.style.underline)
+        );
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -72,6 +72,26 @@ pub struct SyntaxStyle {
     pub property_icon: Option<PropertyIconFn>,
 }
 
+impl Style {
+    /// `self` layered over `base` (the enclosing construct's style): the
+    /// booleans OR, the options prefer `self`'s — so `code` inside bold keeps
+    /// its color/tint while inheriting the bold weight.
+    fn over(mut self, base: &Style) -> Style {
+        self.bold |= base.bold;
+        self.italic |= base.italic;
+        self.strike |= base.strike;
+        self.underline |= base.underline;
+        self.mono |= base.mono;
+        if self.color.is_none() {
+            self.color = base.color;
+        }
+        if self.bg.is_none() {
+            self.bg = base.bg;
+        }
+        self
+    }
+}
+
 /// Maps a property key to an icon asset path the host serves, or `None` for no
 /// icon. Host-provided so the crate makes no assumption about which assets exist.
 pub type PropertyIconFn = std::rc::Rc<dyn Fn(&str) -> Option<gpui::SharedString>>;
@@ -95,6 +115,10 @@ struct Style {
     /// format bar) edit it. Structural markers (links, headings, math) keep
     /// the reveal, since their raw text is the only way to edit them.
     always_hide: bool,
+    /// Non-zero on a formatting marker: the opener and closer of one construct
+    /// share an id, so `fmt_marker_pairs` can pair them even with NESTED
+    /// constructs between (adjacency no longer identifies the pair).
+    pair_id: u16,
     /// What a hidden marker paints in its place (e.g. a block link's `#^`
     /// shows ` → `): every replacement byte maps back to the span's start, so
     /// the display↔source maps stay consistent. `None` = plain removal.
@@ -394,41 +418,28 @@ fn scan(text: &str, st: &SyntaxStyle) -> Vec<Span> {
 /// The always-hidden formatting-marker PAIRS on a line, as
 /// `(opening range, closing range)` per construct — for the editor's
 /// Cditor-style delete (skip the invisible bytes; collapse an emptied pair).
-/// Constructs don't nest in span space (the scanner consumes a construct
-/// wholesale), so pairing is a left-to-right walk: an always-hidden span, at
-/// most one body span, then its always-hidden closer.
 pub(crate) fn fmt_marker_pairs(line: &str, st: &SyntaxStyle) -> Vec<(Range<usize>, Range<usize>)> {
     let mut spans = scan(line, st);
     spans.sort_by_key(|s| s.range.start);
+    // The scanner stamps each construct's opener + closer with a shared
+    // `pair_id`, so pairing survives NESTED constructs between them (the old
+    // adjacency walk assumed at most one body span).
+    let mut open: Vec<(u16, Range<usize>)> = Vec::new();
     let mut pairs = Vec::new();
-    let mut i = 0;
-    while i < spans.len() {
-        if !spans[i].style.always_hide {
-            i += 1;
+    for sp in spans.into_iter().filter(|s| s.style.always_hide) {
+        let id = sp.style.pair_id;
+        if id == 0 {
             continue;
         }
-        let open = spans[i].range.clone();
-        // Optional single body span directly after the opener.
-        let mut j = i + 1;
-        let mut body_end = open.end;
-        if let Some(b) = spans
-            .get(j)
-            .filter(|b| !b.style.always_hide && b.range.start == open.end)
-        {
-            body_end = b.range.end;
-            j += 1;
-        }
-        match spans
-            .get(j)
-            .filter(|c| c.style.always_hide && c.range.start == body_end)
-        {
-            Some(c) => {
-                pairs.push((open, c.range.clone()));
-                i = j + 1;
+        match open.iter().position(|(oid, _)| *oid == id) {
+            Some(k) => {
+                let (_, o) = open.remove(k);
+                pairs.push((o, sp.range));
             }
-            None => i += 1,
+            None => open.push((id, sp.range)),
         }
     }
+    pairs.sort_by_key(|(o, _)| o.start);
     pairs
 }
 
@@ -444,17 +455,62 @@ fn marker(out: &mut Vec<Span>, range: Range<usize>, color: Hsla) {
 }
 
 /// A formatting marker that NEVER reveals (not even with the caret inside its
-/// construct) — see [`Style::always_hide`].
-fn fmt_marker(out: &mut Vec<Span>, range: Range<usize>, color: Hsla) {
+/// construct) — see [`Style::always_hide`]. The construct's opener and closer
+/// share `pair_id` (see [`fmt_marker_pairs`]).
+fn fmt_marker(out: &mut Vec<Span>, range: Range<usize>, color: Hsla, pair_id: u16) {
     out.push(Span {
         range,
         style: Style {
             color: Some(color),
             hide: true,
             always_hide: true,
+            pair_id,
             ..Default::default()
         },
     });
+}
+
+/// Recursively scan a formatting construct's body: inner constructs nest
+/// (bold inside italic, code inside bold, …) with `style` layered under them,
+/// and the gaps — the construct's own plain text — carry `style` itself.
+/// Depth-capped; at the cap the body is one flat styled span.
+#[allow(clippy::too_many_arguments)]
+fn scan_styled_body(
+    text: &str,
+    s: usize,
+    e: usize,
+    st: &SyntaxStyle,
+    out: &mut Vec<Span>,
+    style: Style,
+    depth: u8,
+    next_id: &mut u16,
+) {
+    if s >= e {
+        return;
+    }
+    if depth >= 3 {
+        push(out, s..e, style);
+        return;
+    }
+    let before = out.len();
+    scan_inline(text, s, e, st, out, &style, depth + 1, next_id);
+    // Fill the gaps between the inner constructs with the body style.
+    let mut covered: Vec<Range<usize>> = out[before..].iter().map(|sp| sp.range.clone()).collect();
+    covered.sort_by_key(|r| r.start);
+    let mut pos = s;
+    let mut fills: Vec<Range<usize>> = Vec::new();
+    for r in covered {
+        if r.start > pos {
+            fills.push(pos..r.start);
+        }
+        pos = pos.max(r.end);
+    }
+    if pos < e {
+        fills.push(pos..e);
+    }
+    for f in fills {
+        push(out, f, style.clone());
+    }
 }
 
 /// Heading styling (`#`..`######` + a space) for `text[from..end]`: dim the
@@ -537,6 +593,28 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             return;
         }
     }
+    let mut next_id = 1u16;
+    scan_inline(text, i, end, st, out, &Style::default(), 0, &mut next_id);
+}
+
+/// The inline scanning loop, recursive so formatting constructs NEST: a
+/// construct's body re-scans with the construct's style as `base` (layered by
+/// [`Style::over`]), matching the reader's CommonMark nesting — `**bold
+/// *italic* bold**` styles the inner run bold+italic. `start` is the segment
+/// start (word-boundary and image-bang checks are segment-local).
+#[allow(clippy::too_many_arguments)]
+fn scan_inline(
+    text: &str,
+    start: usize,
+    end: usize,
+    st: &SyntaxStyle,
+    out: &mut Vec<Span>,
+    base: &Style,
+    depth: u8,
+    next_id: &mut u16,
+) {
+    let b = text.as_bytes();
+    let mut i = start;
     while i < end {
         let c = b[i];
         // A backslash escape (`\*`, `\|`, `\\`, … — any ASCII punctuation):
@@ -581,7 +659,9 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                 }
             }
             if let Some(close) = close {
-                fmt_marker(out, i..i + n, st.marker);
+                let id = *next_id;
+                *next_id += 1;
+                fmt_marker(out, i..i + n, st.marker, id);
                 push(
                     out,
                     i + n..close,
@@ -589,9 +669,10 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                         color: Some(st.code),
                         bg: Some(st.code_bg),
                         ..Default::default()
-                    },
+                    }
+                    .over(base),
                 );
-                fmt_marker(out, close..close + n, st.marker);
+                fmt_marker(out, close..close + n, st.marker, id);
                 i = close + n;
                 continue;
             }
@@ -609,16 +690,24 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             && b[i + 1] == b'*'
             && let Some(close) = find2_unescaped(b, i + 2, end, b'*', b'*')
         {
-            fmt_marker(out, i..i + 2, st.marker);
-            push(
+            let id = *next_id;
+            *next_id += 1;
+            fmt_marker(out, i..i + 2, st.marker, id);
+            scan_styled_body(
+                text,
+                i + 2,
+                close,
+                st,
                 out,
-                i + 2..close,
                 Style {
                     bold: true,
                     ..Default::default()
-                },
+                }
+                .over(base),
+                depth,
+                next_id,
             );
-            fmt_marker(out, close..close + 2, st.marker);
+            fmt_marker(out, close..close + 2, st.marker, id);
             i = close + 2;
             continue;
         }
@@ -628,16 +717,24 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             && let Some(close) = find1_unescaped(b, i + 1, end, b'*')
             && close > i + 1
         {
-            fmt_marker(out, i..i + 1, st.marker);
-            push(
+            let id = *next_id;
+            *next_id += 1;
+            fmt_marker(out, i..i + 1, st.marker, id);
+            scan_styled_body(
+                text,
+                i + 1,
+                close,
+                st,
                 out,
-                i + 1..close,
                 Style {
                     italic: true,
                     ..Default::default()
-                },
+                }
+                .over(base),
+                depth,
+                next_id,
             );
-            fmt_marker(out, close..close + 1, st.marker);
+            fmt_marker(out, close..close + 1, st.marker, id);
             i = close + 1;
             continue;
         }
@@ -655,16 +752,24 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                 && b[i + 2] != b' '
                 && let Some(close) = find_underscore_close(b, i + 2, end, true)
             {
-                fmt_marker(out, i..i + 2, st.marker);
-                push(
+                let id = *next_id;
+                *next_id += 1;
+                fmt_marker(out, i..i + 2, st.marker, id);
+                scan_styled_body(
+                    text,
+                    i + 2,
+                    close,
+                    st,
                     out,
-                    i + 2..close,
                     Style {
                         bold: true,
                         ..Default::default()
-                    },
+                    }
+                    .over(base),
+                    depth,
+                    next_id,
                 );
-                fmt_marker(out, close..close + 2, st.marker);
+                fmt_marker(out, close..close + 2, st.marker, id);
                 i = close + 2;
                 continue;
             }
@@ -673,16 +778,24 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                 && b[i + 1] != b' '
                 && let Some(close) = find_underscore_close(b, i + 1, end, false)
             {
-                fmt_marker(out, i..i + 1, st.marker);
-                push(
+                let id = *next_id;
+                *next_id += 1;
+                fmt_marker(out, i..i + 1, st.marker, id);
+                scan_styled_body(
+                    text,
+                    i + 1,
+                    close,
+                    st,
                     out,
-                    i + 1..close,
                     Style {
                         italic: true,
                         ..Default::default()
-                    },
+                    }
+                    .over(base),
+                    depth,
+                    next_id,
                 );
-                fmt_marker(out, close..close + 1, st.marker);
+                fmt_marker(out, close..close + 1, st.marker, id);
                 i = close + 1;
                 continue;
             }
@@ -694,16 +807,24 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             && b[i + 1] == b'~'
             && let Some(close) = find2_unescaped(b, i + 2, end, b'~', b'~')
         {
-            fmt_marker(out, i..i + 2, st.marker);
-            push(
+            let id = *next_id;
+            *next_id += 1;
+            fmt_marker(out, i..i + 2, st.marker, id);
+            scan_styled_body(
+                text,
+                i + 2,
+                close,
+                st,
                 out,
-                i + 2..close,
                 Style {
                     strike: true,
                     ..Default::default()
-                },
+                }
+                .over(base),
+                depth,
+                next_id,
             );
-            fmt_marker(out, close..close + 2, st.marker);
+            fmt_marker(out, close..close + 2, st.marker, id);
             i = close + 2;
             continue;
         }
@@ -722,7 +843,8 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                 Style {
                     color: Some(st.link),
                     ..Default::default()
-                },
+                }
+                .over(base),
             );
             marker(out, i + 1..i + 2, st.marker); // hide the `^`
             push(
@@ -731,7 +853,8 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                 Style {
                     color: Some(st.link),
                     ..Default::default()
-                },
+                }
+                .over(base),
             );
             i = rb + 1;
             continue;
@@ -747,7 +870,8 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             let link = Style {
                 color: Some(st.link),
                 ..Default::default()
-            };
+            }
+            .over(base);
             // An anchor in the target — a block ref (`[[Note#^id]]`) or a
             // heading (`[[Note#My Heading]]`) — renders its `#^`/`#` as ` → `
             // (the reader does the same), keeping the anchor text readable:
@@ -812,7 +936,8 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                 Style {
                     color: Some(st.link),
                     ..Default::default()
-                },
+                }
+                .over(base),
             );
             marker(out, rb..rp + 1, st.marker);
             i = rp + 1;
@@ -834,7 +959,8 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                 Style {
                     color: Some(st.link),
                     ..Default::default()
-                },
+                }
+                .over(base),
             );
             marker(out, rb..rb2 + 1, st.marker);
             i = rb2 + 1;
@@ -848,16 +974,24 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         {
             let body = i + 6;
             let close = body + rel;
-            fmt_marker(out, i..body, st.marker);
-            push(
+            let id = *next_id;
+            *next_id += 1;
+            fmt_marker(out, i..body, st.marker, id);
+            scan_styled_body(
+                text,
+                body,
+                close,
+                st,
                 out,
-                body..close,
                 Style {
                     bg: Some(st.mark_bg),
                     ..Default::default()
-                },
+                }
+                .over(base),
+                depth,
+                next_id,
             );
-            fmt_marker(out, close..close + 7, st.marker);
+            fmt_marker(out, close..close + 7, st.marker, id);
             i = close + 7;
             continue;
         }
@@ -869,16 +1003,24 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         {
             let body = i + 3;
             let close = body + rel;
-            fmt_marker(out, i..body, st.marker);
-            push(
+            let id = *next_id;
+            *next_id += 1;
+            fmt_marker(out, i..body, st.marker, id);
+            scan_styled_body(
+                text,
+                body,
+                close,
+                st,
                 out,
-                body..close,
                 Style {
                     underline: true,
                     ..Default::default()
-                },
+                }
+                .over(base),
+                depth,
+                next_id,
             );
-            fmt_marker(out, close..close + 4, st.marker);
+            fmt_marker(out, close..close + 4, st.marker, id);
             i = close + 4;
             continue;
         }
@@ -897,7 +1039,8 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                     Style {
                         color: Some(st.link),
                         ..Default::default()
-                    },
+                    }
+                    .over(base),
                 );
                 i = j;
                 continue;
@@ -916,7 +1059,8 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                     Style {
                         color: Some(st.tag),
                         ..Default::default()
-                    },
+                    }
+                    .over(base),
                 );
                 i = j;
                 continue;
@@ -2612,6 +2756,38 @@ mod tests {
         // CommonMark: \**bold** = literal *, italic "bold", literal *.
         let (disp, _, _) = hidden_runs(r"\**bold**", &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "*bold*");
+    }
+
+    #[test]
+    fn nested_inline_styles_layer() {
+        let st = test_style();
+        // **bold *italic* bold** — the inner run carries BOTH styles, the
+        // gaps around it stay bold (the reader nests the same way).
+        let line = "**bold *it* bold**";
+        let mut out = Vec::new();
+        scan_line(line, 0, line.len(), &st, &mut out);
+        let styled = |s: usize, e: usize| out.iter().find(|sp| sp.range == (s..e)).unwrap();
+        let inner = styled(8, 10); // "it"
+        assert!(inner.style.bold && inner.style.italic);
+        let gap = styled(2, 7); // "bold " before the italic
+        assert!(gap.style.bold && !gap.style.italic);
+        // Inline code inside bold keeps its tint and inherits the weight.
+        let line = "**b `c` d**";
+        let mut out = Vec::new();
+        scan_line(line, 0, line.len(), &st, &mut out);
+        let code = out
+            .iter()
+            .find(|sp| sp.range == (5..6))
+            .expect("code body span");
+        assert!(code.style.bold && code.style.bg.is_some());
+        // Display hides every marker, nested included.
+        let font = gpui::font("Helvetica");
+        let c = hsla(0., 0., 0., 1.);
+        let (disp, _, _) = hidden_runs("**bold *it* bold**", &font, c, &[], None, 0, 0, false, &st);
+        assert_eq!(disp, "bold it bold");
+        // Pairing survives nesting: two pairs, outer first.
+        let pairs = fmt_marker_pairs("**bold *it* bold**", &st);
+        assert_eq!(pairs, vec![(0..2, 16..18), (7..8, 10..11)]);
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -1584,45 +1584,15 @@ pub(crate) enum Align {
     Right,
 }
 
-/// Visual style of a GFM table, chosen per-table via a `<!-- table:STYLE -->`
-/// marker comment on the line directly above it. `Grid` is the default (no
-/// marker). The renderers honor it; standard Markdown viewers ignore the comment
-/// and show a plain table.
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-pub(crate) enum TableStyle {
-    /// Full outer box + all row/column gridlines.
-    #[default]
-    Grid,
-    /// Alternate body rows shaded; no gridlines; a rule under the header.
-    Striped,
-    /// Only the header row shaded; no gridlines.
-    Header,
-    /// No box or gridlines — just a rule under the header.
-    Minimal,
-}
-
-impl TableStyle {
-    fn from_name(name: &str) -> Option<Self> {
-        match name {
-            "grid" => Some(Self::Grid),
-            "striped" => Some(Self::Striped),
-            "header" => Some(Self::Header),
-            "minimal" => Some(Self::Minimal),
-            _ => None,
-        }
-    }
-}
+/// The shared table-style enum — recognition lives in `gpui_markdown::syntax`
+/// (the sanctioned dependency), including the marker's `cols=` widths.
+pub(crate) use gpui_markdown::syntax::TableStyle;
 
 /// Parse a `<!-- table:STYLE -->` marker line into its [`TableStyle`]. `None` if
 /// the line isn't a recognized table-style marker (so an unknown marker stays a
 /// plain HTML comment).
 pub(crate) fn table_style_marker(line: &str) -> Option<TableStyle> {
-    let inner = line
-        .trim()
-        .strip_prefix("<!--")?
-        .strip_suffix("-->")?
-        .trim();
-    TableStyle::from_name(inner.strip_prefix("table:")?.trim())
+    gpui_markdown::syntax::table_style_marker(line)
 }
 
 /// A detected GFM table region: the half-open range of logical line indices it
@@ -1635,6 +1605,9 @@ pub(crate) struct TableRegion {
     /// Index of the style-marker comment line above the header, if present — the
     /// editor hides it (revealed only when the caret lands on it).
     pub marker_line: Option<usize>,
+    /// Explicit column widths (logical px) from the marker's `cols=` attribute
+    /// — written by drag-to-resize; `None` = content-measured.
+    pub col_widths_attr: Option<Vec<f32>>,
 }
 
 /// Detect GFM table regions in `content` (W4c). A region is a row line (trimmed
@@ -1670,11 +1643,14 @@ pub(crate) fn table_regions(content: &str) -> Vec<TableRegion> {
                 Some((m, Some(s))) => (s, Some(m)),
                 _ => (TableStyle::Grid, None),
             };
+            let col_widths_attr =
+                marker_line.and_then(|m| gpui_markdown::syntax::table_col_widths(lines[m]));
             out.push(TableRegion {
                 lines: start..end,
                 aligns,
                 style,
                 marker_line,
+                col_widths_attr,
             });
             i = end;
         } else {

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -539,6 +539,19 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
     }
     while i < end {
         let c = b[i];
+        // A backslash escape (`\*`, `\|`, `\\`, … — any ASCII punctuation):
+        // the backslash is a hideable marker (the reader consumes it), the
+        // escaped character is literal content — skip it so no construct
+        // opens on it. Reveal-on-caret shows the backslash for editing.
+        if c == b'\\'
+            && i + 1 < end
+            && b[i + 1].is_ascii_punctuation()
+            && !is_backslash_escaped(b, i)
+        {
+            marker(out, i..i + 1, st.marker);
+            i += 2;
+            continue;
+        }
         // Inline code: `code` — backticks are hideable markers, the body a
         // highlight (code color on a tint, body font) matching the reading
         // view. CommonMark run matching: an opening run of N backticks closes
@@ -2564,12 +2577,14 @@ mod tests {
         ] {
             let mut out = Vec::new();
             scan_line(line, 0, line.len(), &st, &mut out);
+            // Escape backslashes become (hidden) marker spans; nothing may
+            // carry actual STYLING.
             assert!(
                 out.iter().all(|s| !s.style.bold
                     && !s.style.italic
                     && !s.style.strike
                     && s.style.bg.is_none()
-                    && s.style.color.is_none()),
+                    && (s.style.hide || s.style.color.is_none())),
                 "{line:?} styled: {:?}",
                 out.iter().map(|s| s.range.clone()).collect::<Vec<_>>()
             );
@@ -2580,6 +2595,23 @@ mod tests {
         let line = r"**a \** x";
         scan_line(line, 0, line.len(), &st, &mut out);
         assert!(out.iter().all(|s| !s.style.bold), "escaped closer ignored");
+    }
+
+    #[test]
+    fn escape_backslash_hides_like_the_reader() {
+        // The reader consumes the `\` of an escape — the editor hides it the
+        // same way (a marker span), leaving the escaped char as content.
+        let font = gpui::font("Helvetica");
+        let c = hsla(0., 0., 0., 1.);
+        let st = test_style();
+        let (disp, _, _) = hidden_runs(r"\*text\*", &font, c, &[], None, 0, 0, false, &st);
+        assert_eq!(disp, "*text*");
+        // `\\` shows a single backslash.
+        let (disp, _, _) = hidden_runs(r"a \\ b", &font, c, &[], None, 0, 0, false, &st);
+        assert_eq!(disp, r"a \ b");
+        // CommonMark: \**bold** = literal *, italic "bold", literal *.
+        let (disp, _, _) = hidden_runs(r"\**bold**", &font, c, &[], None, 0, 0, false, &st);
+        assert_eq!(disp, "*bold*");
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -89,6 +89,12 @@ struct Style {
     /// A syntax marker (`**`, `#`, `[`, …) — dimmed when shown, and removed
     /// entirely when the line's markers are hidden (W6, reveal-on-caret).
     hide: bool,
+    /// A formatting marker (`**`, `*`, `~~`, `` ` ``, `<mark>`, `<u>`) stays
+    /// hidden even with the caret inside its construct — Cditor-style: the
+    /// styling IS the feedback, and the toggles (⌘B/I/U/…, the selection
+    /// format bar) edit it. Structural markers (links, headings, math) keep
+    /// the reveal, since their raw text is the only way to edit them.
+    always_hide: bool,
     /// What a hidden marker paints in its place (e.g. a block link's `#^`
     /// shows ` → `): every replacement byte maps back to the span's start, so
     /// the display↔source maps stay consistent. `None` = plain removal.
@@ -299,7 +305,8 @@ pub(crate) fn hidden_runs(
         let in_construct = reveal.start <= span.range.start && span.range.end <= reveal.end;
         let in_prefix = span.range.end <= reveal_prefix;
         let force = span.range.end <= hide_prefix;
-        let hidden = span.style.hide && (force || (!reveal_inline && !in_construct && !in_prefix));
+        let hidden = span.style.hide
+            && (span.style.always_hide || force || (!reveal_inline && !in_construct && !in_prefix));
         if !hidden {
             segs.push((span.range.clone(), Some(&span.style), None));
         } else if let Some(rep) = span.style.replace {
@@ -395,6 +402,20 @@ fn marker(out: &mut Vec<Span>, range: Range<usize>, color: Hsla) {
     });
 }
 
+/// A formatting marker that NEVER reveals (not even with the caret inside its
+/// construct) — see [`Style::always_hide`].
+fn fmt_marker(out: &mut Vec<Span>, range: Range<usize>, color: Hsla) {
+    out.push(Span {
+        range,
+        style: Style {
+            color: Some(color),
+            hide: true,
+            always_hide: true,
+            ..Default::default()
+        },
+    });
+}
+
 /// Heading styling (`#`..`######` + a space) for `text[from..end]`: dim the
 /// marker, bold the rest. The larger heading SIZE is applied per line at
 /// layout time (variable line heights), not here — so the rest of the line
@@ -482,7 +503,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         if c == b'`'
             && let Some(close) = find1(b, i + 1, end, b'`')
         {
-            marker(out, i..i + 1, st.marker);
+            fmt_marker(out, i..i + 1, st.marker);
             push(
                 out,
                 i + 1..close,
@@ -492,7 +513,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                     ..Default::default()
                 },
             );
-            marker(out, close..close + 1, st.marker);
+            fmt_marker(out, close..close + 1, st.marker);
             i = close + 1;
             continue;
         }
@@ -502,7 +523,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             && b[i + 1] == b'*'
             && let Some(close) = find2(b, i + 2, end, b'*', b'*')
         {
-            marker(out, i..i + 2, st.marker);
+            fmt_marker(out, i..i + 2, st.marker);
             push(
                 out,
                 i + 2..close,
@@ -511,7 +532,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                     ..Default::default()
                 },
             );
-            marker(out, close..close + 2, st.marker);
+            fmt_marker(out, close..close + 2, st.marker);
             i = close + 2;
             continue;
         }
@@ -520,7 +541,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             && let Some(close) = find1(b, i + 1, end, b'*')
             && close > i + 1
         {
-            marker(out, i..i + 1, st.marker);
+            fmt_marker(out, i..i + 1, st.marker);
             push(
                 out,
                 i + 1..close,
@@ -529,7 +550,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                     ..Default::default()
                 },
             );
-            marker(out, close..close + 1, st.marker);
+            fmt_marker(out, close..close + 1, st.marker);
             i = close + 1;
             continue;
         }
@@ -547,7 +568,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                 && b[i + 2] != b' '
                 && let Some(close) = find_underscore_close(b, i + 2, end, true)
             {
-                marker(out, i..i + 2, st.marker);
+                fmt_marker(out, i..i + 2, st.marker);
                 push(
                     out,
                     i + 2..close,
@@ -556,7 +577,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                         ..Default::default()
                     },
                 );
-                marker(out, close..close + 2, st.marker);
+                fmt_marker(out, close..close + 2, st.marker);
                 i = close + 2;
                 continue;
             }
@@ -565,7 +586,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                 && b[i + 1] != b' '
                 && let Some(close) = find_underscore_close(b, i + 1, end, false)
             {
-                marker(out, i..i + 1, st.marker);
+                fmt_marker(out, i..i + 1, st.marker);
                 push(
                     out,
                     i + 1..close,
@@ -574,7 +595,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                         ..Default::default()
                     },
                 );
-                marker(out, close..close + 1, st.marker);
+                fmt_marker(out, close..close + 1, st.marker);
                 i = close + 1;
                 continue;
             }
@@ -585,7 +606,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
             && b[i + 1] == b'~'
             && let Some(close) = find2(b, i + 2, end, b'~', b'~')
         {
-            marker(out, i..i + 2, st.marker);
+            fmt_marker(out, i..i + 2, st.marker);
             push(
                 out,
                 i + 2..close,
@@ -594,7 +615,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                     ..Default::default()
                 },
             );
-            marker(out, close..close + 2, st.marker);
+            fmt_marker(out, close..close + 2, st.marker);
             i = close + 2;
             continue;
         }
@@ -735,7 +756,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         {
             let body = i + 6;
             let close = body + rel;
-            marker(out, i..body, st.marker);
+            fmt_marker(out, i..body, st.marker);
             push(
                 out,
                 body..close,
@@ -744,7 +765,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                     ..Default::default()
                 },
             );
-            marker(out, close..close + 7, st.marker);
+            fmt_marker(out, close..close + 7, st.marker);
             i = close + 7;
             continue;
         }
@@ -756,7 +777,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
         {
             let body = i + 3;
             let close = body + rel;
-            marker(out, i..body, st.marker);
+            fmt_marker(out, i..body, st.marker);
             push(
                 out,
                 body..close,
@@ -765,7 +786,7 @@ fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut V
                     ..Default::default()
                 },
             );
-            marker(out, close..close + 4, st.marker);
+            fmt_marker(out, close..close + 4, st.marker);
             i = close + 4;
             continue;
         }
@@ -1800,11 +1821,14 @@ mod tests {
     fn selection_reveal_shows_inline_but_not_prefix() {
         let (font, c, st) = (Font::default(), Hsla::default(), test_style());
         // A selected list line: the `- ` prefix stays hidden behind its
-        // painted bullet, while inline markers come back so highlighted
-        // glyphs equal copied bytes.
+        // painted bullet — and formatting markers stay hidden too now
+        // (always_hide wins over the selection reveal; structural markers
+        // like links still come back).
         let (disp, _, _) = hidden_runs("- a **b** c", &font, c, &[], None, 0, 2, true, &st);
-        assert_eq!(disp, "a **b** c");
-        // Same line unselected: both prefix and inline markers hidden.
+        assert_eq!(disp, "a b c");
+        let (disp, _, _) = hidden_runs("- [t](u) c", &font, c, &[], None, 0, 2, true, &st);
+        assert_eq!(disp, "[t](u) c");
+        // Same line unselected: everything hidden.
         let (disp, _, _) = hidden_runs("- a **b** c", &font, c, &[], None, 0, 2, false, &st);
         assert_eq!(disp, "a b c");
     }
@@ -2322,18 +2346,23 @@ mod tests {
         let st = test_style();
 
         let line = "**bold** *it*";
-        // Caret in "bold" reveals the bold markers; the italic stays hidden.
+        // Formatting markers never reveal — not even under the caret
+        // (Cditor-style; see `formatting_markers_never_reveal`).
         let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(4), 0, 0, false, &st);
-        assert_eq!(disp, "**bold** it");
-        // Caret in "it" reveals the italic; the bold hides.
-        let (disp, _, _) = hidden_runs(line, &font, c, &[], Some(11), 0, 0, false, &st);
-        assert_eq!(disp, "bold *it*");
-        // Caret in plain text reveals nothing.
+        assert_eq!(disp, "bold it");
+        // Caret in plain text reveals nothing either.
         let (disp, _, _) = hidden_runs("a **b**", &font, c, &[], Some(0), 0, 0, false, &st);
         assert_eq!(disp, "a b");
         // No caret on the line → fully hidden (W6).
         let (disp, _, _) = hidden_runs(line, &font, c, &[], None, 0, 0, false, &st);
         assert_eq!(disp, "bold it");
+        // STRUCTURAL constructs keep the per-construct caret reveal: the
+        // caret inside a link shows its brackets/URL; outside, hidden.
+        let link = "a [t](u) b";
+        let (disp, _, _) = hidden_runs(link, &font, c, &[], Some(3), 0, 0, false, &st);
+        assert_eq!(disp, "a [t](u) b");
+        let (disp, _, _) = hidden_runs(link, &font, c, &[], Some(0), 0, 0, false, &st);
+        assert_eq!(disp, "a t b");
     }
 
     #[test]
@@ -2366,6 +2395,31 @@ mod tests {
         // the caret isn't in it; inline markers still hide unless under the caret.
         let (disp, _, _) = hidden_runs("> a **b**", &font, c, &[], Some(3), 2, 0, false, &st);
         assert_eq!(disp, "> a b");
+    }
+
+    #[test]
+    fn formatting_markers_never_reveal() {
+        // Cditor-style: even with the caret INSIDE the construct, formatting
+        // markers stay hidden (the styling is the feedback; toggles edit it).
+        let font = gpui::font("Helvetica");
+        let c = hsla(0., 0., 0., 1.);
+        let st = test_style();
+        for (line, disp) in [
+            ("**bold** x", "bold x"),
+            ("*it* x", "it x"),
+            ("~~s~~ x", "s x"),
+            ("`c` x", "c x"),
+            ("<u>u</u> x", "u x"),
+            ("<mark>m</mark> x", "m x"),
+        ] {
+            let caret_inside = Some(3.min(line.len() - 1));
+            let (d, _, _) = hidden_runs(line, &font, c, &[], caret_inside, 0, 0, false, &st);
+            assert_eq!(d, disp, "{line:?}");
+        }
+        // Structural constructs keep the caret reveal: a wiki link's brackets
+        // show while the caret is inside it.
+        let (d, _, _) = hidden_runs("[[Page]] x", &font, c, &[], Some(4), 0, 0, false, &st);
+        assert_eq!(d, "[[Page]] x");
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -391,6 +391,47 @@ fn scan(text: &str, st: &SyntaxStyle) -> Vec<Span> {
     out
 }
 
+/// The always-hidden formatting-marker PAIRS on a line, as
+/// `(opening range, closing range)` per construct — for the editor's
+/// Cditor-style delete (skip the invisible bytes; collapse an emptied pair).
+/// Constructs don't nest in span space (the scanner consumes a construct
+/// wholesale), so pairing is a left-to-right walk: an always-hidden span, at
+/// most one body span, then its always-hidden closer.
+pub(crate) fn fmt_marker_pairs(line: &str, st: &SyntaxStyle) -> Vec<(Range<usize>, Range<usize>)> {
+    let mut spans = scan(line, st);
+    spans.sort_by_key(|s| s.range.start);
+    let mut pairs = Vec::new();
+    let mut i = 0;
+    while i < spans.len() {
+        if !spans[i].style.always_hide {
+            i += 1;
+            continue;
+        }
+        let open = spans[i].range.clone();
+        // Optional single body span directly after the opener.
+        let mut j = i + 1;
+        let mut body_end = open.end;
+        if let Some(b) = spans
+            .get(j)
+            .filter(|b| !b.style.always_hide && b.range.start == open.end)
+        {
+            body_end = b.range.end;
+            j += 1;
+        }
+        match spans
+            .get(j)
+            .filter(|c| c.style.always_hide && c.range.start == body_end)
+        {
+            Some(c) => {
+                pairs.push((open, c.range.clone()));
+                i = j + 1;
+            }
+            None => i += 1,
+        }
+    }
+    pairs
+}
+
 fn marker(out: &mut Vec<Span>, range: Range<usize>, color: Hsla) {
     out.push(Span {
         range,
@@ -2395,6 +2436,22 @@ mod tests {
         // the caret isn't in it; inline markers still hide unless under the caret.
         let (disp, _, _) = hidden_runs("> a **b**", &font, c, &[], Some(3), 2, 0, false, &st);
         assert_eq!(disp, "> a b");
+    }
+
+    #[test]
+    fn fmt_marker_pairs_stay_per_construct() {
+        let st = test_style();
+        // Adjacent constructs pair up separately — a delete between them must
+        // never fuse one's closer with the other's opener.
+        assert_eq!(
+            fmt_marker_pairs("**a**~~b~~", &st),
+            vec![(0..2, 3..5), (5..7, 8..10)]
+        );
+        // An empty pair (post-delete state) is still a pair.
+        assert_eq!(fmt_marker_pairs("****", &st), vec![(0..2, 2..4)]);
+        // Structural markers (links) aren't formatting pairs.
+        assert_eq!(fmt_marker_pairs("[t](u)", &st), vec![]);
+        assert_eq!(fmt_marker_pairs("<u>x</u>", &st), vec![(0..3, 4..8)]);
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -1234,31 +1234,6 @@ pub(crate) fn line_scale(line: &str) -> f32 {
     }
 }
 
-/// Fenced code-block regions (W4b/W6): each ` ``` ` line toggles a block;
-/// returns the line-index range `start..end` covering both fences (and the body
-/// between). An unclosed fence runs to the last line.
-pub(crate) fn code_regions(content: &str) -> Vec<Range<usize>> {
-    let mut out = Vec::new();
-    let mut open: Option<usize> = None;
-    let mut last = 0;
-    for (i, line) in content.split('\n').enumerate() {
-        last = i;
-        if line.trim_start().starts_with("```") {
-            match open {
-                None => open = Some(i),
-                Some(s) => {
-                    out.push(s..i + 1);
-                    open = None;
-                }
-            }
-        }
-    }
-    if let Some(s) = open {
-        out.push(s..last + 1);
-    }
-    out
-}
-
 /// Fenced ` ```mermaid ` blocks: each entry is `(line_range, source)` — the line
 /// range covering both fences (so it can collapse), and the diagram source (the
 /// lines between the fences, joined). Used to render the block as a diagram.

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -62,6 +62,8 @@ pub struct SyntaxStyle {
     pub popover_hover: Hsla,
     /// Popover/menu group divider.
     pub popover_divider: Hsla,
+    /// Popover/menu destructive rows ("Delete …" — label + glyph in red).
+    pub popover_danger: Hsla,
     /// Monospace font for inline code.
     pub mono: Font,
     /// Resolves a property key (`tags`, `status`, …) to an icon shown before it
@@ -2208,6 +2210,7 @@ mod tests {
             popover_fg: c,
             popover_hover: c,
             popover_divider: c,
+            popover_danger: c,
             mono: gpui::font("monospace"),
             property_icon: None,
         }

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -1622,6 +1622,7 @@ pub(crate) fn math_align_marker(line: &str) -> Option<MathAlign> {
 
 /// A detected `$$…$$` block: its line range (both fences), the LaTeX between them, its
 /// alignment, and the optional `<!-- math:ALIGN -->` marker line directly above it.
+#[derive(Clone)]
 pub(crate) struct MathRegion {
     pub range: Range<usize>,
     pub source: String,
@@ -1867,6 +1868,7 @@ pub(crate) fn table_style_marker(line: &str) -> Option<TableStyle> {
 /// A detected GFM table region: the half-open range of logical line indices it
 /// spans (header, separator, then body rows) and its per-column alignment, plus
 /// an optional `<!-- table:STYLE -->` marker line directly above it.
+#[derive(Clone)]
 pub(crate) struct TableRegion {
     pub lines: Range<usize>,
     pub aligns: Vec<Align>,

--- a/crates/gpui-markdown/API.md
+++ b/crates/gpui-markdown/API.md
@@ -31,6 +31,8 @@ isn't public. Feature `—` = always compiled (`gpui_markdown::syntax`);
 | [`TableStyle`](#enum-tablestyle) | enum | `Grid \| Striped \| Header \| Minimal` | Per-table visual design (default `Grid`) | — |
 | [`TableStyle::from_name`](#tablestylefrom_name) | method | `fn from_name(name: &str) -> Option<Self>` | Parse a style name (`"striped"` …) | — |
 | [`table_style_marker`](#table_style_marker) | fn | `fn table_style_marker(text: &str) -> Option<TableStyle>` | Parse a `<!-- table:STYLE -->` marker comment | — |
+| [`table_col_widths`](#table_col_widths) | fn | `fn table_col_widths(text: &str) -> Option<Vec<f32>>` | Explicit column widths from a marker's `cols=` | — |
+| [`table_marker_text`](#table_marker_text) | fn | `fn table_marker_text(style: TableStyle, widths: Option<&[f32]>) -> Option<String>` | Write a marker line (the parsers' inverse) | — |
 | [`heading_scale`](#heading_scale) | fn | `fn heading_scale(depth: u8) -> f32` | Font-size multiplier for h1–h6 | — |
 | [`ordered_marker`](#ordered_marker) | fn | `fn ordered_marker(depth: usize, n: u32) -> String` | Word-style list marker (`1.` → `a.` → `i.`) | — |
 | [`LinkHit`](#enum-linkhit) | enum | `Page(String) \| Url(String)` | What a clicked link-like construct targets | — |
@@ -333,7 +335,35 @@ Parse a `<!-- table:STYLE -->` marker into its [`TableStyle`](#enum-tablestyle).
 
 **Returns** — the style, or `None` for anything unrecognized (no comment
 delimiters, no `table:` prefix, unknown style name) — so an unknown marker
-stays a plain HTML comment.
+stays a plain HTML comment. Attribute tokens after the style name (`cols=…`)
+are tolerated and ignored here.
+
+---
+
+## `table_col_widths`
+
+```rust
+pub fn table_col_widths(text: &str) -> Option<Vec<f32>>
+```
+
+Explicit column widths (logical px) from a table marker's `cols=` attribute —
+`<!-- table:grid cols=120,80,200 -->` — written by the editor's
+drag-to-resize. Both renderers apply them over the content measurement.
+
+**Returns** — the widths, or `None` when the attribute is absent or malformed
+(non-numeric, non-positive, or empty) — the table stays content-measured.
+
+---
+
+## `table_marker_text`
+
+```rust
+pub fn table_marker_text(style: TableStyle, widths: Option<&[f32]>) -> Option<String>
+```
+
+The marker line for `style` plus optional explicit column widths (rounded to
+whole px) — the inverse of the two parsers above. **Returns** `None` when the
+marker would say nothing (Grid style, no widths): the default needs no marker.
 
 ---
 

--- a/crates/gpui-markdown/src/syntax.rs
+++ b/crates/gpui-markdown/src/syntax.rs
@@ -160,12 +160,62 @@ impl TableStyle {
 /// value) into its [`TableStyle`]. `None` for anything unrecognized, so an
 /// unknown marker stays a plain HTML comment.
 pub fn table_style_marker(text: &str) -> Option<TableStyle> {
+    let body = table_marker_body(text)?;
+    // The style name is the first token; later tokens are attributes
+    // (`cols=…` column widths).
+    TableStyle::from_name(body.split_whitespace().next().unwrap_or(""))
+}
+
+/// The inner body of a `<!-- table:… -->` marker (style name + attributes),
+/// or `None` for any other text.
+fn table_marker_body(text: &str) -> Option<&str> {
     let inner = text
         .trim()
         .strip_prefix("<!--")?
         .strip_suffix("-->")?
         .trim();
-    TableStyle::from_name(inner.strip_prefix("table:")?.trim())
+    Some(inner.strip_prefix("table:")?.trim())
+}
+
+/// Explicit column widths (logical px) from a table marker's `cols=` attribute
+/// — `<!-- table:grid cols=120,80,200 -->` — written by the editor's
+/// drag-to-resize. `None` when absent or malformed (the table stays
+/// content-measured).
+pub fn table_col_widths(text: &str) -> Option<Vec<f32>> {
+    let body = table_marker_body(text)?;
+    let attr = body
+        .split_whitespace()
+        .find_map(|tok| tok.strip_prefix("cols="))?;
+    let widths: Vec<f32> = attr
+        .split(',')
+        .map(|w| w.trim().parse::<f32>())
+        .collect::<Result<_, _>>()
+        .ok()?;
+    (!widths.is_empty() && widths.iter().all(|w| w.is_finite() && *w > 0.)).then_some(widths)
+}
+
+/// A table marker line for `style` (+ optional explicit column widths) — the
+/// inverse of the parsers above. `None` when the marker would say nothing
+/// (Grid, no widths): the default needs no marker.
+pub fn table_marker_text(style: TableStyle, widths: Option<&[f32]>) -> Option<String> {
+    let name = match style {
+        TableStyle::Grid => "grid",
+        TableStyle::Striped => "striped",
+        TableStyle::Header => "header",
+        TableStyle::Minimal => "minimal",
+    };
+    match widths {
+        Some(w) if !w.is_empty() => {
+            let list = w
+                .iter()
+                .map(|w| (w.round() as i64).to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            Some(format!("<!-- table:{name} cols={list} -->"))
+        }
+        _ if style != TableStyle::Grid => Some(format!("<!-- table:{name} -->")),
+        _ => None,
+    }
 }
 
 /// Font-size multiplier for a heading of the given depth (h1 largest, h6 =

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -11,11 +11,11 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use gpui::{
-    AnyElement, App, Bounds, Corners, ElementId, FontStyle, FontWeight, HighlightStyle, Hsla,
-    InteractiveElement, InteractiveText, IntoElement, MouseButton, MouseDownEvent, ParentElement,
-    Pixels, RenderImage, RenderOnce, ScrollHandle, SharedString, StatefulInteractiveElement,
-    StrikethroughStyle, Styled, StyledText, TextRun, Window, canvas, div, point,
-    prelude::FluentBuilder, px, relative, rgb, rgba, size, svg,
+    AnyElement, App, Bounds, ClipboardItem, Corners, ElementId, FontStyle, FontWeight,
+    HighlightStyle, Hsla, InteractiveElement, InteractiveText, IntoElement, MouseButton,
+    MouseDownEvent, ParentElement, Pixels, RenderImage, RenderOnce, ScrollHandle, SharedString,
+    StatefulInteractiveElement, StrikethroughStyle, Styled, StyledText, TextRun, Window, canvas,
+    div, point, prelude::FluentBuilder, px, relative, rgb, rgba, size, svg,
 };
 use markdown::mdast;
 
@@ -1013,6 +1013,51 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
                         .width()
                 })
                 .fold(px(0.0), Pixels::max);
+            // Hover chrome at the card's top-right (Cditor-inspired): the
+            // language tag and a Copy button (writes the raw code to the
+            // clipboard). The WYSIWYG editor paints the same chip.
+            ctx.counter += 1;
+            let group: SharedString = format!("{}-code-{}", ctx.id_base, ctx.counter).into();
+            let code_text: SharedString = c.value.clone().into();
+            let mut chip_fg = ctx.style.muted_color;
+            chip_fg.a *= 0.9;
+            let chrome = div()
+                .absolute()
+                .top(px(4.0))
+                .right(px(6.0))
+                .invisible()
+                .group_hover(group.clone(), |s| s.visible())
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(8.0))
+                .text_size(px(11.0))
+                .text_color(chip_fg)
+                .children(
+                    c.lang
+                        .clone()
+                        .filter(|l| !l.is_empty())
+                        .map(|l| div().child(SharedString::from(l))),
+                )
+                .child(
+                    div()
+                        .id(ElementId::Name(format!("{group}-copy").into()))
+                        .px(px(6.0))
+                        .py(px(1.0))
+                        .rounded(px(4.0))
+                        .cursor_pointer()
+                        .hover(|s| s.bg(ctx.style.mark_bg))
+                        .on_mouse_down(MouseButton::Left, {
+                            let code_text = code_text.clone();
+                            move |_: &MouseDownEvent, _window, app| {
+                                app.stop_propagation();
+                                app.write_to_clipboard(ClipboardItem::new_string(
+                                    code_text.to_string(),
+                                ));
+                            }
+                        })
+                        .child("Copy"),
+                );
             Some(
                 div()
                     .w(widest + px(26.0))
@@ -1023,7 +1068,10 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
                     .py(px(8.0))
                     .font_family(ctx.style.mono_font.clone())
                     .text_color(color)
+                    .relative()
+                    .group(group)
                     .child(text)
+                    .child(chrome)
                     .into_any_element(),
             )
         }

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -19,7 +19,9 @@ use gpui::{
 };
 use markdown::mdast;
 
-use crate::syntax::{AlertKind, TableStyle, alert_marker, heading_scale, table_style_marker};
+use crate::syntax::{
+    AlertKind, TableStyle, alert_marker, heading_scale, table_col_widths, table_style_marker,
+};
 
 /// Visual configuration for the renderer. The host fills this from its
 /// own theme; defaults are a neutral dark palette.
@@ -780,16 +782,12 @@ impl RenderOnce for MarkdownView {
                     if let mdast::Node::Html(h) = node
                         && let Some(style) = table_style_marker(&h.value)
                     {
-                        pending_style = Some(style);
+                        pending_style = Some((style, table_col_widths(&h.value)));
                         continue;
                     }
                     if let mdast::Node::Table(t) = node {
-                        col = col.child(render_table(
-                            t,
-                            &mut ctx,
-                            pending_style.take().unwrap_or_default(),
-                            window,
-                        ));
+                        let (style, widths) = pending_style.take().unwrap_or_default();
+                        col = col.child(render_table(t, &mut ctx, style, widths, window));
                         continue;
                     }
                     pending_style = None;
@@ -1211,7 +1209,7 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
         ),
         // Top-level tables get their style from a preceding marker (see the root
         // loop); a nested/standalone table here renders as the default Grid.
-        mdast::Node::Table(t) => Some(render_table(t, ctx, TableStyle::default(), window)),
+        mdast::Node::Table(t) => Some(render_table(t, ctx, TableStyle::default(), None, window)),
         // A footnote definition: `[label] <content>`, rendered muted/smaller
         // where it sits (authors put these at the bottom).
         mdast::Node::FootnoteDefinition(f) => {
@@ -2146,16 +2144,12 @@ fn render_embed(
             if let mdast::Node::Html(h) = node
                 && let Some(style) = table_style_marker(&h.value)
             {
-                pending_style = Some(style);
+                pending_style = Some((style, table_col_widths(&h.value)));
                 continue;
             }
             if let mdast::Node::Table(t) = node {
-                body = body.child(render_table(
-                    t,
-                    ctx,
-                    pending_style.take().unwrap_or_default(),
-                    window,
-                ));
+                let (style, widths) = pending_style.take().unwrap_or_default();
+                body = body.child(render_table(t, ctx, style, widths, window));
                 continue;
             }
             pending_style = None;
@@ -2346,6 +2340,7 @@ fn render_table(
     table: &mdast::Table,
     ctx: &mut Ctx,
     style: TableStyle,
+    explicit_widths: Option<Vec<f32>>,
     window: &mut Window,
 ) -> AnyElement {
     let border = ctx.style.muted_color;
@@ -2402,6 +2397,13 @@ fn render_table(
     }
     for w in &mut widths {
         *w = (*w).max(px(48.0));
+    }
+    // The marker's `cols=` widths (the editor's drag-to-resize) override the
+    // measurement, floored so a column can't vanish.
+    if let Some(explicit) = &explicit_widths {
+        for (ci, w) in explicit.iter().enumerate().take(ncols) {
+            widths[ci] = px(w.max(24.0));
+        }
     }
     // The grid must be sized explicitly: gpui's default stretch alignment
     // would otherwise fill the parent's full width, leaving a void after the
@@ -2743,6 +2745,31 @@ mod search_tests {
         );
         assert_eq!(table_style_marker("<!-- table:nope -->"), None);
         assert_eq!(table_style_marker("<!-- ordinary -->"), None);
+        // Width attributes ride along without breaking the style parse.
+        assert_eq!(
+            table_style_marker("<!-- table:striped cols=120,80 -->"),
+            Some(TableStyle::Striped)
+        );
+        assert_eq!(
+            table_col_widths("<!-- table:grid cols=120,80.5 -->"),
+            Some(vec![120.0, 80.5])
+        );
+        assert_eq!(table_col_widths("<!-- table:grid -->"), None);
+        assert_eq!(table_col_widths("<!-- table:grid cols=x,1 -->"), None);
+        assert_eq!(table_col_widths("<!-- table:grid cols=0,1 -->"), None);
+        // The writer round-trips: Grid + no widths needs no marker at all.
+        assert_eq!(
+            crate::syntax::table_marker_text(TableStyle::Grid, None),
+            None
+        );
+        assert_eq!(
+            crate::syntax::table_marker_text(TableStyle::Grid, Some(&[100.4, 50.0])),
+            Some("<!-- table:grid cols=100,50 -->".to_string())
+        );
+        assert_eq!(
+            crate::syntax::table_marker_text(TableStyle::Minimal, None),
+            Some("<!-- table:minimal -->".to_string())
+        );
     }
 
     #[test]

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -736,6 +736,7 @@ impl RenderOnce for MarkdownView {
             folded_headings: self.folded_headings,
             on_heading_toggle: self.on_heading_toggle,
             suppress_heading_top: false,
+            strike_done: false,
             embed_depth: 0,
         };
 
@@ -847,6 +848,9 @@ struct Ctx {
     /// top margin so the bullet marker lines up with the heading text instead of
     /// floating above it.
     suppress_heading_top: bool,
+    /// Set while rendering a checked task item's content: inline text renders
+    /// struck through + muted (Notion-style done state).
+    strike_done: bool,
     /// Transclusion nesting level — embeds inside embeds stop at a small cap,
     /// which also breaks A-embeds-B-embeds-A cycles.
     embed_depth: usize,
@@ -1350,10 +1354,10 @@ fn render_list(list: &mdast::List, ctx: &mut Ctx, depth: usize, window: &mut Win
         let mdast::Node::ListItem(li) = item else {
             continue;
         };
-        // GFM task items (`- [ ]` / `- [x]`) carry `checked`; render a box
-        // instead of a bullet/number.
-        let marker = if let Some(done) = li.checked {
-            (if done { "☑" } else { "☐" }).to_string()
+        // GFM task items (`- [ ]` / `- [x]`) carry `checked`; a drawn box
+        // renders instead of a bullet/number (see below).
+        let marker = if li.checked.is_some() {
+            String::new()
         } else if list.ordered {
             // Word-style depth markers, counted from 1 — the WYSIWYG editor
             // numbers the same way, and source digits are display-irrelevant.
@@ -1372,11 +1376,14 @@ fn render_list(list: &mdast::List, ctx: &mut Ctx, depth: usize, window: &mut Win
                     // Drop a leading heading's top margin so the bullet lines up
                     // with the heading; later blocks in the item keep theirs.
                     let prev = ctx.suppress_heading_top;
+                    let prev_strike = ctx.strike_done;
                     ctx.suppress_heading_top = ci == 0;
+                    ctx.strike_done = li.checked == Some(true);
                     if let Some(el) = render_block(other, ctx, window) {
                         content = content.child(el);
                     }
                     ctx.suppress_heading_top = prev;
+                    ctx.strike_done = prev_strike;
                 }
             }
         }
@@ -1391,13 +1398,46 @@ fn render_list(list: &mdast::List, ctx: &mut Ctx, depth: usize, window: &mut Win
         };
         let marker_top = px(f32::from(ctx.style.text_size) * (lead_scale - 1.0) * 1.618_034 / 2.0);
 
-        // The marker is a plain glyph, except a task's ☐/☑ is clickable: a click
-        // calls back with the item's source offset so the host can flip + persist.
-        let mut marker_el = div()
-            .flex_shrink_0()
-            .pt(marker_top)
-            .text_color(ctx.style.muted_color)
-            .child(marker);
+        // The marker is a plain glyph, except a task's box, which is drawn (a
+        // rounded square, accent-filled with a white check when done — the
+        // editor paints the same) and clickable: a click calls back with the
+        // item's source offset so the host can flip + persist.
+        let mut marker_el = if let Some(done) = li.checked {
+            let sz = px(f32::from(ctx.style.text_size) * 0.9);
+            let line_h = px(f32::from(ctx.style.text_size) * ctx.style.line_height);
+            let bx = if done {
+                div()
+                    .size(sz)
+                    .rounded(px(3.0))
+                    .bg(ctx.style.link_color)
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .text_color(gpui::white())
+                    .text_size(sz * 0.72)
+                    .child("✓")
+            } else {
+                div()
+                    .size(sz)
+                    .rounded(px(3.0))
+                    .border_1()
+                    .border_color(ctx.style.muted_color)
+            };
+            // Center the box on the item's first text line.
+            div()
+                .flex_shrink_0()
+                .pt(marker_top)
+                .h(line_h)
+                .flex()
+                .items_center()
+                .child(bx)
+        } else {
+            div()
+                .flex_shrink_0()
+                .pt(marker_top)
+                .text_color(ctx.style.muted_color)
+                .child(marker)
+        };
         if li.checked.is_some()
             && let (Some(off), Some(toggle)) = (
                 li.position.as_ref().map(|p| p.start.offset),
@@ -1484,9 +1524,18 @@ impl Inline {
 
 fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
     let mut inl = Inline::default();
+    // A checked task's text renders struck through + muted (Notion-style).
+    let mut base = HighlightStyle::default();
+    if ctx.strike_done {
+        base.strikethrough = Some(StrikethroughStyle {
+            thickness: px(1.0),
+            color: None,
+        });
+        base.color = Some(ctx.style.muted_color);
+    }
     build_inline(
         nodes,
-        HighlightStyle::default(),
+        base,
         &ctx.style,
         &ctx.definitions,
         ctx.on_inline_math.as_ref(),

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -1031,7 +1031,7 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
                 .flex_row()
                 .items_center()
                 .gap(px(8.0))
-                .text_size(px(11.0))
+                .text_size(px(13.0))
                 .text_color(chip_fg)
                 .children(
                     c.lang

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -334,6 +334,11 @@ pub const SNIPPETS: &[Snippet] = &[
         caret: 6,
     },
     Snippet {
+        label: "Underline",
+        snippet: "<u></u>",
+        caret: 3,
+    },
+    Snippet {
         label: "Link",
         snippet: "[]()",
         caret: 1,
@@ -1872,14 +1877,23 @@ fn build_inline(
                         .push((start..end, LinkTarget::Url(url.clone().into())));
                 }
             }
-            // Inline raw HTML stays literal (never executed) — except `<mark>`, a
-            // safe highlight tag: toggle a background on the runs it wraps.
+            // Inline raw HTML stays literal (never executed) — except `<mark>`
+            // (a safe highlight tag) and `<u>` (underline — markdown has none
+            // natively): each toggles its style on the runs it wraps.
             mdast::Node::Html(h) => {
                 let tag = h.value.trim().to_ascii_lowercase();
                 if tag == "<mark>" || tag.starts_with("<mark ") {
                     cur.background_color = Some(style.mark_bg);
                 } else if tag == "</mark>" {
                     cur.background_color = None;
+                } else if tag == "<u>" {
+                    cur.underline = Some(gpui::UnderlineStyle {
+                        thickness: px(1.0),
+                        color: None,
+                        wavy: false,
+                    });
+                } else if tag == "</u>" {
+                    cur.underline = None;
                 } else {
                     push_run(&h.value, cur, out);
                 }

--- a/crates/gpui-whiteboard/API.md
+++ b/crates/gpui-whiteboard/API.md
@@ -16,11 +16,23 @@ world-space `f32` (see [`Camera`](#camera)).
 | [`Scene`](#scene) | struct | `{ camera, elements }` | The board document — everything persisted |
 | [`Scene::from_json`](#scenefrom_json) | assoc fn | `fn from_json(s: &str) -> Self` | Parse stored JSON; empty board on bad input |
 | [`Scene::to_json`](#sceneto_json) | method | `fn to_json(&self) -> String` | Serialize for persistence |
-| [`Element`](#element) | struct | `{ id, kind, stroke, fill, label, label_color, styles }` | One board element |
+| [`Element`](#element) | struct | `{ id, kind, stroke, fill, label, label_color, styles, mindmap }` | One board element |
 | [`ElementKind`](#elementkind) | enum | 13 variants | What an element is (pen stroke, shape, text, …) |
 | [`Stroke`](#stroke) | struct | `{ points, width }` | Freehand pen geometry |
 | [`BoxGeom`](#boxgeom) | struct | `{ x, y, w, h, width, rotation }` | Box-shape geometry (rect/ellipse/…) |
-| [`SegGeom`](#seggeom) | struct | `{ x1, y1, x2, y2, width }` | Line / arrow geometry |
+| [`SegGeom`](#seggeom) | struct | `{ x1, y1, x2, y2, width, style, start_anchor, end_anchor }` | Line / arrow geometry |
+| [`SegmentStyle`](#segmentstyle) | enum | `Solid \| Dashed` | A line/arrow's stroke style |
+| [`SegmentAnchor`](#segmentanchor) | struct | `{ element_id, connector }` | A segment endpoint bound to a shape |
+| [`MindMapNodeMeta`](#mindmapnodemeta) | struct | `{ parent, side, order, root_direction, connector_style }` | Mind-map metadata on an element |
+| [`MindMapSide`](#mindmap-enums) | enum | `Left \| Right` | Which side of the root a branch hangs |
+| [`MindMapRootDirection`](#mindmap-enums) | enum | `Both \| Left \| Right` | Root's growth direction |
+| [`MindMapConnectorStyle`](#mindmap-enums) | enum | `Straight \| Bezier \| Orthogonal` | Mind-map connector rendering |
+| [`LocalThumbnailMode`](#local-thumbnails) | enum | thumbnail framing modes | How a snapshot frames the scene |
+| [`LocalThumbnailSpec`](#local-thumbnails) | struct | framing + size | A thumbnail's render parameters |
+| [`LocalThumbnailSnapshot`](#local-thumbnails) | struct | `{ scene, camera, spec, … }` | A frozen scene + framing for a thumbnail |
+| [`BoardEmbedView`](#boardembedview) | struct | entity | A read-only embedded board + Edit button |
+| [`BoardThumbnailView`](#boardthumbnailview) | struct | entity | A static thumbnail rendering of a snapshot |
+| [`ExpandEmbedFn`](#boardembedview) | type alias | `Rc<dyn Fn(&mut Window, &mut App)>` | Embed's Edit button clicked |
 | [`TextGeom`](#textgeom) | struct | `{ x, y, content, size, rotation, … }` | Free-text geometry |
 | [`EmbedGeom`](#embedgeom) | struct | `{ page_id, title, x, y, w, h }` | Page-card geometry |
 | [`ImageGeom`](#imagegeom) | struct | `{ src, x, y, w, h, rotation }` | Image geometry (host-managed `src`) |
@@ -305,11 +317,15 @@ pub struct SegGeom {
     pub x2: f32,
     pub y2: f32,
     pub width: f32,
+    pub style: SegmentStyle,               // serde default: Solid
+    pub start_anchor: Option<SegmentAnchor>, // serde default: None
+    pub end_anchor: Option<SegmentAnchor>,   // serde default: None
 }
 ```
 
 A directed segment (line / arrow), world-space. An arrow's head sits at
-`(x2, y2)`.
+`(x2, y2)`. All three newer fields are serde-defaulted, so boards saved before
+they existed keep loading.
 
 **Fields**
 
@@ -318,6 +334,132 @@ A directed segment (line / arrow), world-space. An arrow's head sits at
 | `x1`, `y1` | `f32` | Start point, world space. |
 | `x2`, `y2` | `f32` | End point, world space. |
 | `width` | `f32` | Stroke width, world units. |
+| `style` | [`SegmentStyle`](#segmentstyle) | Solid (default) or dashed stroke. |
+| `start_anchor`, `end_anchor` | `Option<SegmentAnchor>` | When set, the endpoint is BOUND to a shape's connector point and follows it as the shape moves/resizes/rotates; moving the segment itself detaches. Endpoints snap to hovered connector points while drawing. |
+
+---
+
+## `SegmentStyle`
+
+```rust
+pub enum SegmentStyle { Solid, Dashed }
+```
+
+A line/arrow's stroke rendering. Serde-defaults to `Solid` in older boards.
+
+---
+
+## `SegmentAnchor`
+
+```rust
+pub struct SegmentAnchor {
+    pub element_id: u64,
+    pub connector: usize,
+}
+```
+
+A segment endpoint's binding: the target element's `id` and the index of one
+of its connector points (edge midpoints; see the on-canvas connector dots that
+appear when hovering a shape with the line/arrow tool). Dangling ids (element
+deleted) detach harmlessly.
+
+---
+
+## `MindMapNodeMeta`
+
+```rust
+pub struct MindMapNodeMeta {
+    pub parent: Option<u64>,
+    pub side: MindMapSide,
+    pub order: usize,
+    pub root_direction: MindMapRootDirection,
+    pub connector_style: MindMapConnectorStyle,
+}
+```
+
+Mind-map bookkeeping carried by [`Element::mindmap`](#element) (`None` for
+ordinary elements; serde-skipped when absent). A `parent` of `None` marks the
+tree's ROOT node — `root_direction` and `connector_style` are read from the
+root and apply to its whole tree. Child nodes hang on `side` at `order` among
+their siblings. The view maintains the parent links, auto-layout, and the
+"+" add-node buttons; the tree's connector segments re-sync whenever nodes
+move or the tree changes.
+
+---
+
+## Mind-map enums
+
+```rust
+pub enum MindMapSide { Left, Right }
+pub enum MindMapRootDirection { Both, Left, Right }   // Default: Both
+pub enum MindMapConnectorStyle { Straight, Bezier, Orthogonal } // Default: Bezier
+```
+
+Selecting a root offers Direction and Connector pickers in the context UI;
+`Both` alternates new branches left/right.
+
+---
+
+## Local thumbnails
+
+```rust
+pub enum LocalThumbnailMode { /* framing modes */ }
+pub struct LocalThumbnailSpec { /* framing + pixel size */ }
+pub struct LocalThumbnailSnapshot {
+    pub scene: Scene,
+    pub camera: Camera,
+    pub spec: LocalThumbnailSpec,
+}
+
+impl LocalThumbnailSnapshot {
+    pub fn for_scene_all_content(scene: Scene, width_px: f32, height_px: f32) -> Self
+}
+```
+
+A frozen scene plus the framing needed to paint it small. Build one with
+`for_scene_all_content` (frames the whole board's content into
+`width_px × height_px`) and hand it to a
+[`BoardThumbnailView`](#boardthumbnailview). Pure data — cheap to clone/store;
+re-snapshot when the scene changes.
+
+---
+
+## `BoardEmbedView`
+
+```rust
+pub struct BoardEmbedView { /* entity */ }
+pub type ExpandEmbedFn = Rc<dyn Fn(&mut Window, &mut App)>;
+
+impl BoardEmbedView {
+    pub fn new(scene: Scene, style: WhiteboardStyleFn, cx: &mut Context<Self>) -> Self
+    pub fn board(&self) -> Entity<WhiteboardView>
+    pub fn set_on_expand(&mut self, f: ExpandEmbedFn)
+}
+```
+
+A read-only board embedded inside another surface (a document, a preview
+pane): renders the scene with pan/zoom wheel input suppressed and an "Edit"
+button overlaid; `set_on_expand` receives the click so the HOST runs its own
+maximize / open-editor transition. `board()` exposes the inner
+[`WhiteboardView`](#whiteboardview) (e.g. to `set_scene` on refresh).
+
+---
+
+## `BoardThumbnailView`
+
+```rust
+pub struct BoardThumbnailView { /* entity */ }
+
+impl BoardThumbnailView {
+    pub fn new(snapshot: LocalThumbnailSnapshot, style: WhiteboardStyleFn) -> Self
+    pub fn snapshot(&self) -> &LocalThumbnailSnapshot
+    pub fn set_snapshot(&mut self, snapshot: LocalThumbnailSnapshot)
+}
+```
+
+A static, non-interactive rendering of a
+[`LocalThumbnailSnapshot`](#local-thumbnails) — for board lists, cards, and
+document blocks. No input handling at all; swap the snapshot to refresh.
 
 ---
 
@@ -934,6 +1076,36 @@ pub fn new(scene: Scene, style: WhiteboardStyleFn, cx: &mut Context<Self>) -> Se
 ```
 
 Build a view over `scene`. Call inside `cx.new(|cx| WhiteboardView::new(..))`.
+
+### Read-only mode
+
+```rust
+pub fn new_read_only(scene: Scene, style: WhiteboardStyleFn, cx: &mut Context<Self>) -> Self
+pub fn set_read_only(&mut self, read_only: bool, cx: &mut Context<Self>)
+pub fn read_only(&self) -> bool
+```
+
+A read-only board renders without the toolbar or any editing affordances and
+ignores editing input (wheel pan/zoom too — it sits quietly inside another
+scroll surface). Used by [`BoardEmbedView`](#boardembedview); also togglable
+live on any view.
+
+### Mind-map & flowchart seeds
+
+```rust
+pub fn add_mindmap_seed(&mut self, center_x: f32, center_y: f32, cx: &mut Context<Self>)
+pub fn add_mindmap_seed_at_viewport_center(&mut self, cx: &mut Context<Self>)
+pub fn add_flowchart_seed(&mut self, center_x: f32, center_y: f32, cx: &mut Context<Self>)
+pub fn add_flowchart_seed_at_viewport_center(&mut self, cx: &mut Context<Self>)
+```
+
+Insert a starter mind-map (a root + four labeled branches, with
+[`MindMapNodeMeta`](#mindmapnodemeta) wired and bound connectors) or a starter
+flowchart (Start → Process → Decision with Yes/No branches → End) centered at
+the given world point / the current viewport center. Both are also on the
+toolbar's shapes flyout; one undo step each. Mind-map trees keep their layout
+and connectors in sync as nodes are added (the selection's "+" buttons),
+moved, or deleted; a selected root offers Direction and Connector pickers.
 
 **Parameters**
 

--- a/crates/gpui-whiteboard/README.md
+++ b/crates/gpui-whiteboard/README.md
@@ -7,11 +7,14 @@ picker, templates, copy-paste, and undo/redo.
 
 Host-agnostic: its only dependencies are `gpui`, `serde` / `serde_json`, `log`, and
 `ttf-parser` (**no `gpui-component`, no native libraries**), so it drops into any
-GPUI app on macOS, Linux, or Windows.
+GPUI app on macOS, Linux, or Windows. It comes in two layers:
 
-**📖 Full reference:** every public item — the scene model, all `WhiteboardView`
-methods, every host callback — with signatures, parameter tables, return
-contracts, and edge cases, lives in [API.md](API.md).
+- a plain, serializable **scene model** ([`Scene`](#the-scene-model) / [`Element`] / …)
+  that you persist as an opaque JSON string in your own store, and
+- a ready-made **[`WhiteboardView`](#whiteboardview)** entity that renders the board
+  *and its whole editing UI* (toolbar, flyouts, color picker, templates gallery,
+  right-click menu) and drives all interaction — you supply a theme and a handful of
+  optional callbacks.
 
 ## Features
 
@@ -23,41 +26,40 @@ contracts, and edge cases, lives in [API.md](API.md).
 - **Rich element set.** Freehand pen, rectangle, ellipse, diamond, triangle, rounded
   rectangle, hexagon, 5-point star, line, arrow, text, images, and page-cards — all
   share one select / move / resize / rotate / fill machinery.
-- **Pan / zoom infinite canvas.** World-space coordinates with a camera (pan offset
-  + zoom); drag to pan, scroll/pinch to zoom, snap-to-grid while holding ⌥.
+- **Pan / zoom infinite canvas.** World-space coordinates with a [`Camera`] (pan
+  offset + zoom); drag to pan, scroll/pinch to zoom, snap-to-grid while holding ⌥.
 - **Vector text.** Text is rendered as glyph **outlines** (via `ttf-parser`), not
   gpui overlay glyphs — so it rotates, scales, and z-orders exactly like shapes, and
-  you can swap in a custom/user-uploaded face. JetBrains Mono ships bundled, so the
-  crate works standalone.
-- **Auto-fitting shape labels.** Double-click any closed shape to type a centered
-  label; it word-wraps and auto-shrinks to fit the shape's *inscribed* area, rotates
-  with the shape, and edits with full caret / selection / clipboard support.
-- **Rich text formatting.** Per-character bold, italic, underline, strikethrough,
-  and highlight on any text — via keyboard (⌘B / ⌘I / ⌘U / ⇧⌘X / ⇧⌘H), the
-  right-click **Text ▸** fly-out, or the toolbar's **A** fly-out. Bold/italic are
-  synthetic, so they work with any uploaded face; runs are stored in the scene.
-- **True z-order.** Shapes and image/card overlays paint in one interleaved stack;
-  reorder via the menu or `⌘]` / `⌘[` (± ⇧).
-- **Copy / paste / templates.** `⌘C`/`⌘X`/`⌘V` plus reusable named templates — both
-  serialize a selection to the same portable JSON, so groups move across boards.
-- **Undo / redo**, multi-select (marquee + shift-click), group move/resize/rotate.
+  you can swap in a [custom/user-uploaded face](#custom-fonts). JetBrains Mono ships
+  bundled, so the crate works standalone.
+- **Auto-fitting shape labels.** Double-click any closed shape (rect / ellipse /
+  diamond / triangle / rounded-rect / star / hexagon) to type a centered label. The
+  text word-wraps and auto-shrinks to fit the shape's *inscribed* area — staying
+  inside slanted or round outlines (a diamond's center, a triangle's lower wedge),
+  not just the bounding box — and rotates with the shape, with the same caret /
+  selection / clipboard editing as free text. Color it independently of the outline
+  via the picker's **Text** tab (alongside Stroke / Fill).
+- **Rich text formatting.** Per-character **bold**, italic, underline,
+  strikethrough, and highlight on any text — free text or shape labels. Toggle via
+  keyboard (⌘B / ⌘I / ⌘U / ⇧⌘X / ⇧⌘H), a right-click **Text ▸** fly-out, or the
+  toolbar's **A** fly-out — each showing a ✓ on the formats active across the
+  selection. Bold and italic are synthetic (so they work with any uploaded face);
+  the styling is stored as runs in the scene and survives edits.
+- **True z-order.** Canvas shapes and image/card overlays paint in one interleaved
+  stack, so a shape can sit *above or below* an image. Bring to Front / Forward /
+  Backward / Send to Back via the menu or `⌘]` / `⌘[` (± ⇧).
+- **Copy / paste / templates.** `⌘C`/`⌘X`/`⌘V` and a right-click Copy/Cut/Paste, plus
+  reusable named templates — both serialize a selection to the same portable JSON, so
+  groups move across boards and windows.
+- **Undo / redo**, multi-select (marquee + shift-click), group move/resize, and a
+  rotate grip on the selection.
 - **Theme-reactive.** Colors come from a `Fn() -> WhiteboardStyle` closure read at
-  paint time, so the board follows live theme changes with no push from the host.
+  paint time, so the board follows live theme / light-dark changes (and can differ
+  per window) with no push from the host.
 - **You own persistence, files, and navigation.** The crate never touches disk, the
-  clipboard, or your page store — it calls back to you and hands you a plain JSON
-  string to store however you like.
-
-## Adding the dependency
-
-The crate lives in the Zorite workspace (not on crates.io); depend on it by path:
-
-```toml
-[dependencies]
-gpui-whiteboard = { path = "../gpui-whiteboard" }
-```
-
-It follows the workspace's `gpui` pin (`gpui = { workspace = true }`), so the app
-and the crate unify to one gpui.
+  clipboard, or your page store. It calls back to you ([hooks](#host-hooks)) to fetch
+  an image bitmap, open a page, read/write the clipboard, or persist the scene — and
+  hands you a plain JSON string to store however you like.
 
 ## Quick start
 
@@ -94,25 +96,343 @@ let board = cx.new(|cx| {
 div().size_full().child(board.clone())
 ```
 
-That alone gives a fully usable board (every tool, color picker, undo/redo,
-z-order). Wire the optional hooks to add page-cards, images, system-clipboard
-copy/paste, templates, custom fonts, and toolbar-layout memory — each is a
-`set_on_*` installer documented in [API.md](API.md).
+That alone gives a fully usable board (every tool, color picker, undo/redo, z-order,
+copy/paste between boards). Wire the [optional hooks](#host-hooks) to add page-cards,
+images, templates, and system-clipboard paste.
 
-## Host integration
+## Embedding in a rich-text editor
 
-- **Persistence.** Store the JSON string `on_change` hands you (or
-  `view.scene().to_json()`); reload with `Scene::from_json`, which never panics —
-  empty/garbage yields a blank board. The scene JSON is forward-leaning: new
-  fields use serde defaults, so older boards keep loading.
-- **Images and the clipboard stay yours.** The scene stores only a `src`
-  reference; the crate asks for the decoded bitmap each paint (`ImageFn`) — you
-  own the file store and the cache. Copy/paste routes through `CopyFn`/`PasteFn`
-  so the system clipboard is the source of truth.
-- **Pages, templates, fonts, toolbar layout** all round-trip the same way: a hook
-  reports the change, you persist it, and push it back with the matching `set_*`
-  method. Exact contracts per hook are in [API.md](API.md).
-- **Coordinates** passed to hooks are world-space; see [`Camera`](API.md#camera).
+When you embed the board inside a larger editor, the most common integration mode is
+read-only preview + viewport movement.
+
+Use the dedicated constructor:
+
+```rust
+use std::rc::Rc;
+use gpui_whiteboard::{Scene, WhiteboardStyle, WhiteboardView};
+
+let board = cx.new(|cx| {
+    WhiteboardView::new_read_only(
+        Scene::from_json(&stored_json),
+        Rc::new(light_style),
+        cx,
+    )
+});
+```
+
+Or switch an existing board at runtime:
+
+```rust
+board.update(cx, |view, cx| {
+    view.set_read_only(true, cx);
+});
+```
+
+`read_only = true` means the board behaves like a forced move tool:
+
+- left-drag pans the canvas
+- selection / editing / creation are ignored
+- external `set_tool(..)` calls are coerced back to pan mode
+
+If you want a ready-made embed surface with an "edit / maximize" affordance, use
+`BoardEmbedView`:
+
+```rust
+use std::rc::Rc;
+use gpui_whiteboard::{BoardEmbedView, Scene, WhiteboardStyle};
+
+let embed = cx.new(|cx| {
+    let mut v = BoardEmbedView::new(
+        Scene::from_json(&stored_json),
+        Rc::new(light_style),
+        cx,
+    );
+    v.set_on_expand(Rc::new(|window, cx| {
+        // Host/editor decides what "maximize for editing" means:
+        // - open a modal
+        // - switch to a dedicated editor tab
+        // - expand the current block
+    }));
+    v
+});
+```
+
+Recommended responsibility split:
+
+- `gpui-whiteboard` owns the embedded preview surface and the "Edit" button
+- your editor owns the actual maximize / modal / split-pane transition
+
+For local thumbnails inside a document block, use the snapshot + thumbnail view
+pair:
+
+```rust
+use std::rc::Rc;
+use gpui_whiteboard::{BoardThumbnailView, Scene, WhiteboardStyle, WhiteboardView};
+
+let snapshot = board.read(cx).local_thumbnail_snapshot(320.0, 180.0);
+
+let thumb = snapshot.map(|snapshot| {
+    cx.new(|_| BoardThumbnailView::new(snapshot, Rc::new(light_style)))
+});
+```
+
+This renders a chrome-free local preview:
+
+- background grid
+- shapes / text / connectors
+- page cards
+- image placeholders
+
+It intentionally does not render the toolbar, selection handles, or editing
+chrome.
+
+## API
+
+### `WhiteboardView`
+
+A gpui entity (`impl Render`) that owns the scene, the current tool, selection,
+in-progress edits, undo history, and the entire editing UI. Store the
+`Entity<WhiteboardView>` and render it in a tab/panel.
+
+**Construction**
+
+| Method | Signature | Purpose |
+| --- | --- | --- |
+| `new` | `fn new(scene: Scene, style: WhiteboardStyleFn, cx: &mut Context<Self>) -> Self` | Build a view over `scene`. `style` is read at paint time (see [`WhiteboardStyle`](#whiteboardstyle)). Call inside `cx.new(\|cx\| …)`. |
+| `new_read_only` | `fn new_read_only(scene: Scene, style: WhiteboardStyleFn, cx: &mut Context<Self>) -> Self` | Build a read-only board view for embedding/preview. |
+
+**Imperative controls** (most boards never need these — the built-in toolbar/keys
+drive them — but they're here for custom chrome):
+
+| Method | Signature | Purpose |
+| --- | --- | --- |
+| `tool` / `set_tool` | `fn tool(&self) -> Tool` · `fn set_tool(&mut self, tool: Tool, cx: &mut Context<Self>)` | Read / set the active [`Tool`](#tool). |
+| `read_only` / `set_read_only` | `fn read_only(&self) -> bool` · `fn set_read_only(&mut self, read_only: bool, cx: &mut Context<Self>)` | Read / toggle forced-pan read-only mode. |
+| `zoom_in` / `zoom_out` / `reset_view` | `fn …(&mut self, cx: &mut Context<Self>)` | Zoom about the viewport center; `reset_view` returns to 100% at the origin. |
+| `undo` / `redo` | `fn …(&mut self, window: &mut Window, cx: &mut Context<Self>)` | Step the history. (`⌘Z` / `⌘⇧Z` do this already.) |
+| `scene` | `fn scene(&self) -> &Scene` | Borrow the current model — e.g. to persist after an `add_embed`/`add_image_at` (which don't auto-fire `on_change`). |
+| `viewport_center` | `fn viewport_center(&self) -> [f32; 2]` | The world point at the center of the viewport — where pastes/templates land. |
+| `local_thumbnail_spec` | `fn local_thumbnail_spec(&self, width_px: f32, height_px: f32) -> Option<LocalThumbnailSpec>` | Build the default local-thumbnail focus spec. |
+| `local_thumbnail_spec_for_mode` | `fn local_thumbnail_spec_for_mode(&self, mode: LocalThumbnailMode, width_px: f32, height_px: f32) -> Option<LocalThumbnailSpec>` | Build a local-thumbnail focus spec for an explicit focus mode. |
+| `local_thumbnail_snapshot` | `fn local_thumbnail_snapshot(&self, width_px: f32, height_px: f32) -> Option<LocalThumbnailSnapshot>` | Capture a serializable thumbnail snapshot (`scene + spec`). |
+| `local_thumbnail_snapshot_for_mode` | `fn local_thumbnail_snapshot_for_mode(&self, mode: LocalThumbnailMode, width_px: f32, height_px: f32) -> Option<LocalThumbnailSnapshot>` | Capture a snapshot for an explicit focus mode. |
+
+### `BoardEmbedView`
+
+A small host-facing wrapper around a read-only `WhiteboardView`, intended for rich
+text / document embedding.
+
+| Method | Signature | Purpose |
+| --- | --- | --- |
+| `new` | `fn new(scene: Scene, style: WhiteboardStyleFn, cx: &mut Context<Self>) -> Self` | Build a read-only embedded board preview. |
+| `board` | `fn board(&self) -> Entity<WhiteboardView>` | Access the inner board entity for host-driven inspection or updates. |
+| `set_on_expand` | `fn set_on_expand(&mut self, f: ExpandEmbedFn)` | Install the callback fired when the embed's "编辑" button is clicked. |
+
+### `BoardThumbnailView`
+
+A lightweight, read-only local thumbnail renderer built from a
+`LocalThumbnailSnapshot`.
+
+| Method | Signature | Purpose |
+| --- | --- | --- |
+| `new` | `fn new(snapshot: LocalThumbnailSnapshot, style: WhiteboardStyleFn) -> Self` | Build a chrome-free thumbnail view. |
+| `snapshot` | `fn snapshot(&self) -> &LocalThumbnailSnapshot` | Read the current thumbnail snapshot. |
+| `set_snapshot` | `fn set_snapshot(&mut self, snapshot: LocalThumbnailSnapshot)` | Replace the rendered snapshot without rebuilding the surrounding host UI. |
+
+### Thumbnail focus types
+
+`LocalThumbnailMode` controls what the board focuses when building a local
+thumbnail:
+
+- `Auto`: selected content first, otherwise current viewport, otherwise all content
+- `Selection`: current selection only
+- `Viewport`: current camera viewport
+- `AllContent`: all scene elements
+- `Element(id)`: one explicit element
+
+`LocalThumbnailSpec` returns:
+
+- `anchor_element_id`
+- `focus_bounds`
+- `scene_bounds`
+- `camera`
+
+`LocalThumbnailSnapshot` packages:
+
+- `scene`
+- `spec`
+
+Hosts that only have persisted scene JSON can build a document thumbnail without
+mounting a full board entity first:
+
+```rust
+let scene = Scene::from_json(&stored_json);
+let snapshot = LocalThumbnailSnapshot::for_scene_all_content(scene, 320.0, 180.0);
+let thumbnail = cx.new(|_| BoardThumbnailView::new(snapshot, style));
+```
+
+**Building elements from the host** (called *after* a place-hook fires; see
+[hooks](#host-hooks)). These run mid-host-update and so do **not** fire
+`on_change` — persist explicitly via `scene()` afterward:
+
+| Method | Signature |
+| --- | --- |
+| `add_embed` | `fn add_embed(&mut self, page_id: i64, title: impl Into<String>, x: f32, y: f32, cx: &mut Context<Self>)` |
+| `add_image_at` | `fn add_image_at(&mut self, src: impl Into<String>, px_w: f32, px_h: f32, cx_world: f32, cy_world: f32, cx: &mut Context<Self>)` |
+| `paste_elements` | `fn paste_elements(&mut self, json: &str, window: &mut Window, cx: &mut Context<Self>)` |
+
+`add_image_at` sizes the element from the image's pixel dimensions (`px_w`/`px_h`,
+aspect preserved) centered on `(cx_world, cy_world)`. `paste_elements` stamps a
+serialized selection (from a clipboard read) centered in the viewport.
+
+### `WhiteboardStyle`
+
+The board reads its palette through a `Fn() -> WhiteboardStyle` each paint (not
+stored), so returning fresh values tracks live theme changes.
+
+```rust
+pub struct WhiteboardStyle {
+    pub bg: Hsla,           // canvas background
+    pub grid: Hsla,         // background grid dots
+    pub text: Hsla,         // HUD / muted on-canvas text (zoom %, "Loading…")
+    pub ink: Hsla,          // default stroke/shape color (per-element color overrides it)
+    pub panel: Hsla,        // toolbar / flyout pills (can be glassy)
+    pub panel_strong: Hsla, // color picker / menu surface (keep opaque + readable)
+    pub accent: Hsla,       // active-tool highlight
+    pub selection: Hsla,    // selection outline (use a strong, visible color)
+    pub swatches: Vec<Hsla>,// quick swatches in the color picker (your theme colors)
+}
+
+pub type WhiteboardStyleFn = Rc<dyn Fn() -> WhiteboardStyle>;
+```
+
+### Host hooks
+
+All optional — install with the matching `set_*` method after `new`. Each is an
+`Rc<dyn Fn(...)>`; the board works with none installed (you just lose that feature).
+Coordinates passed to hooks are **world-space** (see [`Camera`]).
+
+| Setter | Type | Fires when… | You should… |
+| --- | --- | --- | --- |
+| `set_on_change` | `ChangeFn` = `Fn(String, &mut Window, &mut App)` | the board changes (element committed/moved/deleted, camera moved) | persist the scene JSON string |
+| `set_on_place_embed` | `PlaceEmbedFn` = `Fn(f32, f32, &mut Window, &mut App)` | the page-card tool is clicked at `(x, y)` | pick a page, then call `add_embed(page_id, title, x, y, cx)` |
+| `set_on_open` | `OpenPageFn` = `Fn(i64, &mut Window, &mut App)` | a page-card is double-clicked | open that page (`page_id`) in your app |
+| `set_on_image` | `ImageFn` = `Fn(&str, f32, &mut Window, &mut App) -> Option<ImageSource>` | each paint, per image element | return the decoded bitmap for `src` rotated by the `f32` radians (decode off-thread; `None` until ready, then re-render) |
+| `set_on_place_image` | `PlaceImageFn` = `Fn(f32, f32, &mut Window, &mut App)` | the image tool is clicked at `(x, y)` | pick a file, import it, then call `add_image_at(...)` |
+| `set_on_drop_files` | `DropFilesFn` = `Fn(Vec<PathBuf>, f32, f32, &mut Window, &mut App)` | files are dropped on the canvas at `(x, y)` | import any images and place them via `add_image_at(...)` |
+| `set_on_copy` | `CopyFn` = `Fn(String, &mut Window, &mut App)` | `⌘C` / `⌘X` with a selection | write the serialized selection to the system clipboard |
+| `set_on_paste` | `PasteFn` = `Fn(&mut Window, &mut App) -> Option<String>` | the context-menu **Paste** | read the clipboard; return previously copied board JSON, or `None` |
+| `set_on_save_template` | `SaveTemplateFn` = `Fn(String, &mut Window, &mut App)` | the user saves a selection as a template | name + store it, then feed the list back via `set_templates` |
+| `set_on_delete_template` | `DeleteTemplateFn` = `Fn(i64, &mut Window, &mut App)` | a template card is right-clicked → delete | remove it (by id), then `set_templates` |
+| `set_on_save_colors` | `SavedColorsFn` = `Fn(Vec<u32>, &mut Window, &mut App)` | the user adds/removes a swatch in the picker's **Saved** palette | persist the packed `0xRRGGBBAA` list, then push it back via `set_saved_colors` |
+| `set_on_pick_font` | `PickFontFn` = `Fn(FontPick, &mut Window, &mut App)` | the **Aa** Font flyout's *Upload* / *Use default* is clicked | load the `.ttf`/`.otf` (or the default) and call `set_font` — and persist the per-board choice |
+| `set_on_move_toolbar` | `MoveToolbarFn` = `Fn(Option<(f32, f32)>, bool, &mut Window, &mut App)` | the toolbar is dragged, reset (double-click the grip), or flipped row↔column | persist its new board-relative top-left (`None` = default top-center) and orientation (`bool` = vertical) |
+| `set_templates` | `fn(&mut self, Vec<Template>, &mut Context<Self>)` | — | push the current template list (on open and after any save/delete) |
+| `set_saved_colors` | `fn(&mut self, Vec<u32>, &mut Context<Self>)` | — | push the user's saved-color palette (on open and after a change) |
+| `set_toolbar_pos` | `fn(&mut self, Option<(f32, f32)>, &mut Context<Self>)` | — | push the saved toolbar position (`None` = default top-center) on open and after a change |
+| `set_toolbar_vertical` | `fn(&mut self, bool, &mut Context<Self>)` | — | push the saved toolbar orientation (vertical = a column) on open and after a change |
+| `set_font` | `fn(&mut self, Font, &mut Context<Self>)` | — | swap the text face (see [Custom fonts](#custom-fonts)) |
+
+> **Image & clipboard flow.** Images aren't stored in the scene — only a `src`
+> reference is. The crate asks for the bitmap via `ImageFn` each paint; you own the
+> file store and the cache (decode off-thread, downscale, manage the GPU texture).
+> Copy/paste likewise routes the bytes through `CopyFn`/`PasteFn` so the system
+> clipboard stays the source of truth (and `⌘V` prefers copied elements over a
+> clipboard image). Templates persist through `SaveTemplateFn`/`set_templates`.
+
+### The scene model
+
+A `Scene` is the board's persisted state — a [`Camera`] plus a `Vec<Element>` in
+paint order (earlier = behind). It's plain serde data: store
+`view.scene().to_json()` and reload with `Scene::from_json(&s)` (which never panics —
+empty/garbage yields a blank board). Element colors are packed `0xRRGGBBAA` `u32`s.
+
+```rust
+pub struct Scene { pub camera: Camera, pub elements: Vec<Element> }
+impl Scene {
+    pub fn from_json(s: &str) -> Self;   // empty board on "" / malformed input
+    pub fn to_json(&self) -> String;
+}
+
+pub struct Camera { pub x: f32, pub y: f32, pub zoom: f32 } // pan offset + zoom
+// world point under a canvas point `s`:  camera.offset + s / zoom
+
+pub struct Element {
+    pub id: u64,
+    pub kind: ElementKind,
+    pub stroke: Option<u32>,    // packed 0xRRGGBBAA; None = follow theme ink
+    pub fill:   Option<u32>,    // closed shapes only; None = unfilled outline
+    pub label:  Option<String>, // closed shapes only; centered, word-wrapped + auto-shrunk to fit
+    pub label_color: Option<u32>, // shape label color; None = follow the stroke / theme ink
+    pub styles: Vec<StyleSpan>,   // per-character bold/italic/underline/strike/highlight runs
+}
+
+pub enum ElementKind {       // serialized snake_case: {"rect": {...}}, {"image": {...}}, …
+    Draw(Stroke),                                        // freehand pen
+    Rect(BoxGeom), Ellipse(BoxGeom), Diamond(BoxGeom),   // box-like shapes
+    Triangle(BoxGeom), RoundRect(BoxGeom),
+    Star(BoxGeom), Hexagon(BoxGeom),
+    Line(SegGeom), Arrow(SegGeom),
+    Text(TextGeom),
+    Embed(EmbedGeom),                                    // page-card
+    Image(ImageGeom),
+}
+
+pub struct Stroke   { pub points: Vec<[f32; 2]>, pub width: f32 }
+pub struct BoxGeom  { pub x: f32, pub y: f32, pub w: f32, pub h: f32, pub width: f32, pub rotation: f32 }
+pub struct SegGeom  { pub x1: f32, pub y1: f32, pub x2: f32, pub y2: f32, pub width: f32 }
+pub struct TextGeom { pub x: f32, pub y: f32, pub content: String, pub size: f32, pub rotation: f32, /* measured_* cached */ }
+pub struct EmbedGeom{ pub page_id: i64, pub title: String, pub x: f32, pub y: f32, pub w: f32, pub h: f32 }
+pub struct ImageGeom{ pub src: String, pub x: f32, pub y: f32, pub w: f32, pub h: f32, pub rotation: f32 }
+```
+
+`rotation` is radians clockwise about the element's center. All geometry is
+world-space; multiply by `camera.zoom` and subtract the pan offset for screen space.
+
+### `Tool`
+
+```rust
+pub enum Tool {
+    Pan, Select, Pen, Rect, Ellipse, Diamond, Triangle,
+    RoundRect, Star, Hexagon, Line, Arrow, Text, Embed, Image,
+}
+```
+
+`Pan` is the default. The view renders a toolbar for these and handles their
+single-key shortcuts itself; use `set_tool` only if you drive tools from your own UI.
+
+### Templates
+
+A reusable group of elements, stamped centered in the viewport. The crate renders the
+preview gallery and instantiates on click; **you own storage and the `id`.**
+
+```rust
+pub struct Template { pub id: i64, pub name: String, pub elements: Vec<Element> }
+impl Template {
+    // `elements_json` is a serialized `Vec<Element>` (what `SaveTemplateFn` hands you);
+    // malformed JSON yields an empty (still-listable) template.
+    pub fn from_json(id: i64, name: impl Into<String>, elements_json: &str) -> Self;
+}
+```
+
+### Custom fonts
+
+Text is drawn from glyph outlines, so any TrueType/OpenType face works. The default is
+bundled (JetBrains Mono, OFL); swap one in directly with `set_font`:
+
+```rust
+use gpui_whiteboard::Font;
+if let Some(face) = Font::from_bytes(ttf_bytes, /* face index */ 0) {
+    board.update(cx, |v, cx| v.set_font(face, cx));
+}
+// Font::default() is the bundled face.
+```
+
+For a user-facing picker, install `set_on_pick_font`: the toolbar then shows an **Aa**
+button whose flyout offers *Upload font…* and *Use default*. The crate hands you a
+`FontPick` (`Upload` / `Default`); you run the file dialog, build the face, call
+`set_font`, and persist the choice however you like (the host app keeps one face per
+board, restored on reopen).
 
 ## Keyboard & mouse
 
@@ -130,24 +450,34 @@ The view handles these when it has focus (it focuses on a canvas click):
 | scroll · pinch | zoom |
 | hold `⌥` while dragging | snap to the grid |
 | click / shift-click / marquee-drag (Select tool) | select one / add / box-select |
-| drag a handle · the round grip above a selection | resize · rotate |
-| double-click a page-card | open its page |
-| double-click text or a closed shape | edit the text / centered label |
-| `⌘B` `⌘I` `⌘U` `⇧⌘X` `⇧⌘H` (editing text) | toggle bold / italic / underline / strikethrough / highlight |
-| drag the dotted grip (left of the toolbar) | move the toolbar (`R` mid-drag flips row ↔ column; double-click the grip resets) |
-| right-click | context menu (z-order, copy/cut/paste, save as template, text formatting) |
+| drag a handle · the round grip above a selection | resize (corners scale; edge handles stretch one axis, on a single element or a group) · rotate |
+| double-click a page-card | open its page (via `OpenPageFn`) |
+| double-click text · `T`-click text | edit it — click a letter for the caret, drag / double-click to select |
+| double-click a closed shape | edit its centered label — wraps + auto-shrinks to fit; full caret / selection / clipboard |
+| `⌘B` `⌘I` `⌘U` `⇧⌘X` `⇧⌘H` (editing text) | bold / italic / underline / strikethrough / highlight the selection (toggle) |
+| drag the dotted grip (left of the toolbar) | move the toolbar (tap `R` mid-drag to flip row ↔ column; double-click the grip resets it) |
+| right-click | context menu (z-order, copy/cut/paste, save as template); while editing text, a **Text ▸** fly-out toggles bold / italic / underline / strike / highlight (✓ marks active) |
 
-While editing text it behaves like a normal text field: click to place the caret,
-drag / double-click to select, arrows / Home / End (⇧ extends), ⌘A, and system
-clipboard ⌘C / ⌘X / ⌘V; Esc (or a click away) commits.
+While editing a text element it behaves like a normal text field: click to place the
+caret, click-drag or double-click to select, arrows / Home / End (⇧ extends), ⌘A, and
+⌘C / ⌘X / ⌘V on the system clipboard; Esc (or a click away) commits.
+
+## Persistence
+
+The crate is storage-agnostic. Persist a board by storing the string from `on_change`
+(or `view.scene().to_json()`); reload with `WhiteboardView::new(Scene::from_json(&s), …)`.
+Images and templates live in *your* store — the scene only references images by `src`,
+and templates round-trip through your `SaveTemplateFn` + `set_templates`.
 
 ## Status
 
-Pre-1.0 (`0.1`). The API may still shift before 1.0. Performance note: elements
-are re-tessellated each paint (as GPUI's own `painting` examples do); a built-`Path`
-cache + viewport culling is the planned optimization once boards get large.
+Pre-1.0 (`0.1`). The scene JSON is forward-leaning — new fields use serde defaults, so
+older boards keep loading — but the API may still shift before 1.0. Performance note:
+elements are re-tessellated each paint (as GPUI's own `painting` examples do); a
+built-`Path` cache + viewport culling is the planned optimization once boards get
+large.
 
 ## License
 
-GPL-3.0-or-later. The bundled default font (JetBrains Mono) is under the SIL Open
-Font License — see `assets/JetBrainsMono-OFL.txt`.
+GPL-3.0-or-later. The bundled default font (JetBrains Mono) is under the SIL Open Font
+License — see `assets/JetBrainsMono-OFL.txt`.

--- a/crates/gpui-whiteboard/assets/icons/down.svg
+++ b/crates/gpui-whiteboard/assets/icons/down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-arrow-down-icon lucide-circle-arrow-down"><circle cx="12" cy="12" r="10"/><path d="M12 8v8"/><path d="m8 12 4 4 4-4"/></svg>

--- a/crates/gpui-whiteboard/assets/icons/flowchart.svg
+++ b/crates/gpui-whiteboard/assets/icons/flowchart.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="3" width="16" height="5" rx="2"/>
+  <path d="M12 8v3"/>
+  <path d="M8 14h8l-4 4z"/>
+  <path d="M12 18v3"/>
+</svg>

--- a/crates/gpui-whiteboard/assets/icons/left.svg
+++ b/crates/gpui-whiteboard/assets/icons/left.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-arrow-left-icon lucide-circle-arrow-left"><circle cx="12" cy="12" r="10"/><path d="m12 8-4 4 4 4"/><path d="M16 12H8"/></svg>

--- a/crates/gpui-whiteboard/assets/icons/mindmap.svg
+++ b/crates/gpui-whiteboard/assets/icons/mindmap.svg
@@ -1,0 +1,20 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect x="3" y="10" width="6" height="4" rx="1.5" />
+  <rect x="15" y="4" width="6" height="4" rx="1.5" />
+  <rect x="15" y="16" width="6" height="4" rx="1.5" />
+  <path d="M9 12h3" />
+  <path d="M12 12V6" />
+  <path d="M12 12v6" />
+  <path d="M12 6h3" />
+  <path d="M12 18h3" />
+</svg>

--- a/crates/gpui-whiteboard/assets/icons/refresh.svg
+++ b/crates/gpui-whiteboard/assets/icons/refresh.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-rotate-cw-icon lucide-rotate-cw"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>

--- a/crates/gpui-whiteboard/assets/icons/right.svg
+++ b/crates/gpui-whiteboard/assets/icons/right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-arrow-right-icon lucide-circle-arrow-right"><circle cx="12" cy="12" r="10"/><path d="m12 16 4-4-4-4"/><path d="M8 12h8"/></svg>

--- a/crates/gpui-whiteboard/assets/icons/up.svg
+++ b/crates/gpui-whiteboard/assets/icons/up.svg
@@ -1,0 +1,2 @@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-arrow-up-icon lucide-circle-arrow-up"><circle cx="12" cy="12" r="10"/><path d="m16 12-4-4-4 4"/><path d="M12 16V8"/></svg>

--- a/crates/gpui-whiteboard/src/font.rs
+++ b/crates/gpui-whiteboard/src/font.rs
@@ -9,7 +9,7 @@
 //! default (JetBrains Mono, OFL — see `assets/JetBrainsMono-OFL.txt`) is bundled
 //! so the crate works standalone.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// The bundled default face.
 const DEFAULT_FONT: &[u8] = include_bytes!("../assets/JetBrainsMono-Regular.ttf");
@@ -58,14 +58,60 @@ pub struct Font {
 
 impl Default for Font {
     fn default() -> Self {
-        Self {
+        Self::system_cjk_fallback().unwrap_or_else(|| Self {
             bytes: Arc::new(DEFAULT_FONT.to_vec()),
             index: 0,
-        }
+        })
     }
 }
 
 impl Font {
+    fn system_cjk_fallback() -> Option<Self> {
+        static SYSTEM_CJK: OnceLock<Option<(Arc<Vec<u8>>, u32)>> = OnceLock::new();
+
+        SYSTEM_CJK
+            .get_or_init(Self::load_system_cjk_fallback)
+            .as_ref()
+            .map(|(bytes, index)| Self {
+                bytes: bytes.clone(),
+                index: *index,
+            })
+    }
+
+    fn load_system_cjk_fallback() -> Option<(Arc<Vec<u8>>, u32)> {
+        // The editor uses GPUI's text stack, which gets system font fallback for
+        // free. Whiteboard text is converted to vector outlines, so we need a
+        // single face that actually contains CJK glyphs. Prefer broad Unicode / CJK
+        // system fonts, then fall back to the bundled Latin-only JetBrains Mono.
+        // This lookup is cached by `system_cjk_fallback`: CJK collections are often
+        // tens of megabytes and must not be re-read for every whiteboard entity.
+        let candidates: &[(&str, u32)] = &[
+            // macOS
+            ("/Library/Fonts/Arial Unicode.ttf", 0),
+            ("/System/Library/Fonts/PingFang.ttc", 0),
+            ("/System/Library/Fonts/Hiragino Sans GB.ttc", 0),
+            ("/System/Library/Fonts/STHeiti Medium.ttc", 0),
+            ("/System/Library/Fonts/STHeiti Light.ttc", 0),
+            // Windows
+            ("C:/Windows/Fonts/msyh.ttc", 0),
+            ("C:/Windows/Fonts/simhei.ttf", 0),
+            ("C:/Windows/Fonts/simsun.ttc", 0),
+            // Linux common CJK packages
+            ("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc", 0),
+            ("/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc", 0),
+            (
+                "/usr/share/fonts/opentype/noto/NotoSansCJKsc-Regular.otf",
+                0,
+            ),
+        ];
+
+        candidates.iter().find_map(|(path, index)| {
+            let bytes = std::fs::read(path).ok()?;
+            ttf_parser::Face::parse(&bytes, *index).ok()?;
+            Some((Arc::new(bytes), *index))
+        })
+    }
+
     /// Build a font from raw face bytes (e.g. a user-uploaded `.ttf`/`.otf`),
     /// returning `None` if they don't parse. `index` selects a face within a
     /// collection (`.ttc`); pass 0 otherwise.
@@ -87,9 +133,13 @@ impl Font {
     }
 
     /// Lay out `content` at `font_size` (world units) into local-space outlines.
-    /// Newlines break lines; the block's origin is its top-left corner. Word-wraps
-    /// to `max_width` (world units) when `Some` — for fitting a label inside a
-    /// shape; `None` lays out unwrapped. Glyph positions come
+    /// Newlines break lines; the block's origin is its top-left corner.
+    pub fn layout(&self, content: &str, font_size: f32) -> TextLayout {
+        self.layout_wrapped(content, font_size, None)
+    }
+
+    /// Like [`layout`](Self::layout) but word-wraps to `max_width` (world units)
+    /// when `Some` — for fitting a label inside a shape. Glyph positions come
     /// from the same [`line_stops`](Self::line_stops) the caret uses, so the
     /// caret always lands exactly between the rendered glyphs.
     pub fn layout_wrapped(
@@ -452,8 +502,12 @@ impl Font {
 
     /// The content byte offset whose caret sits nearest the local point `p`
     /// (text-local space). Picks the line by y, then the closest caret stop by x —
-    /// so a click lands the caret between letters like a real text field. Honors a
-    /// `max_width` wrap (label editing) when `Some`.
+    /// so a click lands the caret between letters like a real text field.
+    pub fn index_at(&self, content: &str, font_size: f32, p: [f32; 2]) -> usize {
+        self.index_at_wrapped(content, font_size, None, p)
+    }
+
+    /// [`index_at`](Self::index_at) honoring a `max_width` wrap (label editing).
     pub fn index_at_wrapped(
         &self,
         content: &str,
@@ -681,7 +735,7 @@ mod tests {
     #[test]
     fn default_font_parses_and_lays_out() {
         let f = Font::default();
-        let l = f.layout_wrapped("A", 20.0, None);
+        let l = f.layout("A", 20.0);
         assert!(l.width > 0.0, "width {}", l.width);
         assert!(l.line_height > 0.0);
         assert!(
@@ -701,14 +755,14 @@ mod tests {
         let two = f.measure("x\ny", 20.0).1;
         assert!((two - 2.0 * one).abs() < 0.5, "{one} {two}");
         // The caret of a two-line block sits on the lower line.
-        let l = f.layout_wrapped("x\ny", 20.0, None);
+        let l = f.layout("x\ny", 20.0);
         assert!(l.caret[1] > 0.0, "caret {:?}", l.caret);
     }
 
     #[test]
     fn empty_content_has_no_segments_but_a_caret() {
         let f = Font::default();
-        let l = f.layout_wrapped("", 20.0, None);
+        let l = f.layout("", 20.0);
         assert!(l.segs.is_empty());
         assert_eq!(l.caret, [0.0, 0.0]);
         assert!(l.height > 0.0);
@@ -723,7 +777,7 @@ mod tests {
     fn caret_pos_walks_per_char_and_across_lines() {
         let f = Font::default();
         let a = f.measure("M", 20.0).0; // monospace advance
-        let lh = f.layout_wrapped("M", 20.0, None).line_height;
+        let lh = f.layout("M", 20.0).line_height;
         // One stop per boundary on a line.
         assert_eq!(f.caret_pos("MMM", 20.0, 0), [0.0, 0.0]);
         assert!((f.caret_pos("MMM", 20.0, 1)[0] - a).abs() < 0.5);
@@ -740,14 +794,14 @@ mod tests {
     fn index_at_picks_the_nearest_boundary() {
         let f = Font::default();
         let a = f.measure("M", 20.0).0;
-        let lh = f.layout_wrapped("M", 20.0, None).line_height;
+        let lh = f.layout("M", 20.0).line_height;
         // Just past the first glyph's midpoint rounds to the next boundary.
-        assert_eq!(f.index_at_wrapped("MMM", 20.0, None, [0.4 * a, 0.0]), 0);
-        assert_eq!(f.index_at_wrapped("MMM", 20.0, None, [0.6 * a, 0.0]), 1);
+        assert_eq!(f.index_at("MMM", 20.0, [0.4 * a, 0.0]), 0);
+        assert_eq!(f.index_at("MMM", 20.0, [0.6 * a, 0.0]), 1);
         // Way off to the right clamps to the line end; clicking the lower line
         // (by y) lands on it.
-        assert_eq!(f.index_at_wrapped("MMM", 20.0, None, [99.0 * a, 0.0]), 3);
-        assert_eq!(f.index_at_wrapped("M\nMM", 20.0, None, [0.0, lh]), 2); // start of line 2
+        assert_eq!(f.index_at("MMM", 20.0, [99.0 * a, 0.0]), 3);
+        assert_eq!(f.index_at("M\nMM", 20.0, [0.0, lh]), 2); // start of line 2
     }
 
     #[test]

--- a/crates/gpui-whiteboard/src/lib.rs
+++ b/crates/gpui-whiteboard/src/lib.rs
@@ -17,26 +17,33 @@
 //! camera and a host can supply a custom face ([`Font`]). See `README.md` for the
 //! full API and usage; design notes in `docs/whiteboard-architecture.md`.
 //!
-//! Perf note: elements are re-tessellated each paint (as GPUI's own
-//! `painting`/`brush` examples do). A built-`Path` cache + viewport culling is the
-//! planned optimization once boards get large — deferred so we don't build it
-//! before there's something to measure.
+//! Perf note: element geometry is re-tessellated when painted (as GPUI's own
+//! `painting`/`brush` examples do), but rendering is viewport-culled and text
+//! glyph layouts are cached. A built-`Path` cache remains a further optimization
+//! for extremely dense visible scenes.
 
 mod font;
+mod render_perf;
 
 use std::cell::Cell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::ops::Range;
 use std::rc::Rc;
+use std::sync::Arc;
 
 pub use font::Font;
+use render_perf::WorldViewport;
 
 use gpui::{
-    AnyView, App, AppContext, Bounds, Context, CursorStyle, Div, FocusHandle, Hsla,
-    InteractiveElement, IntoElement, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, ObjectFit, ParentElement, PathBuilder, PinchEvent, Pixels, Point, Render, Rgba,
-    ScrollDelta, ScrollWheelEvent, SharedString, StatefulInteractiveElement, Styled, StyledImage,
-    TransformationMatrix, Window, canvas, div, fill, hsla, linear_color_stop, linear_gradient,
-    point, px, rgba, size,
+    AnyElement, AnyView, App, AppContext, Bounds, Context, CursorStyle, Div, ElementId,
+    ElementInputHandler, Entity, EntityInputHandler, FocusHandle, GlobalElementId, Hsla,
+    InspectorElementId, InteractiveElement, IntoElement, KeyDownEvent, LayoutId, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, ObjectFit, ParentElement, PathBuilder,
+    PinchEvent, Pixels, Point, Render, Rgba, ScrollDelta, ScrollWheelEvent, SharedString,
+    StatefulInteractiveElement, Style, Styled, StyledImage, TransformationMatrix, UTF16Selection,
+    Window, canvas, div, fill, hsla, linear_color_stop, linear_gradient, point, px, relative, rgba,
+    size,
 };
 use serde::{Deserialize, Serialize};
 
@@ -52,6 +59,11 @@ const MIN_DOT_SPACING: f32 = 16.0;
 const DOT: f32 = 2.0;
 /// Screen px per scroll "line" for inexact (`Lines`) scroll deltas.
 const LINE_PX: f32 = 16.0;
+const VIEWPORT_CULL_MARGIN_PX: f32 = 96.0;
+
+fn accepts_wheel_input(read_only: bool) -> bool {
+    !read_only
+}
 /// Pen nib in screen px. A stored width is world-space (`NIB / zoom` at draw
 /// time) so strokes/shapes feel like a constant nib yet scale with the content.
 /// Also the default of [`WhiteboardView::active_width`].
@@ -70,14 +82,13 @@ const MIN_POINT_PX: f32 = 2.0;
 const SELECT_PAD: f32 = 6.0;
 /// Most undo steps kept (bounds memory; each step is a scene snapshot).
 const UNDO_CAP: usize = 50;
-/// Selection-box padding around the element, screen px (handles sit on it).
-const SEL_PAD_PX: f32 = 5.0;
 /// Half-size of a corner resize handle, screen px.
-const HANDLE_HALF: f32 = 4.5;
+const HANDLE_HALF: f32 = 4.0;
 /// Grab radius for a corner handle, screen px.
 const HANDLE_GRAB: f32 = 10.0;
-/// Gap from the selection's top to the rotate handle, screen px.
-const ROTATE_DIST: f32 = 22.0;
+/// Distance in screen pixels from a selected shape edge to its connector button.
+const CONNECTOR_BUTTON_GAP: f32 = 24.0;
+const CONNECTOR_BUTTON_SIZE: f32 = 20.0;
 /// Color picker: saturation/brightness square + hue strip dimensions, px.
 const SV_W: f32 = 216.0;
 const SV_H: f32 = 140.0;
@@ -106,6 +117,16 @@ const TEXT_LINE_H: f32 = 1.3;
 /// Default page-card size at creation, screen px (stored world size is / zoom).
 const EMBED_W: f32 = 210.0;
 const EMBED_H: f32 = 76.0;
+const MINDMAP_ROOT_W: f32 = 196.0;
+const MINDMAP_ROOT_H: f32 = 60.0;
+const MINDMAP_NODE_W: f32 = 164.0;
+const MINDMAP_NODE_H: f32 = 48.0;
+const MINDMAP_BRANCH_GAP_X: f32 = 120.0;
+const MINDMAP_BRANCH_GAP_Y: f32 = 84.0;
+const FLOWCHART_NODE_W: f32 = 180.0;
+const FLOWCHART_NODE_H: f32 = 52.0;
+const FLOWCHART_GAP_Y: f32 = 92.0;
+const FLOWCHART_BRANCH_GAP_X: f32 = 240.0;
 /// Longest edge of a freshly placed image, screen px (aspect preserved).
 const IMAGE_PLACE_PX: f32 = 280.0;
 
@@ -179,6 +200,48 @@ pub struct Element {
     /// non-overlapping and maintained across edits; absent in older boards.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub styles: Vec<StyleSpan>,
+    /// Optional whiteboard-native mind-map metadata. Only mind-map nodes carry
+    /// this; lines stay regular anchored arrows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mindmap: Option<MindMapNodeMeta>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MindMapSide {
+    Left,
+    Right,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MindMapRootDirection {
+    #[default]
+    Both,
+    Left,
+    Right,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MindMapConnectorStyle {
+    Straight,
+    #[default]
+    Bezier,
+    Orthogonal,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MindMapNodeMeta {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<u64>,
+    pub side: MindMapSide,
+    #[serde(default)]
+    pub order: usize,
+    #[serde(default)]
+    pub root_direction: MindMapRootDirection,
+    #[serde(default)]
+    pub connector_style: MindMapConnectorStyle,
 }
 
 /// Whether a [`RunStyle`] flag is unset — its default, kept out of the JSON.
@@ -496,6 +559,14 @@ pub struct BoxGeom {
 }
 
 /// A directed segment (line / arrow), world-space.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SegmentAnchor {
+    /// The connected shape/text/image element.
+    pub element_id: u64,
+    /// Which connector on that element: 0/1/2/3 = top/right/bottom/left.
+    pub connector: usize,
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct SegGeom {
     pub x1: f32,
@@ -503,6 +574,25 @@ pub struct SegGeom {
     pub x2: f32,
     pub y2: f32,
     pub width: f32,
+    #[serde(default = "default_segment_style")]
+    pub style: SegmentStyle,
+    /// Attachment for the first endpoint. Absent in older boards.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_anchor: Option<SegmentAnchor>,
+    /// Attachment for the second endpoint. Absent in older boards.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_anchor: Option<SegmentAnchor>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SegmentStyle {
+    Solid,
+    Dashed,
+}
+
+fn default_segment_style() -> SegmentStyle {
+    SegmentStyle::Solid
 }
 
 /// The viewport: a world-space pan offset and a zoom factor. The offset is the
@@ -560,6 +650,108 @@ impl Camera {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LocalThumbnailMode {
+    Auto,
+    Selection,
+    Viewport,
+    AllContent,
+    Element(u64),
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct LocalThumbnailSpec {
+    pub anchor_element_id: Option<u64>,
+    /// Focus bounds in world coordinates: `[x0, y0, x1, y1]`.
+    pub focus_bounds: [f32; 4],
+    /// Whole-scene bounds in world coordinates, when available.
+    pub scene_bounds: Option<[f32; 4]>,
+    /// Recommended camera to render this thumbnail into the requested size.
+    pub camera: Camera,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LocalThumbnailSnapshot {
+    pub scene: Scene,
+    pub spec: LocalThumbnailSpec,
+}
+
+impl LocalThumbnailSnapshot {
+    /// Build a chrome-free all-content thumbnail directly from a persisted scene.
+    /// Hosts can use this without mounting a full [`WhiteboardView`] entity first.
+    pub fn for_scene_all_content(scene: Scene, width_px: f32, height_px: f32) -> Self {
+        let width_px = width_px.max(1.0);
+        let height_px = height_px.max(1.0);
+        let scene_bounds = scene_bbox_for_local_thumbnail(&scene);
+        let spec = if let Some(focus) = scene_bounds {
+            local_thumbnail_spec_from_bbox(None, focus, scene_bounds, width_px, height_px)
+        } else {
+            let zoom = scene.camera.zoom.clamp(MIN_ZOOM, MAX_ZOOM);
+            LocalThumbnailSpec {
+                anchor_element_id: None,
+                focus_bounds: [
+                    scene.camera.x,
+                    scene.camera.y,
+                    scene.camera.x + width_px / zoom,
+                    scene.camera.y + height_px / zoom,
+                ],
+                scene_bounds: None,
+                camera: Camera {
+                    x: scene.camera.x,
+                    y: scene.camera.y,
+                    zoom,
+                },
+            }
+        };
+        Self { scene, spec }
+    }
+}
+
+fn scene_bbox_for_local_thumbnail(scene: &Scene) -> Option<(f32, f32, f32, f32)> {
+    let mut bounds = scene.elements.iter().map(|element| bbox(&element.kind));
+    let first = bounds.next()?;
+    Some(bounds.fold(first, |current, next| {
+        (
+            current.0.min(next.0),
+            current.1.min(next.1),
+            current.2.max(next.2),
+            current.3.max(next.3),
+        )
+    }))
+}
+
+fn local_thumbnail_spec_from_bbox(
+    anchor_element_id: Option<u64>,
+    focus: (f32, f32, f32, f32),
+    scene_bounds: Option<(f32, f32, f32, f32)>,
+    width_px: f32,
+    height_px: f32,
+) -> LocalThumbnailSpec {
+    let width_px = width_px.max(1.0);
+    let height_px = height_px.max(1.0);
+    let focus_w = (focus.2 - focus.0).abs().max(1.0);
+    let focus_h = (focus.3 - focus.1).abs().max(1.0);
+    let pad_x = (focus_w * 0.18).max(48.0);
+    let pad_y = (focus_h * 0.18).max(36.0);
+    let padded_w = (focus_w + pad_x * 2.0).max(1.0);
+    let padded_h = (focus_h + pad_y * 2.0).max(1.0);
+    let zoom = (width_px / padded_w)
+        .min(height_px / padded_h)
+        .clamp(MIN_ZOOM, MAX_ZOOM);
+    let center_x = (focus.0 + focus.2) * 0.5;
+    let center_y = (focus.1 + focus.3) * 0.5;
+    LocalThumbnailSpec {
+        anchor_element_id,
+        focus_bounds: [focus.0, focus.1, focus.2, focus.3],
+        scene_bounds: scene_bounds.map(|bounds| [bounds.0, bounds.1, bounds.2, bounds.3]),
+        camera: Camera {
+            x: center_x - width_px / (2.0 * zoom),
+            y: center_y - height_px / (2.0 * zoom),
+            zoom,
+        },
+    }
+}
+
 /// The active tool. UI state — not part of the persisted scene.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Tool {
@@ -576,7 +768,10 @@ pub enum Tool {
     Hexagon,
     Line,
     Arrow,
+    DashedArrow,
     Text,
+    MindMap,
+    Flowchart,
     Embed,
     Image,
 }
@@ -600,7 +795,10 @@ impl Tool {
             Tool::Hexagon => "⬡",
             Tool::Line => "╱",
             Tool::Arrow => "↗",
+            Tool::DashedArrow => "⇢",
             Tool::Text => "T",
+            Tool::MindMap => "◎",
+            Tool::Flowchart => "⇅",
             Tool::Embed => "▤",
             Tool::Image => "▦",
         }
@@ -622,7 +820,10 @@ impl Tool {
             Tool::Hexagon => "Hexagon (X)",
             Tool::Line => "Line (L)",
             Tool::Arrow => "Arrow (A)",
+            Tool::DashedArrow => "Dashed arrow (K)",
             Tool::Text => "Text (T)",
+            Tool::MindMap => "Mind map (M)",
+            Tool::Flowchart => "Flowchart (F)",
             Tool::Embed => "Page card",
             Tool::Image => "Image (I) — click to place",
         }
@@ -643,7 +844,10 @@ impl Tool {
             "x" => Tool::Hexagon,
             "l" => Tool::Line,
             "a" => Tool::Arrow,
+            "k" => Tool::DashedArrow,
             "t" => Tool::Text,
+            "m" => Tool::MindMap,
+            "f" => Tool::Flowchart,
             "i" => Tool::Image,
             _ => return None,
         })
@@ -669,6 +873,8 @@ impl Tool {
         const LINE: &[u8] = include_bytes!("../assets/icons/line.svg");
         const ARROW: &[u8] = include_bytes!("../assets/icons/arrow.svg");
         const TEXT: &[u8] = include_bytes!("../assets/icons/text.svg");
+        const MINDMAP: &[u8] = include_bytes!("../assets/icons/mindmap.svg");
+        const FLOWCHART: &[u8] = include_bytes!("../assets/icons/flowchart.svg");
         const EMBED: &[u8] = include_bytes!("../assets/icons/embed.svg");
         const IMAGE: &[u8] = include_bytes!("../assets/icons/image.svg");
         match self {
@@ -684,7 +890,10 @@ impl Tool {
             Tool::Hexagon => Some(("wb-icon-hexagon", HEXAGON)),
             Tool::Line => Some(("wb-icon-line", LINE)),
             Tool::Arrow => Some(("wb-icon-arrow", ARROW)),
+            Tool::DashedArrow => None,
             Tool::Text => Some(("wb-icon-text", TEXT)),
+            Tool::MindMap => Some(("wb-icon-mindmap", MINDMAP)),
+            Tool::Flowchart => Some(("wb-icon-flowchart", FLOWCHART)),
             Tool::Embed => Some(("wb-icon-embed", EMBED)),
             Tool::Image => Some(("wb-icon-image", IMAGE)),
         }
@@ -719,8 +928,8 @@ impl ToolGroup {
                 Tool::Hexagon,
                 Tool::Star,
             ],
-            ToolGroup::Lines => &[Tool::Pen, Tool::Line, Tool::Arrow],
-            ToolGroup::PagesImages => &[Tool::Embed, Tool::Image],
+            ToolGroup::Lines => &[Tool::Pen, Tool::Line, Tool::Arrow, Tool::DashedArrow],
+            ToolGroup::PagesImages => &[Tool::MindMap, Tool::Flowchart, Tool::Embed, Tool::Image],
         }
     }
 
@@ -732,8 +941,8 @@ impl ToolGroup {
     fn representative(self) -> Tool {
         match self {
             ToolGroup::Shapes => Tool::Rect,
-            ToolGroup::Lines => Tool::Line,
-            ToolGroup::PagesImages => Tool::Embed,
+            ToolGroup::Lines => Tool::Arrow,
+            ToolGroup::PagesImages => Tool::Flowchart,
         }
     }
 
@@ -910,6 +1119,10 @@ pub type PickFontFn = Rc<dyn Fn(FontPick, &mut Window, &mut App)>;
 /// layout is per-session.
 pub type MoveToolbarFn = Rc<dyn Fn(Option<(f32, f32)>, bool, &mut Window, &mut App)>;
 
+/// Host callback fired by an embed view when the user requests "open / maximize
+/// for editing". The host owns the actual layout transition.
+pub type ExpandEmbedFn = Rc<dyn Fn(&mut Window, &mut App)>;
+
 /// A reusable group of elements the user can stamp onto a board. Element
 /// positions are normalized so the group's bounding box starts at the origin;
 /// applying re-bases them to the viewport. The host owns persistence and the
@@ -938,6 +1151,26 @@ impl Template {
 struct Pending {
     anchor: [f32; 2],
     kind: ElementKind,
+}
+
+/// A connector point shown on a hovered shape. `index` is 0/1/2/3 = top/right/bottom/left.
+#[derive(Clone, Copy, PartialEq)]
+struct ConnectPoint {
+    id: u64,
+    index: usize,
+    pos: [f32; 2],
+}
+
+/// A line being dragged from a shape connector while the Select tool is active.
+#[derive(Clone, Copy)]
+struct ConnectDrag {
+    from: ConnectPoint,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+struct AlignmentGuides {
+    vertical: Option<f32>,
+    horizontal: Option<f32>,
 }
 
 /// An in-progress resize of a single selected element by one of its handles.
@@ -1057,6 +1290,7 @@ enum PickerDrag {
 pub struct WhiteboardView {
     scene: Scene,
     style: WhiteboardStyleFn,
+    read_only: bool,
     on_change: Option<ChangeFn>,
     on_place_embed: Option<PlaceEmbedFn>,
     on_open: Option<OpenPageFn>,
@@ -1086,6 +1320,10 @@ pub struct WhiteboardView {
     /// The face used to render text as vector outlines. Defaults to the bundled
     /// JetBrains Mono; the host can swap in a custom/user-uploaded font.
     font: Font,
+    /// Camera-independent glyph outlines keyed by element id and text/style
+    /// signature. Panning and zooming can reuse these directly.
+    text_layout_cache: HashMap<u64, CachedTextLayout>,
+    label_layout_cache: HashMap<u64, CachedLabelLayout>,
     tool: Tool,
     /// Keyboard focus — grabbed while editing a text element.
     focus: FocusHandle,
@@ -1098,6 +1336,8 @@ pub struct WhiteboardView {
     sel_anchor: usize,
     /// A click-drag text selection is in progress (extends the selection on move).
     text_selecting: bool,
+    /// Active IME marked/composition byte range in the editing text.
+    marked_range: Option<Range<usize>>,
     /// Canvas bounds in window coords, captured each paint so input handlers can
     /// map window-relative event positions into the board.
     bounds: Rc<Cell<Bounds<Pixels>>>,
@@ -1107,6 +1347,10 @@ pub struct WhiteboardView {
     selected: Vec<u64>,
     /// In-progress marquee box (start, current) in world coords.
     marquee: Option<([f32; 2], [f32; 2])>,
+    /// Connector point currently under/near the mouse, painted on hovered shapes.
+    hovered_connector: Option<ConnectPoint>,
+    /// Line creation started by pressing a connector point.
+    connecting: Option<ConnectDrag>,
     /// The world point where an in-progress move-drag was grabbed (a *fixed*
     /// anchor — the move uses the total cursor delta from here, so grid-snapping
     /// stays cursor-synced and doesn't lose sub-grid motion).
@@ -1116,6 +1360,8 @@ pub struct WhiteboardView {
     move_origin: [f32; 2],
     /// Whether the current move-drag has actually moved (undo is pushed once).
     moved: bool,
+    /// Active world-space smart-alignment guides while moving a selection.
+    alignment_guides: AlignmentGuides,
     /// In-progress corner-resize of the selected box/stroke.
     resizing: Option<Resizing>,
     /// In-progress proportional resize of a multi-selection.
@@ -1184,6 +1430,23 @@ pub struct WhiteboardView {
     dirty: bool,
 }
 
+/// A read-only whiteboard embedding surface for use inside rich-text editors and
+/// other host containers. It overlays a small "edit / maximize" affordance and
+/// delegates the actual expansion behavior back to the host.
+pub struct BoardEmbedView {
+    board: Entity<WhiteboardView>,
+    style: WhiteboardStyleFn,
+    on_expand: Option<ExpandEmbedFn>,
+}
+
+/// A lightweight, chrome-free thumbnail renderer for embedding a local board
+/// snapshot in documents, lists, and rich-text blocks.
+pub struct BoardThumbnailView {
+    snapshot: LocalThumbnailSnapshot,
+    style: WhiteboardStyleFn,
+    font: Font,
+}
+
 impl WhiteboardView {
     /// Build a view over `scene`. Call inside `cx.new(|cx| WhiteboardView::new(..))`.
     pub fn new(scene: Scene, style: WhiteboardStyleFn, cx: &mut Context<Self>) -> Self {
@@ -1196,6 +1459,7 @@ impl WhiteboardView {
         Self {
             scene,
             style,
+            read_only: false,
             on_change: None,
             on_place_embed: None,
             on_open: None,
@@ -1215,19 +1479,25 @@ impl WhiteboardView {
             ctx_text_sub: false,
             format_flyout: false,
             font: Font::default(),
+            text_layout_cache: HashMap::new(),
+            label_layout_cache: HashMap::new(),
             tool: Tool::Pan,
             focus: cx.focus_handle(),
             editing: None,
             caret: 0,
             sel_anchor: 0,
             text_selecting: false,
+            marked_range: None,
             bounds: Rc::new(Cell::new(Bounds::default())),
             pending: None,
             selected: Vec::new(),
             marquee: None,
+            hovered_connector: None,
+            connecting: None,
             drag_from: None,
             move_origin: [0.0, 0.0],
             moved: false,
+            alignment_guides: AlignmentGuides::default(),
             resizing: None,
             group_resizing: None,
             endpoint: None,
@@ -1261,6 +1531,15 @@ impl WhiteboardView {
             next_id,
             dirty: false,
         }
+    }
+
+    /// Build a read-only board view. Useful when embedding inside other editors
+    /// that should only preview the board and allow viewport movement.
+    pub fn new_read_only(scene: Scene, style: WhiteboardStyleFn, cx: &mut Context<Self>) -> Self {
+        let mut this = Self::new(scene, style, cx);
+        this.read_only = true;
+        this.tool = Tool::Pan;
+        this
     }
 
     /// Install the persistence hook (called with the serialized scene on change).
@@ -1329,6 +1608,35 @@ impl WhiteboardView {
     /// Install the toolbar-moved hook (the host persists the new position).
     pub fn set_on_move_toolbar(&mut self, f: MoveToolbarFn) {
         self.on_move_toolbar = Some(f);
+    }
+
+    /// Toggle read-only mode. In this mode the board behaves like a fixed move
+    /// tool: left-drag pans the canvas and edit interactions are ignored.
+    pub fn set_read_only(&mut self, read_only: bool, cx: &mut Context<Self>) {
+        self.read_only = read_only;
+        if read_only {
+            self.tool = Tool::Pan;
+            self.selected.clear();
+            self.editing = None;
+            self.pending = None;
+            self.connecting = None;
+            self.hovered_connector = None;
+            self.context_menu = None;
+            self.open_group = None;
+            self.font_open = false;
+            self.width_open = false;
+            self.templates_open = false;
+            self.picker = None;
+            self.format_flyout = false;
+            self.text_selecting = false;
+            self.marked_range = None;
+        }
+        cx.notify();
+    }
+
+    /// Whether the board is currently in read-only (forced pan) mode.
+    pub fn read_only(&self) -> bool {
+        self.read_only
     }
 
     /// Set the toolbar's board-relative top-left (`None` = default top-center). The
@@ -1462,6 +1770,8 @@ impl WhiteboardView {
     /// with [`Font::from_bytes`].
     pub fn set_font(&mut self, font: Font, cx: &mut Context<Self>) {
         self.font = font;
+        self.text_layout_cache.clear();
+        self.label_layout_cache.clear();
         cx.notify();
     }
 
@@ -1517,6 +1827,7 @@ impl WhiteboardView {
             label: None,
             label_color: None,
             styles: Vec::new(),
+            mindmap: None,
         });
         self.selected = vec![id];
         self.tool = Tool::Select;
@@ -1560,10 +1871,984 @@ impl WhiteboardView {
             label: None,
             label_color: None,
             styles: Vec::new(),
+            mindmap: None,
         });
         self.selected = vec![id];
         self.tool = Tool::Select;
         cx.notify();
+    }
+
+    /// Insert a native mind-map seed built from whiteboard round-rect nodes and
+    /// anchored arrows. This stays entirely inside the whiteboard scene model, so
+    /// selection, movement, text editing, IME, and connector-follow all reuse the
+    /// existing whiteboard machinery.
+    pub fn add_mindmap_seed(&mut self, center_x: f32, center_y: f32, cx: &mut Context<Self>) {
+        self.push_undo();
+        let zoom = self.scene.camera.zoom.max(MIN_ZOOM);
+        let root_w = MINDMAP_ROOT_W / zoom;
+        let root_h = MINDMAP_ROOT_H / zoom;
+        let node_w = MINDMAP_NODE_W / zoom;
+        let node_h = MINDMAP_NODE_H / zoom;
+        let gap_x = MINDMAP_BRANCH_GAP_X / zoom;
+        let gap_y = MINDMAP_BRANCH_GAP_Y / zoom;
+        let stroke = Some(0x2563ebff);
+        let root_fill = Some(0xdbeafeff);
+        let node_fill = Some(0xffffffff);
+
+        let add_node = |scene: &mut Scene,
+                        next_id: &mut u64,
+                        x: f32,
+                        y: f32,
+                        w: f32,
+                        h: f32,
+                        label: &str,
+                        fill: Option<u32>,
+                        mindmap: Option<MindMapNodeMeta>| {
+            let id = *next_id;
+            *next_id += 1;
+            scene.elements.push(Element {
+                id,
+                kind: ElementKind::RoundRect(BoxGeom {
+                    x,
+                    y,
+                    w,
+                    h,
+                    width: NIB / zoom,
+                    rotation: 0.0,
+                }),
+                stroke,
+                fill,
+                label: Some(label.to_string()),
+                label_color: Some(0x0f172aff),
+                styles: Vec::new(),
+                mindmap,
+            });
+            id
+        };
+
+        let root_id = add_node(
+            &mut self.scene,
+            &mut self.next_id,
+            center_x - root_w / 2.0,
+            center_y - root_h / 2.0,
+            root_w,
+            root_h,
+            "Central topic",
+            root_fill,
+            Some(MindMapNodeMeta {
+                parent: None,
+                side: MindMapSide::Right,
+                order: 0,
+                root_direction: MindMapRootDirection::Both,
+                connector_style: MindMapConnectorStyle::Bezier,
+            }),
+        );
+        let right_top_id = add_node(
+            &mut self.scene,
+            &mut self.next_id,
+            center_x + root_w / 2.0 + gap_x,
+            center_y - gap_y - node_h / 2.0,
+            node_w,
+            node_h,
+            "Branch 1",
+            node_fill,
+            Some(MindMapNodeMeta {
+                parent: Some(root_id),
+                side: MindMapSide::Right,
+                order: 0,
+                root_direction: MindMapRootDirection::Both,
+                connector_style: MindMapConnectorStyle::Bezier,
+            }),
+        );
+        let right_bottom_id = add_node(
+            &mut self.scene,
+            &mut self.next_id,
+            center_x + root_w / 2.0 + gap_x,
+            center_y + gap_y - node_h / 2.0,
+            node_w,
+            node_h,
+            "Branch 2",
+            node_fill,
+            Some(MindMapNodeMeta {
+                parent: Some(root_id),
+                side: MindMapSide::Right,
+                order: 1,
+                root_direction: MindMapRootDirection::Both,
+                connector_style: MindMapConnectorStyle::Bezier,
+            }),
+        );
+        let left_top_id = add_node(
+            &mut self.scene,
+            &mut self.next_id,
+            center_x - root_w / 2.0 - gap_x - node_w,
+            center_y - gap_y - node_h / 2.0,
+            node_w,
+            node_h,
+            "Branch 3",
+            node_fill,
+            Some(MindMapNodeMeta {
+                parent: Some(root_id),
+                side: MindMapSide::Left,
+                order: 0,
+                root_direction: MindMapRootDirection::Both,
+                connector_style: MindMapConnectorStyle::Bezier,
+            }),
+        );
+        let left_bottom_id = add_node(
+            &mut self.scene,
+            &mut self.next_id,
+            center_x - root_w / 2.0 - gap_x - node_w,
+            center_y + gap_y - node_h / 2.0,
+            node_w,
+            node_h,
+            "Branch 4",
+            node_fill,
+            Some(MindMapNodeMeta {
+                parent: Some(root_id),
+                side: MindMapSide::Left,
+                order: 1,
+                root_direction: MindMapRootDirection::Both,
+                connector_style: MindMapConnectorStyle::Bezier,
+            }),
+        );
+
+        let add_branch = |scene: &mut Scene,
+                          next_id: &mut u64,
+                          from_id: u64,
+                          from_connector: usize,
+                          to_id: u64,
+                          to_connector: usize| {
+            let start_anchor = SegmentAnchor {
+                element_id: from_id,
+                connector: from_connector,
+            };
+            let end_anchor = SegmentAnchor {
+                element_id: to_id,
+                connector: to_connector,
+            };
+            let [x1, y1] =
+                connector_world_pos_in(&scene.elements, start_anchor).unwrap_or([0.0, 0.0]);
+            let [x2, y2] =
+                connector_world_pos_in(&scene.elements, end_anchor).unwrap_or([0.0, 0.0]);
+            let id = *next_id;
+            *next_id += 1;
+            scene.elements.push(Element {
+                id,
+                kind: ElementKind::Arrow(SegGeom {
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    width: NIB / zoom,
+                    style: SegmentStyle::Solid,
+                    start_anchor: Some(start_anchor),
+                    end_anchor: Some(end_anchor),
+                }),
+                stroke,
+                fill: None,
+                label: None,
+                label_color: None,
+                styles: Vec::new(),
+                mindmap: None,
+            });
+        };
+
+        add_branch(
+            &mut self.scene,
+            &mut self.next_id,
+            root_id,
+            1,
+            right_top_id,
+            3,
+        );
+        add_branch(
+            &mut self.scene,
+            &mut self.next_id,
+            root_id,
+            1,
+            right_bottom_id,
+            3,
+        );
+        add_branch(
+            &mut self.scene,
+            &mut self.next_id,
+            root_id,
+            3,
+            left_top_id,
+            1,
+        );
+        add_branch(
+            &mut self.scene,
+            &mut self.next_id,
+            root_id,
+            3,
+            left_bottom_id,
+            1,
+        );
+
+        self.selected = vec![root_id];
+        self.tool = Tool::Select;
+        cx.notify();
+    }
+
+    pub fn add_mindmap_seed_at_viewport_center(&mut self, cx: &mut Context<Self>) {
+        let center = self.viewport_center();
+        self.add_mindmap_seed(center[0], center[1], cx);
+    }
+
+    /// Insert a native flowchart seed made from regular whiteboard nodes and
+    /// anchored arrows. This is the first structured flowchart primitive inside
+    /// the board and can later grow auto-layout / auto-branch behavior.
+    pub fn add_flowchart_seed(&mut self, center_x: f32, center_y: f32, cx: &mut Context<Self>) {
+        self.push_undo();
+        let zoom = self.scene.camera.zoom.max(MIN_ZOOM);
+        let node_w = FLOWCHART_NODE_W / zoom;
+        let node_h = FLOWCHART_NODE_H / zoom;
+        let gap_y = FLOWCHART_GAP_Y / zoom;
+        let branch_gap_x = FLOWCHART_BRANCH_GAP_X / zoom;
+        let stroke = Some(0x0f172aff);
+        let fill = Some(0xffffffff);
+
+        let add_box = |scene: &mut Scene, next_id: &mut u64, kind: ElementKind, label: &str| {
+            let id = *next_id;
+            *next_id += 1;
+            scene.elements.push(Element {
+                id,
+                kind,
+                stroke,
+                fill,
+                label: Some(label.to_string()),
+                label_color: Some(0x0f172aff),
+                styles: Vec::new(),
+                mindmap: None,
+            });
+            id
+        };
+        let add_arrow = |scene: &mut Scene,
+                         next_id: &mut u64,
+                         from_id: u64,
+                         from_connector: usize,
+                         to_id: u64,
+                         to_connector: usize| {
+            let start_anchor = SegmentAnchor {
+                element_id: from_id,
+                connector: from_connector,
+            };
+            let end_anchor = SegmentAnchor {
+                element_id: to_id,
+                connector: to_connector,
+            };
+            let [x1, y1] =
+                connector_world_pos_in(&scene.elements, start_anchor).unwrap_or([0.0, 0.0]);
+            let [x2, y2] =
+                connector_world_pos_in(&scene.elements, end_anchor).unwrap_or([0.0, 0.0]);
+            let id = *next_id;
+            *next_id += 1;
+            scene.elements.push(Element {
+                id,
+                kind: ElementKind::Arrow(SegGeom {
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    width: NIB / zoom,
+                    style: SegmentStyle::Solid,
+                    start_anchor: Some(start_anchor),
+                    end_anchor: Some(end_anchor),
+                }),
+                stroke,
+                fill: None,
+                label: None,
+                label_color: None,
+                styles: Vec::new(),
+                mindmap: None,
+            });
+        };
+
+        let start_id = add_box(
+            &mut self.scene,
+            &mut self.next_id,
+            ElementKind::Ellipse(BoxGeom {
+                x: center_x - node_w / 2.0,
+                y: center_y - gap_y - node_h * 1.5,
+                w: node_w,
+                h: node_h,
+                width: NIB / zoom,
+                rotation: 0.0,
+            }),
+            "Start",
+        );
+        let process_id = add_box(
+            &mut self.scene,
+            &mut self.next_id,
+            ElementKind::RoundRect(BoxGeom {
+                x: center_x - node_w / 2.0,
+                y: center_y - node_h / 2.0,
+                w: node_w,
+                h: node_h,
+                width: NIB / zoom,
+                rotation: 0.0,
+            }),
+            "Process",
+        );
+        let decision_id = add_box(
+            &mut self.scene,
+            &mut self.next_id,
+            ElementKind::Diamond(BoxGeom {
+                x: center_x - node_w / 2.0,
+                y: center_y + gap_y - node_h / 2.0,
+                w: node_w,
+                h: node_h,
+                width: NIB / zoom,
+                rotation: 0.0,
+            }),
+            "Decision",
+        );
+        let branch_yes_id = add_box(
+            &mut self.scene,
+            &mut self.next_id,
+            ElementKind::RoundRect(BoxGeom {
+                x: center_x + branch_gap_x - node_w / 2.0,
+                y: center_y + gap_y - node_h / 2.0,
+                w: node_w,
+                h: node_h,
+                width: NIB / zoom,
+                rotation: 0.0,
+            }),
+            "Yes",
+        );
+        let branch_no_id = add_box(
+            &mut self.scene,
+            &mut self.next_id,
+            ElementKind::RoundRect(BoxGeom {
+                x: center_x - branch_gap_x - node_w / 2.0,
+                y: center_y + gap_y - node_h / 2.0,
+                w: node_w,
+                h: node_h,
+                width: NIB / zoom,
+                rotation: 0.0,
+            }),
+            "No",
+        );
+        let end_id = add_box(
+            &mut self.scene,
+            &mut self.next_id,
+            ElementKind::Ellipse(BoxGeom {
+                x: center_x - node_w / 2.0,
+                y: center_y + gap_y * 2.0 + node_h * 0.5,
+                w: node_w,
+                h: node_h,
+                width: NIB / zoom,
+                rotation: 0.0,
+            }),
+            "End",
+        );
+
+        add_arrow(
+            &mut self.scene,
+            &mut self.next_id,
+            start_id,
+            2,
+            process_id,
+            0,
+        );
+        add_arrow(
+            &mut self.scene,
+            &mut self.next_id,
+            process_id,
+            2,
+            decision_id,
+            0,
+        );
+        add_arrow(
+            &mut self.scene,
+            &mut self.next_id,
+            decision_id,
+            1,
+            branch_yes_id,
+            3,
+        );
+        add_arrow(
+            &mut self.scene,
+            &mut self.next_id,
+            decision_id,
+            3,
+            branch_no_id,
+            1,
+        );
+        add_arrow(
+            &mut self.scene,
+            &mut self.next_id,
+            branch_yes_id,
+            2,
+            end_id,
+            1,
+        );
+        add_arrow(
+            &mut self.scene,
+            &mut self.next_id,
+            branch_no_id,
+            2,
+            end_id,
+            3,
+        );
+
+        self.selected = vec![process_id];
+        self.tool = Tool::Select;
+        cx.notify();
+    }
+
+    pub fn add_flowchart_seed_at_viewport_center(&mut self, cx: &mut Context<Self>) {
+        let center = self.viewport_center();
+        self.add_flowchart_seed(center[0], center[1], cx);
+    }
+
+    fn mindmap_meta(&self, id: u64) -> Option<MindMapNodeMeta> {
+        self.scene
+            .elements
+            .iter()
+            .find(|element| element.id == id)
+            .and_then(|element| element.mindmap)
+    }
+
+    fn is_mindmap_node(&self, id: u64) -> bool {
+        self.mindmap_meta(id).is_some()
+    }
+
+    fn is_mindmap_root(&self, id: u64) -> bool {
+        self.mindmap_meta(id)
+            .is_some_and(|meta| meta.parent.is_none())
+    }
+
+    fn selected_mindmap_root(&self) -> Option<u64> {
+        self.selected_single()
+            .filter(|id| self.is_mindmap_root(*id))
+    }
+
+    fn mindmap_root_direction(&self, root_id: u64) -> MindMapRootDirection {
+        self.mindmap_meta(root_id)
+            .map(|meta| meta.root_direction)
+            .unwrap_or_default()
+    }
+
+    fn mindmap_connector_style_for_root(&self, root_id: u64) -> MindMapConnectorStyle {
+        self.mindmap_meta(root_id)
+            .map(|meta| meta.connector_style)
+            .unwrap_or_default()
+    }
+
+    fn mindmap_root_of(&self, id: u64) -> Option<u64> {
+        let mut current = id;
+        loop {
+            let meta = self.mindmap_meta(current)?;
+            match meta.parent {
+                Some(parent) => current = parent,
+                None => return Some(current),
+            }
+        }
+    }
+
+    fn mindmap_children(&self, parent: u64, side: MindMapSide) -> Vec<u64> {
+        let mut children: Vec<(usize, u64)> = self
+            .scene
+            .elements
+            .iter()
+            .filter_map(|element| {
+                let meta = element.mindmap?;
+                (meta.parent == Some(parent) && meta.side == side)
+                    .then_some((meta.order, element.id))
+            })
+            .collect();
+        children.sort_by_key(|(order, id)| (*order, *id));
+        children.into_iter().map(|(_, id)| id).collect()
+    }
+
+    fn set_mindmap_node_side(&mut self, id: u64, side: MindMapSide) {
+        if let Some(element) = self
+            .scene
+            .elements
+            .iter_mut()
+            .find(|element| element.id == id)
+            && let Some(meta) = &mut element.mindmap
+        {
+            meta.side = side;
+        }
+        self.sync_mindmap_parent_link(id);
+    }
+
+    fn sync_mindmap_parent_link(&mut self, child_id: u64) {
+        let Some(meta) = self.mindmap_meta(child_id) else {
+            return;
+        };
+        let Some(parent_id) = meta.parent else {
+            return;
+        };
+        let parent_connector = match meta.side {
+            MindMapSide::Right => 1,
+            MindMapSide::Left => 3,
+        };
+        let child_connector = match meta.side {
+            MindMapSide::Right => 3,
+            MindMapSide::Left => 1,
+        };
+        for element in &mut self.scene.elements {
+            let segment = match &mut element.kind {
+                ElementKind::Line(segment) | ElementKind::Arrow(segment) => segment,
+                _ => continue,
+            };
+            let start_id = segment.start_anchor.map(|anchor| anchor.element_id);
+            let end_id = segment.end_anchor.map(|anchor| anchor.element_id);
+            let links_parent_child = matches!((start_id, end_id), (Some(a), Some(b)) if (a == parent_id && b == child_id) || (a == child_id && b == parent_id));
+            if !links_parent_child {
+                continue;
+            }
+            if let Some(anchor) = &mut segment.start_anchor {
+                if anchor.element_id == parent_id {
+                    anchor.connector = parent_connector;
+                } else if anchor.element_id == child_id {
+                    anchor.connector = child_connector;
+                }
+            }
+            if let Some(anchor) = &mut segment.end_anchor {
+                if anchor.element_id == parent_id {
+                    anchor.connector = parent_connector;
+                } else if anchor.element_id == child_id {
+                    anchor.connector = child_connector;
+                }
+            }
+        }
+        self.sync_segment_anchors_for(&[parent_id, child_id]);
+    }
+
+    fn sync_mindmap_links_for_root(&mut self, root_id: u64) {
+        let child_ids: Vec<u64> = self
+            .scene
+            .elements
+            .iter()
+            .filter_map(|element| {
+                let meta = element.mindmap?;
+                meta.parent?;
+                (self.mindmap_root_of(element.id) == Some(root_id)).then_some(element.id)
+            })
+            .collect();
+        for child_id in &child_ids {
+            let Some(meta) = self.mindmap_meta(*child_id) else {
+                continue;
+            };
+            let Some(parent_id) = meta.parent else {
+                continue;
+            };
+            let parent_connector = match meta.side {
+                MindMapSide::Right => 1,
+                MindMapSide::Left => 3,
+            };
+            let child_connector = match meta.side {
+                MindMapSide::Right => 3,
+                MindMapSide::Left => 1,
+            };
+            for element in &mut self.scene.elements {
+                let segment = match &mut element.kind {
+                    ElementKind::Line(segment) | ElementKind::Arrow(segment) => segment,
+                    _ => continue,
+                };
+                let start_id = segment.start_anchor.map(|anchor| anchor.element_id);
+                let end_id = segment.end_anchor.map(|anchor| anchor.element_id);
+                let links_parent_child = matches!((start_id, end_id), (Some(a), Some(b)) if (a == parent_id && b == *child_id) || (a == *child_id && b == parent_id));
+                if !links_parent_child {
+                    continue;
+                }
+                if let Some(anchor) = &mut segment.start_anchor {
+                    if anchor.element_id == parent_id {
+                        anchor.connector = parent_connector;
+                    } else if anchor.element_id == *child_id {
+                        anchor.connector = child_connector;
+                    }
+                }
+                if let Some(anchor) = &mut segment.end_anchor {
+                    if anchor.element_id == parent_id {
+                        anchor.connector = parent_connector;
+                    } else if anchor.element_id == *child_id {
+                        anchor.connector = child_connector;
+                    }
+                }
+            }
+        }
+        self.sync_segment_anchors_for(&child_ids);
+    }
+
+    fn ordered_mindmap_children(&self, parent: u64) -> Vec<u64> {
+        let mut children: Vec<(f32, f32, usize, u64)> = self
+            .scene
+            .elements
+            .iter()
+            .filter_map(|element| {
+                let meta = element.mindmap?;
+                (meta.parent == Some(parent)).then(|| {
+                    let (x, y, _, h, _) =
+                        box_like(&element.kind).unwrap_or((0.0, 0.0, 0.0, 0.0, 0.0));
+                    (y + h / 2.0, x, meta.order, element.id)
+                })
+            })
+            .collect();
+        children.sort_by(|a, b| {
+            a.0.total_cmp(&b.0)
+                .then_with(|| a.1.total_cmp(&b.1))
+                .then_with(|| a.2.cmp(&b.2))
+                .then_with(|| a.3.cmp(&b.3))
+        });
+        children.into_iter().map(|(_, _, _, id)| id).collect()
+    }
+
+    fn set_mindmap_children_side(&mut self, parent: u64, side: MindMapSide) {
+        for child_id in self.ordered_mindmap_children(parent) {
+            self.set_mindmap_node_side(child_id, side);
+        }
+    }
+
+    fn set_mindmap_children_side_alternating(&mut self, parent: u64) {
+        for (index, child_id) in self
+            .ordered_mindmap_children(parent)
+            .into_iter()
+            .enumerate()
+        {
+            let side = if index % 2 == 0 {
+                MindMapSide::Right
+            } else {
+                MindMapSide::Left
+            };
+            self.set_mindmap_node_side(child_id, side);
+        }
+    }
+
+    fn reindex_mindmap_children(&mut self, parent: u64) {
+        for side in [MindMapSide::Left, MindMapSide::Right] {
+            let children = self.mindmap_children(parent, side);
+            for (order, child_id) in children.into_iter().enumerate() {
+                if let Some(element) = self
+                    .scene
+                    .elements
+                    .iter_mut()
+                    .find(|element| element.id == child_id)
+                    && let Some(meta) = &mut element.mindmap
+                {
+                    meta.order = order;
+                }
+                self.reindex_mindmap_children(child_id);
+            }
+        }
+    }
+
+    fn set_mindmap_root_direction(
+        &mut self,
+        root_id: u64,
+        direction: MindMapRootDirection,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(element) = self
+            .scene
+            .elements
+            .iter_mut()
+            .find(|element| element.id == root_id)
+            && let Some(meta) = &mut element.mindmap
+        {
+            meta.root_direction = direction;
+        }
+        match direction {
+            MindMapRootDirection::Left => {
+                self.set_mindmap_children_side(root_id, MindMapSide::Left)
+            }
+            MindMapRootDirection::Right => {
+                self.set_mindmap_children_side(root_id, MindMapSide::Right)
+            }
+            MindMapRootDirection::Both => self.set_mindmap_children_side_alternating(root_id),
+        }
+        self.reindex_mindmap_children(root_id);
+        self.relayout_mindmap_tree(root_id);
+        cx.notify();
+    }
+
+    fn set_mindmap_connector_style(
+        &mut self,
+        root_id: u64,
+        style: MindMapConnectorStyle,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(element) = self
+            .scene
+            .elements
+            .iter_mut()
+            .find(|element| element.id == root_id)
+            && let Some(meta) = &mut element.mindmap
+        {
+            meta.connector_style = style;
+        }
+        cx.notify();
+    }
+
+    fn set_mindmap_node_position(&mut self, id: u64, x: f32, y: f32) {
+        if let Some(element) = self
+            .scene
+            .elements
+            .iter_mut()
+            .find(|element| element.id == id)
+            && let ElementKind::RoundRect(geom) = &mut element.kind
+        {
+            geom.x = x;
+            geom.y = y;
+        }
+    }
+
+    fn mindmap_node_size(&self, id: u64, zoom: f32) -> (f32, f32) {
+        self.scene
+            .elements
+            .iter()
+            .find(|element| element.id == id)
+            .and_then(|element| box_like(&element.kind).map(|(_, _, w, h, _)| (w, h)))
+            .unwrap_or((MINDMAP_NODE_W / zoom, MINDMAP_NODE_H / zoom))
+    }
+
+    fn side_stack_height(&self, parent: u64, side: MindMapSide, zoom: f32) -> f32 {
+        let children = self.mindmap_children(parent, side);
+        if children.is_empty() {
+            return 0.0;
+        }
+        let gap_y = MINDMAP_BRANCH_GAP_Y / zoom;
+        children
+            .into_iter()
+            .enumerate()
+            .fold(0.0, |acc, (index, child_id)| {
+                acc + if index > 0 { gap_y } else { 0.0 }
+                    + self.mindmap_subtree_height(child_id, zoom)
+            })
+    }
+
+    fn mindmap_subtree_height(&self, id: u64, zoom: f32) -> f32 {
+        let (_, node_h) = self.mindmap_node_size(id, zoom);
+        node_h.max(
+            self.side_stack_height(id, MindMapSide::Left, zoom)
+                .max(self.side_stack_height(id, MindMapSide::Right, zoom)),
+        )
+    }
+
+    fn relayout_mindmap_subtree(&mut self, node_id: u64, moved: &mut Vec<u64>, zoom: f32) {
+        self.relayout_mindmap_children(node_id, MindMapSide::Left, moved, zoom);
+        self.relayout_mindmap_children(node_id, MindMapSide::Right, moved, zoom);
+    }
+
+    fn relayout_mindmap_children(
+        &mut self,
+        parent_id: u64,
+        side: MindMapSide,
+        moved: &mut Vec<u64>,
+        zoom: f32,
+    ) {
+        let children = self.mindmap_children(parent_id, side);
+        if children.is_empty() {
+            return;
+        }
+        let Some((px, py, pw, ph, _)) = self
+            .scene
+            .elements
+            .iter()
+            .find(|element| element.id == parent_id)
+            .and_then(|element| box_like(&element.kind))
+        else {
+            return;
+        };
+        let gap_x = MINDMAP_BRANCH_GAP_X / zoom;
+        let gap_y = MINDMAP_BRANCH_GAP_Y / zoom;
+        let total_h = children
+            .iter()
+            .enumerate()
+            .fold(0.0, |acc, (index, child_id)| {
+                acc + if index > 0 { gap_y } else { 0.0 }
+                    + self.mindmap_subtree_height(*child_id, zoom)
+            });
+        let mut cursor_y = py + ph / 2.0 - total_h / 2.0;
+        for child_id in children {
+            let subtree_h = self.mindmap_subtree_height(child_id, zoom);
+            let (cw, ch) = self.mindmap_node_size(child_id, zoom);
+            let cy = cursor_y + subtree_h / 2.0;
+            let x = match side {
+                MindMapSide::Right => px + pw + gap_x,
+                MindMapSide::Left => px - gap_x - cw,
+            };
+            self.set_mindmap_node_position(child_id, x, cy - ch / 2.0);
+            moved.push(child_id);
+            self.relayout_mindmap_subtree(child_id, moved, zoom);
+            cursor_y += subtree_h + gap_y;
+        }
+    }
+
+    fn relayout_mindmap_tree(&mut self, root_id: u64) {
+        let zoom = self.scene.camera.zoom.max(MIN_ZOOM);
+        let mut moved = vec![root_id];
+        self.relayout_mindmap_subtree(root_id, &mut moved, zoom);
+        self.sync_mindmap_links_for_root(root_id);
+        self.sync_segment_anchors_for(&moved);
+    }
+
+    fn bump_mindmap_sibling_orders(&mut self, parent: u64, side: MindMapSide, from_order: usize) {
+        for element in &mut self.scene.elements {
+            if let Some(meta) = &mut element.mindmap
+                && meta.parent == Some(parent)
+                && meta.side == side
+                && meta.order >= from_order
+            {
+                meta.order += 1;
+            }
+        }
+    }
+
+    fn create_mindmap_node(
+        &mut self,
+        parent: u64,
+        side: MindMapSide,
+        order: usize,
+        label: &str,
+    ) -> u64 {
+        self.bump_mindmap_sibling_orders(parent, side, order);
+        let zoom = self.scene.camera.zoom.max(MIN_ZOOM);
+        let id = self.next_id;
+        self.next_id += 1;
+        let w = MINDMAP_NODE_W / zoom;
+        let h = MINDMAP_NODE_H / zoom;
+        let (x, y) = self
+            .scene
+            .elements
+            .iter()
+            .find(|element| element.id == parent)
+            .and_then(|element| box_like(&element.kind))
+            .map(|(px, py, pw, ph, _)| match side {
+                MindMapSide::Right => (
+                    px + pw + MINDMAP_BRANCH_GAP_X / zoom,
+                    py + ph / 2.0 - h / 2.0,
+                ),
+                MindMapSide::Left => (
+                    px - MINDMAP_BRANCH_GAP_X / zoom - w,
+                    py + ph / 2.0 - h / 2.0,
+                ),
+            })
+            .unwrap_or((0.0, 0.0));
+        self.scene.elements.push(Element {
+            id,
+            kind: ElementKind::RoundRect(BoxGeom {
+                x,
+                y,
+                w,
+                h,
+                width: NIB / zoom,
+                rotation: 0.0,
+            }),
+            stroke: Some(0x2563ebff),
+            fill: Some(0xffffffff),
+            label: Some(label.to_string()),
+            label_color: Some(0x0f172aff),
+            styles: Vec::new(),
+            mindmap: Some(MindMapNodeMeta {
+                parent: Some(parent),
+                side,
+                order,
+                root_direction: MindMapRootDirection::Both,
+                connector_style: MindMapConnectorStyle::Bezier,
+            }),
+        });
+        let start_anchor = SegmentAnchor {
+            element_id: parent,
+            connector: match side {
+                MindMapSide::Right => 1,
+                MindMapSide::Left => 3,
+            },
+        };
+        let end_anchor = SegmentAnchor {
+            element_id: id,
+            connector: match side {
+                MindMapSide::Right => 3,
+                MindMapSide::Left => 1,
+            },
+        };
+        let [x1, y1] = connector_world_pos_in(&self.scene.elements, start_anchor).unwrap_or([x, y]);
+        let [x2, y2] = connector_world_pos_in(&self.scene.elements, end_anchor).unwrap_or([x, y]);
+        let line_id = self.next_id;
+        self.next_id += 1;
+        self.scene.elements.push(Element {
+            id: line_id,
+            kind: ElementKind::Arrow(SegGeom {
+                x1,
+                y1,
+                x2,
+                y2,
+                width: NIB / zoom,
+                style: SegmentStyle::Solid,
+                start_anchor: Some(start_anchor),
+                end_anchor: Some(end_anchor),
+            }),
+            stroke: Some(0x2563ebff),
+            fill: None,
+            label: None,
+            label_color: None,
+            styles: Vec::new(),
+            mindmap: None,
+        });
+        if let Some(root_id) = self.mindmap_root_of(parent) {
+            self.relayout_mindmap_tree(root_id);
+        }
+        id
+    }
+
+    fn add_mindmap_relative(
+        &mut self,
+        source_id: u64,
+        sibling: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(meta) = self.mindmap_meta(source_id) else {
+            return false;
+        };
+        let (parent, side, order) = if sibling {
+            match meta.parent {
+                Some(parent) => (parent, meta.side, meta.order + 1),
+                None => (
+                    source_id,
+                    MindMapSide::Right,
+                    self.mindmap_children(source_id, MindMapSide::Right).len(),
+                ),
+            }
+        } else {
+            (
+                source_id,
+                meta.side,
+                self.mindmap_children(source_id, meta.side).len(),
+            )
+        };
+        self.push_undo();
+        let new_id = self.create_mindmap_node(parent, side, order, "");
+        self.selected = vec![new_id];
+        self.begin_text_edit(new_id, 0, window, cx);
+        self.dirty = true;
+        cx.notify();
+        true
+    }
+
+    fn mindmap_connector_style_for_element(
+        &self,
+        kind: &ElementKind,
+    ) -> Option<MindMapConnectorStyle> {
+        let seg = match kind {
+            ElementKind::Line(seg) | ElementKind::Arrow(seg) => seg,
+            _ => return None,
+        };
+        let start_root = seg
+            .start_anchor
+            .and_then(|anchor| self.mindmap_root_of(anchor.element_id));
+        let end_root = seg
+            .end_anchor
+            .and_then(|anchor| self.mindmap_root_of(anchor.element_id));
+        match (start_root, end_root) {
+            (Some(a), Some(b)) if a == b => Some(self.mindmap_connector_style_for_root(a)),
+            _ => None,
+        }
     }
 
     /// The world point at the center of the current viewport — where paste drops
@@ -1583,6 +2868,70 @@ impl WhiteboardView {
         &self.scene
     }
 
+    /// Build a local-thumbnail focus spec for the board. The board default has
+    /// no natural root, so `Auto` means:
+    ///
+    /// - selected content, if any
+    /// - otherwise the current viewport
+    /// - otherwise all content
+    pub fn local_thumbnail_spec(
+        &self,
+        width_px: f32,
+        height_px: f32,
+    ) -> Option<LocalThumbnailSpec> {
+        self.local_thumbnail_spec_for_mode(LocalThumbnailMode::Auto, width_px, height_px)
+    }
+
+    pub fn local_thumbnail_snapshot(
+        &self,
+        width_px: f32,
+        height_px: f32,
+    ) -> Option<LocalThumbnailSnapshot> {
+        self.local_thumbnail_snapshot_for_mode(LocalThumbnailMode::Auto, width_px, height_px)
+    }
+
+    pub fn local_thumbnail_spec_for_mode(
+        &self,
+        mode: LocalThumbnailMode,
+        width_px: f32,
+        height_px: f32,
+    ) -> Option<LocalThumbnailSpec> {
+        let scene_bounds = self.scene_bbox();
+        let (anchor_element_id, focus) = match mode {
+            LocalThumbnailMode::Auto => self
+                .selection_bbox()
+                .map(|bb| (self.selected_single(), bb))
+                .or_else(|| self.viewport_world_bbox().map(|bb| (None, bb)))
+                .or_else(|| scene_bounds.map(|bb| (None, bb)))?,
+            LocalThumbnailMode::Selection => {
+                let bb = self.selection_bbox()?;
+                (self.selected_single(), bb)
+            }
+            LocalThumbnailMode::Viewport => (None, self.viewport_world_bbox()?),
+            LocalThumbnailMode::AllContent => (None, scene_bounds?),
+            LocalThumbnailMode::Element(id) => (Some(id), self.element_bbox(id)?),
+        };
+        Some(self.thumbnail_spec_from_bbox(
+            anchor_element_id,
+            focus,
+            scene_bounds,
+            width_px,
+            height_px,
+        ))
+    }
+
+    pub fn local_thumbnail_snapshot_for_mode(
+        &self,
+        mode: LocalThumbnailMode,
+        width_px: f32,
+        height_px: f32,
+    ) -> Option<LocalThumbnailSnapshot> {
+        Some(LocalThumbnailSnapshot {
+            scene: self.scene.clone(),
+            spec: self.local_thumbnail_spec_for_mode(mode, width_px, height_px)?,
+        })
+    }
+
     /// The lone selected id, if exactly one element is selected. Single-element
     /// manipulation (resize, endpoints, edit) only applies then.
     fn selected_single(&self) -> Option<u64> {
@@ -1594,6 +2943,59 @@ impl WhiteboardView {
 
     fn is_selected(&self, id: u64) -> bool {
         self.selected.contains(&id)
+    }
+
+    fn element_bbox(&self, id: u64) -> Option<(f32, f32, f32, f32)> {
+        self.scene
+            .elements
+            .iter()
+            .find(|e| e.id == id)
+            .map(|e| bbox(&e.kind))
+    }
+
+    fn scene_bbox(&self) -> Option<(f32, f32, f32, f32)> {
+        scene_bbox_for_local_thumbnail(&self.scene)
+    }
+
+    fn viewport_world_bbox(&self) -> Option<(f32, f32, f32, f32)> {
+        let b = self.bounds.get();
+        let vw = f32::from(b.size.width);
+        let vh = f32::from(b.size.height);
+        if vw <= 1.0 || vh <= 1.0 {
+            return None;
+        }
+        let cam = self.scene.camera;
+        let z = cam.zoom.max(MIN_ZOOM);
+        Some((cam.x, cam.y, cam.x + vw / z, cam.y + vh / z))
+    }
+
+    fn render_viewport(&self, fallback_size: Option<gpui::Size<Pixels>>) -> Option<WorldViewport> {
+        let bounds = self.bounds.get();
+        let size = if f32::from(bounds.size.width) > 1.0 && f32::from(bounds.size.height) > 1.0 {
+            bounds.size
+        } else {
+            fallback_size?
+        };
+        let camera = self.scene.camera;
+        WorldViewport::from_canvas(
+            f32::from(size.width),
+            f32::from(size.height),
+            camera.x,
+            camera.y,
+            camera.zoom.max(MIN_ZOOM),
+            VIEWPORT_CULL_MARGIN_PX,
+        )
+    }
+
+    fn thumbnail_spec_from_bbox(
+        &self,
+        anchor_element_id: Option<u64>,
+        focus: (f32, f32, f32, f32),
+        scene_bounds: Option<(f32, f32, f32, f32)>,
+        width_px: f32,
+        height_px: f32,
+    ) -> LocalThumbnailSpec {
+        local_thumbnail_spec_from_bbox(anchor_element_id, focus, scene_bounds, width_px, height_px)
     }
 
     /// World-space bounds enclosing the whole selection, or `None` if empty.
@@ -1608,6 +3010,149 @@ impl WhiteboardView {
         Some(it.fold(first, |a, b| {
             (a.0.min(b.0), a.1.min(b.1), a.2.max(b.2), a.3.max(b.3))
         }))
+    }
+
+    fn aligned_move_delta(&self, dx: f32, dy: f32) -> (f32, f32, AlignmentGuides) {
+        const SNAP_PX: f32 = 6.0;
+        let Some(selection) = self.selection_bbox() else {
+            return (dx, dy, AlignmentGuides::default());
+        };
+        let threshold = SNAP_PX / self.scene.camera.zoom.max(MIN_ZOOM);
+        let moving_x = [
+            selection.0 + dx,
+            (selection.0 + selection.2) / 2.0 + dx,
+            selection.2 + dx,
+        ];
+        let moving_y = [
+            selection.1 + dy,
+            (selection.1 + selection.3) / 2.0 + dy,
+            selection.3 + dy,
+        ];
+        let mut best_x: Option<(f32, f32)> = None;
+        let mut best_y: Option<(f32, f32)> = None;
+
+        for element in self
+            .scene
+            .elements
+            .iter()
+            .filter(|element| !self.selected.contains(&element.id))
+        {
+            let bb = bbox(&element.kind);
+            for moving in moving_x {
+                for target in [bb.0, (bb.0 + bb.2) / 2.0, bb.2] {
+                    let correction = target - moving;
+                    if correction.abs() <= threshold
+                        && best_x.is_none_or(|(best, _)| correction.abs() < best.abs())
+                    {
+                        best_x = Some((correction, target));
+                    }
+                }
+            }
+            for moving in moving_y {
+                for target in [bb.1, (bb.1 + bb.3) / 2.0, bb.3] {
+                    let correction = target - moving;
+                    if correction.abs() <= threshold
+                        && best_y.is_none_or(|(best, _)| correction.abs() < best.abs())
+                    {
+                        best_y = Some((correction, target));
+                    }
+                }
+            }
+        }
+
+        (
+            dx + best_x.map_or(0.0, |(correction, _)| correction),
+            dy + best_y.map_or(0.0, |(correction, _)| correction),
+            AlignmentGuides {
+                vertical: best_x.map(|(_, target)| target),
+                horizontal: best_y.map(|(_, target)| target),
+            },
+        )
+    }
+
+    fn sync_segment_anchors_for(&mut self, changed_ids: &[u64]) {
+        if changed_ids.is_empty() {
+            return;
+        }
+        let elements = self.scene.elements.clone();
+        for element in &mut self.scene.elements {
+            let segment = match &mut element.kind {
+                ElementKind::Line(segment) | ElementKind::Arrow(segment) => segment,
+                _ => continue,
+            };
+            if let Some(anchor) = segment.start_anchor
+                && changed_ids.contains(&anchor.element_id)
+                && let Some(pos) = connector_world_pos_in(&elements, anchor)
+            {
+                segment.x1 = pos[0];
+                segment.y1 = pos[1];
+            }
+            if let Some(anchor) = segment.end_anchor
+                && changed_ids.contains(&anchor.element_id)
+                && let Some(pos) = connector_world_pos_in(&elements, anchor)
+            {
+                segment.x2 = pos[0];
+                segment.y2 = pos[1];
+            }
+        }
+    }
+
+    fn detach_segment_bindings_for_move(&mut self, ids: &[u64]) {
+        for element in &mut self.scene.elements {
+            if !ids.contains(&element.id) {
+                continue;
+            }
+            if let ElementKind::Line(segment) | ElementKind::Arrow(segment) = &mut element.kind {
+                if segment
+                    .start_anchor
+                    .is_some_and(|anchor| !ids.contains(&anchor.element_id))
+                {
+                    segment.start_anchor = None;
+                }
+                if segment
+                    .end_anchor
+                    .is_some_and(|anchor| !ids.contains(&anchor.element_id))
+                {
+                    segment.end_anchor = None;
+                }
+            }
+        }
+    }
+
+    fn set_segment_endpoint_anchor(
+        &mut self,
+        segment_id: u64,
+        endpoint: usize,
+        anchor: Option<SegmentAnchor>,
+    ) {
+        let pos = anchor.and_then(|anchor| {
+            connector_world_pos_in(&self.scene.elements, anchor).map(|pos| (anchor, pos))
+        });
+        let Some(element) = self
+            .scene
+            .elements
+            .iter_mut()
+            .find(|element| element.id == segment_id)
+        else {
+            return;
+        };
+        let segment = match &mut element.kind {
+            ElementKind::Line(segment) | ElementKind::Arrow(segment) => segment,
+            _ => return,
+        };
+        if endpoint == 0 {
+            segment.start_anchor = anchor;
+            if let Some((_, pos)) = pos {
+                segment.x1 = pos[0];
+                segment.y1 = pos[1];
+            }
+        } else {
+            segment.end_anchor = anchor;
+            if let Some((_, pos)) = pos {
+                segment.x2 = pos[0];
+                segment.y2 = pos[1];
+            }
+        }
     }
 
     /// Whether a *group* rotation applies: more than one element selected, at
@@ -1629,6 +3174,13 @@ impl WhiteboardView {
     /// Switch the active drawing tool. Leaving Select clears the selection.
     /// Always closes an open tool flyout (the tool was just chosen).
     pub fn set_tool(&mut self, tool: Tool, cx: &mut Context<Self>) {
+        if self.read_only {
+            self.tool = Tool::Pan;
+            self.selected.clear();
+            self.open_group = None;
+            cx.notify();
+            return;
+        }
         self.open_group = None;
         if self.tool != tool {
             self.tool = tool;
@@ -1925,7 +3477,7 @@ impl WhiteboardView {
                 for e in &elems {
                     let stroke = e.stroke.map_or(ink, u32_to_hsla);
                     let fill = e.fill.map(u32_to_hsla);
-                    paint_element(&e.kind, cam, bounds.origin, stroke, fill, window);
+                    paint_element(&e.kind, None, cam, bounds.origin, stroke, fill, window);
                 }
             },
         )
@@ -2002,23 +3554,16 @@ impl WhiteboardView {
         });
     }
 
-    /// Close every popover/flyout (only one shows at a time). Called at the top
-    /// of each `toggle_*` so each then only flips its own field.
-    fn close_popovers(&mut self) {
-        self.picker = None;
+    /// Open or close the color picker. Opening seeds the controls from the
+    /// stroke color (selection's, else active, else a default).
+    fn toggle_picker(&mut self, cx: &mut Context<Self>) {
         self.open_group = None;
         self.templates_open = false;
         self.width_open = false;
         self.font_open = false;
-        self.context_menu = None;
-    }
-
-    /// Open or close the color picker. Opening seeds the controls from the
-    /// stroke color (selection's, else active, else a default).
-    fn toggle_picker(&mut self, cx: &mut Context<Self>) {
-        let was_open = self.picker.is_some();
-        self.close_popovers();
-        if !was_open {
+        if self.picker.is_some() {
+            self.picker = None;
+        } else {
             self.seed_picker(PickerTarget::Stroke);
         }
         cx.notify();
@@ -2026,9 +3571,12 @@ impl WhiteboardView {
 
     /// Open / close the thickness-preset flyout (closing the other popovers).
     fn toggle_width(&mut self, cx: &mut Context<Self>) {
-        let open = !self.width_open;
-        self.close_popovers();
-        self.width_open = open;
+        self.picker = None;
+        self.open_group = None;
+        self.templates_open = false;
+        self.context_menu = None;
+        self.font_open = false;
+        self.width_open = !self.width_open;
         cx.notify();
     }
 
@@ -2070,30 +3618,38 @@ impl WhiteboardView {
     /// Open the given tool category's flyout (or close it if already open).
     /// Closes the color picker so only one popover shows at a time.
     fn toggle_group(&mut self, group: ToolGroup, cx: &mut Context<Self>) {
-        let next = if self.open_group == Some(group) {
+        self.picker = None;
+        self.templates_open = false;
+        self.width_open = false;
+        self.font_open = false;
+        self.open_group = if self.open_group == Some(group) {
             None
         } else {
             Some(group)
         };
-        self.close_popovers();
-        self.open_group = next;
         cx.notify();
     }
 
     /// Open / close the templates gallery modal (closing the other popovers).
     fn toggle_templates(&mut self, cx: &mut Context<Self>) {
-        let open = !self.templates_open;
-        self.close_popovers();
-        self.templates_open = open;
+        self.picker = None;
+        self.open_group = None;
+        self.width_open = false;
+        self.context_menu = None;
+        self.font_open = false;
+        self.templates_open = !self.templates_open;
         cx.notify();
     }
 
     /// Open / close the font flyout (upload a face / revert to default), closing
     /// the other popovers.
     fn toggle_font(&mut self, cx: &mut Context<Self>) {
-        let open = !self.font_open;
-        self.close_popovers();
-        self.font_open = open;
+        self.picker = None;
+        self.open_group = None;
+        self.width_open = false;
+        self.templates_open = false;
+        self.context_menu = None;
+        self.font_open = !self.font_open;
         cx.notify();
     }
 
@@ -2224,12 +3780,6 @@ impl WhiteboardView {
                 }
             }
             let wc = [(bb.0, bb.1), (bb.2, bb.1), (bb.0, bb.3), (bb.2, bb.3)];
-            let off = [
-                (-SEL_PAD_PX, -SEL_PAD_PX),
-                (SEL_PAD_PX, -SEL_PAD_PX),
-                (-SEL_PAD_PX, SEL_PAD_PX),
-                (SEL_PAD_PX, SEL_PAD_PX),
-            ];
             let collect_orig = || -> Vec<(u64, ElementKind)> {
                 self.scene
                     .elements
@@ -2239,7 +3789,7 @@ impl WhiteboardView {
                     .collect()
             };
             for i in 0..4 {
-                if near(wc[i].0, wc[i].1, off[i].0, off[i].1) {
+                if near(wc[i].0, wc[i].1, 0.0, 0.0) {
                     let opp = wc[3 - i];
                     return Some(HandleGrab::GroupCorner(GroupResizing {
                         handle: ResizeHandle::Corner,
@@ -2254,30 +3804,10 @@ impl WhiteboardView {
             // the opposite edge: a left/right grip scales x, a top/bottom grip y.
             let (mx, my) = ((bb.0 + bb.2) / 2.0, (bb.1 + bb.3) / 2.0);
             let edges = [
-                (
-                    ResizeHandle::EdgeX,
-                    [bb.0, my],
-                    (-SEL_PAD_PX, 0.0),
-                    [bb.2, my],
-                ),
-                (
-                    ResizeHandle::EdgeX,
-                    [bb.2, my],
-                    (SEL_PAD_PX, 0.0),
-                    [bb.0, my],
-                ),
-                (
-                    ResizeHandle::EdgeY,
-                    [mx, bb.1],
-                    (0.0, -SEL_PAD_PX),
-                    [mx, bb.3],
-                ),
-                (
-                    ResizeHandle::EdgeY,
-                    [mx, bb.3],
-                    (0.0, SEL_PAD_PX),
-                    [mx, bb.1],
-                ),
+                (ResizeHandle::EdgeX, [bb.0, my], (0.0, 0.0), [bb.2, my]),
+                (ResizeHandle::EdgeX, [bb.2, my], (0.0, 0.0), [bb.0, my]),
+                (ResizeHandle::EdgeY, [mx, bb.1], (0.0, 0.0), [mx, bb.3]),
+                (ResizeHandle::EdgeY, [mx, bb.3], (0.0, 0.0), [mx, bb.1]),
             ];
             for (handle, from, (ox, oy), anchor) in edges {
                 if near(from[0], from[1], ox, oy) {
@@ -2319,9 +3849,8 @@ impl WhiteboardView {
         // resizes proportionally about the center — a similarity transform that
         // stays correct under rotation (set up here, applied in `on_move`).
         if let Some((x, y, w, h, rot)) = box_like(kind) {
-            let z = cam.zoom.max(MIN_ZOOM);
             let cu = box_padded_corners(x, y, w, h, rot, 0.0);
-            let cp = box_padded_corners(x, y, w, h, rot, SEL_PAD_PX / z);
+            let cp = cu;
             let center = [x + w / 2.0, y + h / 2.0];
             let rotated = rot.abs() > ROT_EPS;
             for i in 0..4 {
@@ -2362,14 +3891,8 @@ impl WhiteboardView {
         // Draw / Embed: corners on the padded AABB (offset the hit to match).
         let bb = bbox(kind);
         let wc = [(bb.0, bb.1), (bb.2, bb.1), (bb.0, bb.3), (bb.2, bb.3)];
-        let off = [
-            (-SEL_PAD_PX, -SEL_PAD_PX),
-            (SEL_PAD_PX, -SEL_PAD_PX),
-            (-SEL_PAD_PX, SEL_PAD_PX),
-            (SEL_PAD_PX, SEL_PAD_PX),
-        ];
         for i in 0..4 {
-            if near(wc[i].0, wc[i].1, off[i].0, off[i].1) {
+            if near(wc[i].0, wc[i].1, 0.0, 0.0) {
                 let opp = wc[3 - i];
                 return Some(HandleGrab::Corner(Resizing {
                     id,
@@ -2411,10 +3934,10 @@ impl WhiteboardView {
         left: [f32; 2],
     ) -> Option<HandleGrab> {
         let edges = [
-            (ResizeHandle::EdgeY, top, (0.0, -SEL_PAD_PX), bottom),
-            (ResizeHandle::EdgeY, bottom, (0.0, SEL_PAD_PX), top),
-            (ResizeHandle::EdgeX, right, (SEL_PAD_PX, 0.0), left),
-            (ResizeHandle::EdgeX, left, (-SEL_PAD_PX, 0.0), right),
+            (ResizeHandle::EdgeY, top, (0.0, 0.0), bottom),
+            (ResizeHandle::EdgeY, bottom, (0.0, 0.0), top),
+            (ResizeHandle::EdgeX, right, (0.0, 0.0), left),
+            (ResizeHandle::EdgeX, left, (0.0, 0.0), right),
         ];
         for (handle, from, (ox, oy), anchor) in edges {
             if near(from[0], from[1], ox, oy) {
@@ -2429,6 +3952,55 @@ impl WhiteboardView {
             }
         }
         None
+    }
+
+    /// The topmost connector point under the cursor. Connectors are exposed on
+    /// box-like visual elements (closed shapes, text, image) at the midpoints of
+    /// their rotated top/right/bottom/left edges.
+    fn connector_at(&self, pos: Point<Pixels>) -> Option<ConnectPoint> {
+        let origin = self.bounds.get().origin;
+        let near_px = CONNECTOR_BUTTON_SIZE * 0.65;
+        let (sx, sy) = (f32::from(pos.x), f32::from(pos.y));
+        let id = self.selected_single()?;
+        let element = self
+            .scene
+            .elements
+            .iter()
+            .find(|element| element.id == id && connector_capable(&element.kind))?;
+        let points = connector_points(&element.kind);
+        let buttons = connector_button_centers(&element.kind, self.scene.camera, origin);
+        buttons.into_iter().enumerate().find_map(|(index, button)| {
+            let dx = f32::from(button.x) - sx;
+            let dy = f32::from(button.y) - sy;
+            (dx * dx + dy * dy <= near_px * near_px).then_some(ConnectPoint {
+                id,
+                index,
+                pos: points[index],
+            })
+        })
+    }
+
+    /// Update hover connector state and request repaint only when it changes.
+    fn update_hover_connector(&mut self, pos: Point<Pixels>, cx: &mut Context<Self>) {
+        let next = if self.tool == Tool::Select
+            && self.editing.is_none()
+            && self.pending.is_none()
+            && self.connecting.is_none()
+            && self.drag_from.is_none()
+            && self.resizing.is_none()
+            && self.group_resizing.is_none()
+            && self.endpoint.is_none()
+            && self.rotating.is_none()
+            && self.marquee.is_none()
+        {
+            self.connector_at(pos)
+        } else {
+            None
+        };
+        if self.hovered_connector != next {
+            self.hovered_connector = next;
+            cx.notify();
+        }
     }
 
     /// The topmost text element under a world point (within `pad`), if any.
@@ -2466,8 +4038,66 @@ impl WhiteboardView {
             })
     }
 
+    /// Nearest edge connector on another shape while a connection is being
+    /// dragged. This path is intentionally separate from `connector_at`, whose
+    /// hit targets are the selected source shape's outward arrow buttons.
+    fn snap_connector_at(
+        &self,
+        pos: Point<Pixels>,
+        source_id: u64,
+    ) -> Option<(ConnectPoint, bool)> {
+        const SHOW_DISTANCE_PX: f32 = 64.0;
+        const SNAP_DISTANCE_PX: f32 = 20.0;
+        let origin = self.bounds.get().origin;
+        let (sx, sy) = (f32::from(pos.x), f32::from(pos.y));
+        let world = self.event_to_world(pos);
+        let target = self
+            .scene
+            .elements
+            .iter()
+            .rev()
+            .filter(|element| element.id != source_id && connector_capable(&element.kind))
+            .find(|element| {
+                hit_test(
+                    &element.kind,
+                    world[0],
+                    world[1],
+                    SHOW_DISTANCE_PX / self.scene.camera.zoom.max(MIN_ZOOM),
+                )
+            })?;
+        connector_points(&target.kind)
+            .into_iter()
+            .enumerate()
+            .map(|(index, point)| {
+                let screen = to_screen(point[0], point[1], self.scene.camera, origin);
+                let dx = f32::from(screen.x) - sx;
+                let dy = f32::from(screen.y) - sy;
+                let distance_sq = dx * dx + dy * dy;
+                (
+                    distance_sq,
+                    ConnectPoint {
+                        id: target.id,
+                        index,
+                        pos: point,
+                    },
+                )
+            })
+            .min_by(|a, b| a.0.total_cmp(&b.0))
+            .map(|(distance_sq, connector)| {
+                (
+                    connector,
+                    distance_sq <= SNAP_DISTANCE_PX * SNAP_DISTANCE_PX,
+                )
+            })
+    }
+
     fn on_left_down(&mut self, ev: &MouseDownEvent, window: &mut Window, cx: &mut Context<Self>) {
         if self.panning {
+            return;
+        }
+        if self.read_only {
+            self.panning = true;
+            self.last = ev.position;
             return;
         }
 
@@ -2598,24 +4228,32 @@ impl WhiteboardView {
             self.commit_text(window, cx);
         }
 
+        // Ctrl + left-drag always pans the canvas, regardless of the active tool
+        // or what's under the pointer. Reuses the same panning state as the Pan
+        // tool and middle-button drag.
+        if ev.modifiers.control {
+            self.panning = true;
+            self.last = ev.position;
+            return;
+        }
+
         if ev.click_count >= 2 {
             self.pending = None;
+            // Existing text and shape labels have one consistent edit gesture:
+            // double-click, regardless of which tool happened to be active.
+            if let Some(id) = self.text_at(p, SELECT_PAD / zoom) {
+                self.selected = vec![id];
+                self.editing = Some(id);
+                self.place_caret_from_click(id, p, ev, window, cx);
+                return;
+            }
+            if let Some(id) = self.shape_at(p, SELECT_PAD / zoom) {
+                self.selected = vec![id];
+                self.editing = Some(id);
+                self.place_caret_from_click(id, p, ev, window, cx);
+                return;
+            }
             if self.tool == Tool::Select {
-                // Double-click a text element re-opens it for editing, selecting
-                // the word under the cursor.
-                if let Some(id) = self.text_at(p, SELECT_PAD / zoom) {
-                    self.selected = vec![id];
-                    self.editing = Some(id);
-                    self.place_caret_from_click(id, p, ev, window, cx);
-                    return;
-                }
-                // Double-click a closed shape edits its centered label.
-                if let Some(id) = self.shape_at(p, SELECT_PAD / zoom) {
-                    self.selected = vec![id];
-                    self.editing = Some(id);
-                    self.place_caret_from_click(id, p, ev, window, cx);
-                    return;
-                }
                 // Double-click a page-card opens its page.
                 if let Some((id, page_id)) = self.embed_at(p, SELECT_PAD / zoom) {
                     self.selected = vec![id];
@@ -2630,6 +4268,36 @@ impl WhiteboardView {
             return;
         }
 
+        // A single click on any existing element always means selection, even if
+        // a drawing/text tool is currently active. This prevents accidentally
+        // drawing over a shape when the user only meant to select it. A second
+        // click (handled above) is the sole path into text/label editing.
+        if self.tool != Tool::Select {
+            let pad = SELECT_PAD / zoom;
+            let hit = self
+                .scene
+                .elements
+                .iter()
+                .rev()
+                .find(|element| hit_test(&element.kind, p[0], p[1], pad))
+                .map(|element| element.id);
+            if let Some(id) = hit {
+                self.tool = Tool::Select;
+                if ev.modifiers.shift {
+                    if let Some(index) = self.selected.iter().position(|&selected| selected == id) {
+                        self.selected.remove(index);
+                    } else {
+                        self.selected.push(id);
+                    }
+                } else {
+                    self.selected = vec![id];
+                }
+                self.drag_from = None;
+                cx.notify();
+                return;
+            }
+        }
+
         // Pan tool: a left-drag pans the canvas (the default navigation tool;
         // double-click above still recenters). Reuses the middle-drag machinery.
         if self.tool == Tool::Pan {
@@ -2639,11 +4307,12 @@ impl WhiteboardView {
         }
 
         if self.tool == Tool::Text {
-            // Edit a text under the cursor (caret at the click), else create one.
+            // A single click on existing text only selects it. Editing existing
+            // content is deliberately double-click-only; clicking empty canvas
+            // still creates a fresh text element and immediately edits that.
             if let Some(id) = self.text_at(p, SELECT_PAD / zoom) {
                 self.selected = vec![id];
-                self.editing = Some(id);
-                self.place_caret_from_click(id, p, ev, window, cx);
+                cx.notify();
             } else {
                 self.push_undo();
                 let id = self.next_id;
@@ -2664,12 +4333,23 @@ impl WhiteboardView {
                     label: None,
                     label_color: None,
                     styles: Vec::new(),
+                    mindmap: None,
                 });
                 self.selected = vec![id];
                 self.begin_text_edit(id, 0, window, cx);
                 self.dirty = true;
                 cx.notify();
             }
+            return;
+        }
+
+        if self.tool == Tool::MindMap {
+            self.add_mindmap_seed(p[0], p[1], cx);
+            return;
+        }
+
+        if self.tool == Tool::Flowchart {
+            self.add_flowchart_seed(p[0], p[1], cx);
             return;
         }
 
@@ -2690,6 +4370,31 @@ impl WhiteboardView {
         }
 
         if self.tool == Tool::Select {
+            // A connector point on a hovered shape starts drawing a line from that
+            // exact side/midpoint without switching away from Select.
+            if let Some(cp) = self.connector_at(ev.position) {
+                let width = self.active_width / zoom;
+                self.pending = Some(Pending {
+                    anchor: cp.pos,
+                    kind: ElementKind::Arrow(SegGeom {
+                        x1: cp.pos[0],
+                        y1: cp.pos[1],
+                        x2: cp.pos[0],
+                        y2: cp.pos[1],
+                        width,
+                        style: SegmentStyle::Solid,
+                        start_anchor: Some(SegmentAnchor {
+                            element_id: cp.id,
+                            connector: cp.index,
+                        }),
+                        end_anchor: None,
+                    }),
+                });
+                self.connecting = Some(ConnectDrag { from: cp });
+                self.hovered_connector = Some(cp);
+                cx.notify();
+                return;
+            }
             // A handle on the current selection takes priority.
             if let Some(grab) = self.handle_hit(ev.position) {
                 self.push_undo();
@@ -2822,6 +4527,9 @@ impl WhiteboardView {
                 x2: anchor[0],
                 y2: anchor[1],
                 width,
+                style: SegmentStyle::Solid,
+                start_anchor: None,
+                end_anchor: None,
             }),
             Tool::Arrow => ElementKind::Arrow(SegGeom {
                 x1: anchor[0],
@@ -2829,9 +4537,28 @@ impl WhiteboardView {
                 x2: anchor[0],
                 y2: anchor[1],
                 width,
+                style: SegmentStyle::Solid,
+                start_anchor: None,
+                end_anchor: None,
+            }),
+            Tool::DashedArrow => ElementKind::Arrow(SegGeom {
+                x1: anchor[0],
+                y1: anchor[1],
+                x2: anchor[0],
+                y2: anchor[1],
+                width,
+                style: SegmentStyle::Dashed,
+                start_anchor: None,
+                end_anchor: None,
             }),
             // These tools don't create a drag-element here (handled earlier).
-            Tool::Pan | Tool::Select | Tool::Text | Tool::Embed | Tool::Image => return,
+            Tool::Pan
+            | Tool::Select
+            | Tool::Text
+            | Tool::MindMap
+            | Tool::Flowchart
+            | Tool::Embed
+            | Tool::Image => return,
         };
         self.pending = Some(Pending { anchor, kind });
         cx.notify();
@@ -2875,6 +4602,7 @@ impl WhiteboardView {
                 self.dirty = true;
             }
             self.moved = false;
+            self.alignment_guides = AlignmentGuides::default();
             cx.notify();
             self.flush(window, cx);
             return;
@@ -2894,6 +4622,7 @@ impl WhiteboardView {
             return;
         }
         if let Some(pending) = self.pending.take() {
+            let completed_connection = self.connecting.take().is_some();
             if committable(&pending.kind) {
                 self.push_undo();
                 let id = self.next_id;
@@ -2912,7 +4641,14 @@ impl WhiteboardView {
                     label: None,
                     label_color: self.active_text,
                     styles: Vec::new(),
+                    mindmap: None,
                 });
+                if completed_connection {
+                    // The newly-created connector becomes the active object so
+                    // its endpoints can be adjusted immediately.
+                    self.selected = vec![id];
+                    self.focus.focus(window, cx);
+                }
                 self.dirty = true;
             }
             cx.notify();
@@ -2923,6 +4659,11 @@ impl WhiteboardView {
     /// Right-click: with a selection (and a host save hook), open a small menu to
     /// save it as a template; otherwise just dismiss any open menu.
     fn on_right_down(&mut self, ev: &MouseDownEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.read_only {
+            self.context_menu = None;
+            cx.notify();
+            return;
+        }
         // A right-click inside the open color picker (e.g. removing a saved swatch)
         // shouldn't also open the board context menu.
         if self.picker.is_some() && self.picker_bounds.get().contains(&ev.position) {
@@ -3017,6 +4758,42 @@ impl WhiteboardView {
             cx.notify();
             return;
         }
+        // Dragging a line out of a connector point. Snaps the endpoint to another
+        // connector if the cursor is close to one, so shape-to-shape links land cleanly.
+        if let Some(conn) = self.connecting {
+            let target = self.snap_connector_at(ev.position, conn.from.id);
+            let cur = if let Some((target, snapped)) = target {
+                self.hovered_connector = Some(target);
+                if snapped {
+                    target.pos
+                } else {
+                    self.event_to_world(ev.position)
+                }
+            } else {
+                self.hovered_connector = None;
+                self.event_to_world(ev.position)
+            };
+            if let Some(pending) = self.pending.as_mut()
+                && let ElementKind::Line(s) | ElementKind::Arrow(s) = &mut pending.kind
+            {
+                s.x1 = conn.from.pos[0];
+                s.y1 = conn.from.pos[1];
+                s.x2 = cur[0];
+                s.y2 = cur[1];
+                s.start_anchor = Some(SegmentAnchor {
+                    element_id: conn.from.id,
+                    connector: conn.from.index,
+                });
+                s.end_anchor = target.and_then(|(target, snapped)| {
+                    snapped.then_some(SegmentAnchor {
+                        element_id: target.id,
+                        connector: target.index,
+                    })
+                });
+            }
+            cx.notify();
+            return;
+        }
         // Dragging inside the color picker (SV square, hue strip, alpha strip) or
         // the thickness flyout's width slider.
         if let Some(drag) = self.picker_drag {
@@ -3083,6 +4860,7 @@ impl WhiteboardView {
                     rotate_element(&mut e.kind, rot.center[0], rot.center[1], delta);
                 }
             }
+            self.sync_segment_anchors_for(&sel);
             rot.applied += delta;
             self.rotating = Some(rot);
             cx.notify();
@@ -3119,6 +4897,8 @@ impl WhiteboardView {
                     e.kind = kind;
                 }
             }
+            let changed: Vec<u64> = gr.orig.iter().map(|(id, _)| *id).collect();
+            self.sync_segment_anchors_for(&changed);
             self.group_resizing = Some(gr);
             cx.notify();
             return;
@@ -3173,6 +4953,7 @@ impl WhiteboardView {
                     t.measured_h = h;
                 }
             }
+            self.sync_segment_anchors_for(&[id]);
             cx.notify();
             return;
         }
@@ -3199,10 +4980,31 @@ impl WhiteboardView {
                 if ep.which == 0 {
                     s.x1 = nx;
                     s.y1 = ny;
+                    s.start_anchor = None;
                 } else {
                     s.x2 = nx;
                     s.y2 = ny;
+                    s.end_anchor = None;
                 }
+            }
+            if !ev.modifiers.shift && !ev.modifiers.alt {
+                if let Some((target, snapped)) = self.snap_connector_at(ev.position, ep.id)
+                    && snapped
+                {
+                    self.hovered_connector = Some(target);
+                    self.set_segment_endpoint_anchor(
+                        ep.id,
+                        ep.which,
+                        Some(SegmentAnchor {
+                            element_id: target.id,
+                            connector: target.index,
+                        }),
+                    );
+                } else {
+                    self.hovered_connector = None;
+                }
+            } else {
+                self.hovered_connector = None;
             }
             cx.notify();
             return;
@@ -3227,18 +5029,26 @@ impl WhiteboardView {
                     [x, y]
                 })
                 .unwrap_or(self.move_origin);
-            let (dx, dy) = (target[0] - cur_min[0], target[1] - cur_min[1]);
+            let (raw_dx, raw_dy) = (target[0] - cur_min[0], target[1] - cur_min[1]);
+            let (dx, dy, guides) = if ev.modifiers.alt {
+                (raw_dx, raw_dy, AlignmentGuides::default())
+            } else {
+                self.aligned_move_delta(raw_dx, raw_dy)
+            };
+            self.alignment_guides = guides;
             if dx != 0.0 || dy != 0.0 {
                 if !self.moved {
                     self.push_undo();
                     self.moved = true;
                 }
                 let sel = self.selected.clone();
+                self.detach_segment_bindings_for_move(&sel);
                 for e in self.scene.elements.iter_mut() {
                     if sel.contains(&e.id) {
                         translate(&mut e.kind, dx, dy);
                     }
                 }
+                self.sync_segment_anchors_for(&sel);
                 cx.notify();
             }
             return;
@@ -3297,6 +5107,7 @@ impl WhiteboardView {
             cx.notify();
             return;
         }
+        self.update_hover_connector(ev.position, cx);
         // Panning.
         if self.panning {
             let dx = f32::from(ev.position.x - self.last.x);
@@ -3420,6 +5231,7 @@ impl WhiteboardView {
             el.styles = splice_styles(&el.styles, s, e, ins.len(), insert_style);
             self.caret = s + ins.len();
             self.sel_anchor = self.caret;
+            self.marked_range = None;
             self.dirty = true;
             cx.notify();
         }
@@ -3429,6 +5241,86 @@ impl WhiteboardView {
     fn replace_selection(&mut self, id: u64, ins: &str, cx: &mut Context<Self>) {
         let (s, e) = self.sel_range();
         self.replace_range(id, s, e, ins, cx);
+    }
+
+    fn editing_content(&self) -> Option<String> {
+        self.editing
+            .and_then(|id| self.edit_target(id).map(|tg| tg.content))
+    }
+
+    // Kept byte-for-byte equivalent to gpui-markdown-editor's UTF-16 bridge.
+    fn utf16_to_utf8_in(text: &str, offset: usize) -> usize {
+        let mut utf8_offset = 0;
+        let mut utf16_count = 0;
+
+        for ch in text.chars() {
+            if utf16_count >= offset {
+                break;
+            }
+            utf16_count += ch.len_utf16();
+            utf8_offset += ch.len_utf8();
+        }
+
+        utf8_offset
+    }
+
+    fn utf8_to_utf16_in(text: &str, offset: usize) -> usize {
+        let mut utf16_offset = 0;
+        let mut utf8_count = 0;
+
+        for ch in text.chars() {
+            if utf8_count >= offset {
+                break;
+            }
+            utf8_count += ch.len_utf8();
+            utf16_offset += ch.len_utf16();
+        }
+
+        utf16_offset
+    }
+
+    fn utf16_range_to_utf8_in(text: &str, range_utf16: &Range<usize>) -> Range<usize> {
+        Self::utf16_to_utf8_in(text, range_utf16.start)
+            ..Self::utf16_to_utf8_in(text, range_utf16.end)
+    }
+
+    fn utf8_range_to_utf16_in(text: &str, range: &Range<usize>) -> Range<usize> {
+        Self::utf8_to_utf16_in(text, range.start)..Self::utf8_to_utf16_in(text, range.end)
+    }
+
+    /// Whiteboard storage adapter for the editor's `replace_text_in_visible_range`.
+    /// The full inserted text is the marked range; the IME's relative selection is
+    /// tracked independently, exactly as in gpui-markdown-editor.
+    fn replace_text_in_visible_range(
+        &mut self,
+        visible_range: Range<usize>,
+        new_text: &str,
+        selected_range_relative: Option<Range<usize>>,
+        mark_inserted_text: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(id) = self.editing else {
+            return;
+        };
+        let insert_start = visible_range.start;
+        self.replace_range(id, visible_range.start, visible_range.end, new_text, cx);
+
+        self.marked_range = if mark_inserted_text && !new_text.is_empty() {
+            Some(insert_start..insert_start + new_text.len())
+        } else {
+            None
+        };
+        let selected_range = selected_range_relative
+            .map(|relative| insert_start + relative.start..insert_start + relative.end);
+        self.caret = selected_range
+            .as_ref()
+            .map(|range| range.end)
+            .unwrap_or(insert_start + new_text.len());
+        self.sel_anchor = selected_range
+            .as_ref()
+            .map(|range| range.start)
+            .unwrap_or(self.caret);
+        cx.notify();
     }
 
     /// The formatting active across the current selection (or, collapsed, the
@@ -3588,6 +5480,9 @@ impl WhiteboardView {
         self.caret = floor_boundary(&content, self.caret);
         self.sel_anchor = floor_boundary(&content, self.sel_anchor);
         let ks = &ev.keystroke;
+        if ks.is_ime_in_progress() {
+            return;
+        }
         let cmd = ks.modifiers.platform || ks.modifiers.control;
         let shift = ks.modifiers.shift;
 
@@ -3625,6 +5520,17 @@ impl WhiteboardView {
                 }
                 _ => cx.propagate(), // ⌘Z / ⌘W / … belong to the host
             }
+            return;
+        }
+
+        if ks.key == "tab" && self.is_mindmap_node(id) {
+            self.commit_text(window, cx);
+            self.add_mindmap_relative(id, false, window, cx);
+            return;
+        }
+        if ks.key == "enter" && self.is_mindmap_node(id) {
+            self.commit_text(window, cx);
+            self.add_mindmap_relative(id, true, window, cx);
             return;
         }
 
@@ -3675,12 +5581,19 @@ impl WhiteboardView {
             }
             "enter" => self.replace_selection(id, "\n", cx),
             "tab" => cx.propagate(),
-            _ => match ks.key_char.as_deref() {
-                Some(c) if c.chars().next().is_some_and(|ch| !ch.is_control()) => {
-                    self.replace_selection(id, c, cx);
+            _ => {
+                // Printable text is handled by GPUI's ElementInputHandler path.
+                // Inserting `key_char` here duplicates IME composition: pinyin is
+                // inserted by keydown, then the committed Chinese text is inserted
+                // by the input handler. Keep keydown for navigation/deletion only.
+                if !ks
+                    .key_char
+                    .as_deref()
+                    .is_some_and(|c| c.chars().next().is_some_and(|ch| !ch.is_control()))
+                {
+                    cx.propagate();
                 }
-                _ => cx.propagate(),
-            },
+            }
         }
     }
 
@@ -3689,6 +5602,7 @@ impl WhiteboardView {
         self.editing = Some(id);
         self.caret = at;
         self.sel_anchor = at;
+        self.marked_range = None;
         self.focus.focus(window, cx);
     }
 
@@ -3734,6 +5648,9 @@ impl WhiteboardView {
             }
             self.text_selecting = true;
         }
+        // Clicking establishes a new native selection and cancels any stale
+        // composition range left by an IME that did not send `unmark_text`.
+        self.marked_range = None;
         self.focus.focus(window, cx);
         cx.notify();
     }
@@ -3742,6 +5659,7 @@ impl WhiteboardView {
     fn commit_text(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.text_selecting = false;
         self.pending_style = None;
+        self.marked_range = None;
         self.format_flyout = false;
         let Some(id) = self.editing.take() else {
             return;
@@ -3840,6 +5758,19 @@ impl WhiteboardView {
     }
 
     fn on_key(&mut self, ev: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
+        if self.read_only {
+            cx.propagate();
+            return;
+        }
+        // Escape cancels an in-progress connector without losing the source
+        // shape selection; its four direction buttons become visible again.
+        if ev.keystroke.key == "escape" && self.connecting.is_some() {
+            self.connecting = None;
+            self.pending = None;
+            self.hovered_connector = None;
+            cx.notify();
+            return;
+        }
         // Escape closes an open color picker or the templates modal (when the
         // board holds focus).
         if ev.keystroke.key == "escape" && (self.picker.is_some() || self.templates_open) {
@@ -3867,6 +5798,135 @@ impl WhiteboardView {
         }
         // Editing → full text-box key handling (caret, selection, edit, clipboard).
         self.text_edit_key(ev, window, cx);
+    }
+}
+
+impl BoardEmbedView {
+    /// Build a read-only embedded board view. The inner board starts in
+    /// read-only forced-pan mode.
+    pub fn new(scene: Scene, style: WhiteboardStyleFn, cx: &mut Context<Self>) -> Self {
+        let board_style = style.clone();
+        let board = cx.new(|cx| WhiteboardView::new_read_only(scene, board_style, cx));
+        Self {
+            board,
+            style,
+            on_expand: None,
+        }
+    }
+
+    /// Access the inner board entity for host-driven inspection or updates.
+    pub fn board(&self) -> Entity<WhiteboardView> {
+        self.board.clone()
+    }
+
+    /// Install the callback fired by the embed view's "edit" affordance.
+    pub fn set_on_expand(&mut self, f: ExpandEmbedFn) {
+        self.on_expand = Some(f);
+    }
+}
+
+impl Render for BoardEmbedView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let st = (self.style)();
+        let ink = st.ink;
+        let panel = st.panel_strong;
+        let grid = st.grid;
+        let accent = st.accent;
+        let button = self.on_expand.as_ref().map(|_| {
+            div()
+                .id("board-embed-expand")
+                .absolute()
+                .top(px(10.0))
+                .right(px(10.0))
+                .h(px(30.0))
+                .px(px(10.0))
+                .flex()
+                .items_center()
+                .justify_center()
+                .gap(px(6.0))
+                .rounded(px(8.0))
+                .bg(panel)
+                .border_1()
+                .border_color(grid.opacity(0.5))
+                .hover(|s| s.bg(accent))
+                .text_size(px(12.0))
+                .text_color(ink)
+                .child("↗")
+                .child("Edit")
+                .on_click(cx.listener(|this, _ev, window, cx| {
+                    if let Some(f) = this.on_expand.clone() {
+                        f(window, cx);
+                    }
+                }))
+        });
+        div()
+            .size_full()
+            .relative()
+            .child(self.board.clone())
+            .children(button)
+    }
+}
+
+impl BoardThumbnailView {
+    pub fn new(snapshot: LocalThumbnailSnapshot, style: WhiteboardStyleFn) -> Self {
+        Self {
+            snapshot,
+            style,
+            font: Font::default(),
+        }
+    }
+
+    pub fn snapshot(&self) -> &LocalThumbnailSnapshot {
+        &self.snapshot
+    }
+
+    pub fn set_snapshot(&mut self, snapshot: LocalThumbnailSnapshot) {
+        self.snapshot = snapshot;
+    }
+}
+
+impl Render for BoardThumbnailView {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let WhiteboardStyle {
+            bg,
+            grid,
+            text,
+            ink,
+            panel,
+            ..
+        } = (self.style)();
+        let cam = self.snapshot.spec.camera;
+        let layers = build_thumbnail_layers(
+            &self.snapshot.scene,
+            &self.font,
+            cam,
+            ink,
+            text,
+            grid,
+            panel,
+            None,
+            None,
+            None,
+        );
+        let board_layer = canvas(
+            |_, _, _| {},
+            move |bounds, _, window, _| paint_board(bounds, cam, bg, grid, window),
+        )
+        .absolute()
+        .size_full();
+        let element_layers: Vec<gpui::AnyElement> = layers
+            .into_iter()
+            .map(|l| match l {
+                Layer::Band(es) => band_canvas(es, cam).into_any_element(),
+                Layer::Overlay(el) => el,
+            })
+            .collect();
+        div()
+            .size_full()
+            .relative()
+            .overflow_hidden()
+            .child(board_layer)
+            .children(element_layers)
     }
 }
 
@@ -4172,23 +6232,43 @@ fn rotate_element(kind: &mut ElementKind, cx: f32, cy: f32, delta: f32) {
     }
 }
 
-/// Screen position of a rotate handle: above a bounds' top-center. `handle_hit`
-/// and `paint_selection` agree via this one source (for single elements and for
-/// a group, whose bounds is the union of the selection).
+/// Screen position of a group's rotate button: the intersection of the top
+/// connector's horizontal guide and the right connector's vertical guide.
 fn rotate_handle_for_bbox(
     bb: (f32, f32, f32, f32),
     cam: Camera,
     origin: Point<Pixels>,
 ) -> (f32, f32) {
-    let top = to_screen((bb.0 + bb.2) / 2.0, bb.1, cam, origin);
+    let top_right = to_screen(bb.2, bb.1, cam, origin);
     (
-        f32::from(top.x),
-        f32::from(top.y) - SEL_PAD_PX - ROTATE_DIST,
+        f32::from(top_right.x) + CONNECTOR_BUTTON_GAP,
+        f32::from(top_right.y) - CONNECTOR_BUTTON_GAP,
     )
 }
 
-/// Screen position of a single element's rotate handle.
+/// Screen position of a single element's rotate button. For a rotated box the
+/// offset follows its local top/right outward directions.
 fn rotate_handle_screen(kind: &ElementKind, cam: Camera, origin: Point<Pixels>) -> (f32, f32) {
+    if let Some((x, y, w, h, rotation)) = box_like(kind) {
+        let corners = box_padded_corners(x, y, w, h, rotation, 0.0);
+        let top_right = to_screen(corners[1][0], corners[1][1], cam, origin);
+        let connectors = connector_points(kind);
+        let top = to_screen(connectors[0][0], connectors[0][1], cam, origin);
+        let right = to_screen(connectors[1][0], connectors[1][1], cam, origin);
+        let center = to_screen(x + w / 2.0, y + h / 2.0, cam, origin);
+        let unit = |point: Point<Pixels>| {
+            let dx = f32::from(point.x - center.x);
+            let dy = f32::from(point.y - center.y);
+            let length = (dx * dx + dy * dy).sqrt().max(1.0);
+            (dx / length, dy / length)
+        };
+        let up = unit(top);
+        let right = unit(right);
+        return (
+            f32::from(top_right.x) + (up.0 + right.0) * CONNECTOR_BUTTON_GAP,
+            f32::from(top_right.y) + (up.1 + right.1) * CONNECTOR_BUTTON_GAP,
+        );
+    }
     rotate_handle_for_bbox(bbox(kind), cam, origin)
 }
 
@@ -4241,6 +6321,46 @@ fn elements_extent(elems: &[Element]) -> (f32, f32) {
     } else {
         (0.0, 0.0)
     }
+}
+
+/// Whether an element exposes connector points while hovered.
+fn connector_capable(kind: &ElementKind) -> bool {
+    matches!(kind, ElementKind::Text(_) | ElementKind::Image(_)) || is_closed_shape(kind)
+}
+
+/// Connector points for a box-like element: top, right, bottom, left midpoints,
+/// rotated with the element. Empty for non-connectable kinds.
+fn connector_points(kind: &ElementKind) -> Vec<[f32; 2]> {
+    if !connector_capable(kind) {
+        return Vec::new();
+    }
+    let Some((x, y, w, h, rot)) = box_like(kind) else {
+        return Vec::new();
+    };
+    let (cx, cy) = (x + w / 2.0, y + h / 2.0);
+    [
+        (x + w / 2.0, y),
+        (x + w, y + h / 2.0),
+        (x + w / 2.0, y + h),
+        (x, y + h / 2.0),
+    ]
+    .into_iter()
+    .map(|(px_, py_)| {
+        let (rx, ry) = rotate_pt(px_, py_, cx, cy, rot);
+        [rx, ry]
+    })
+    .collect()
+}
+
+fn connector_world_pos_in(elements: &[Element], anchor: SegmentAnchor) -> Option<[f32; 2]> {
+    elements
+        .iter()
+        .find(|element| element.id == anchor.element_id)
+        .and_then(|element| {
+            connector_points(&element.kind)
+                .get(anchor.connector)
+                .copied()
+        })
 }
 
 /// Whether `(wx, wy)` falls within an element's bounds, padded by `pad` (world).
@@ -4462,6 +6582,11 @@ fn block_local(x: f32, y: f32, rotation: f32, pivot: [f32; 2], p: [f32; 2]) -> [
     [rx - x, ry - y]
 }
 
+/// Block-local point → world space, applying rotation about the block/shape pivot.
+fn block_world(x: f32, y: f32, rotation: f32, pivot: [f32; 2], p: [f32; 2]) -> (f32, f32) {
+    rotate_pt(x + p[0], y + p[1], pivot[0], pivot[1], rotation)
+}
+
 /// Snap target `(tx, ty)` so its angle from `(ox, oy)` is a multiple of 45°,
 /// preserving the distance (the line-drawing constraint for endpoint drags).
 fn snap_45(ox: f32, oy: f32, tx: f32, ty: f32) -> (f32, f32) {
@@ -4527,25 +6652,6 @@ fn text_extent(t: &TextGeom) -> (f32, f32) {
     (cols * t.size * TEXT_CHAR_W, rows * t.size * TEXT_LINE_H)
 }
 
-/// Scale a `(x, y, w, h)` box in place by the per-axis maps `fx`/`fy`,
-/// normalizing to non-negative width/height. Shared by the box-shaped arms of
-/// [`resize_about`].
-fn resize_box(
-    x: &mut f32,
-    y: &mut f32,
-    w: &mut f32,
-    h: &mut f32,
-    fx: impl Fn(f32) -> f32,
-    fy: impl Fn(f32) -> f32,
-) {
-    let (x0, x1) = (fx(*x), fx(*x + *w));
-    let (y0, y1) = (fy(*y), fy(*y + *h));
-    *x = x0.min(x1);
-    *w = (x1 - x0).abs();
-    *y = y0.min(y1);
-    *h = (y1 - y0).abs();
-}
-
 /// Scale an element's geometry about `(ax, ay)` by `(sx, sy)` (world space).
 /// Stroke width is left unchanged.
 fn resize_about(kind: &mut ElementKind, ax: f32, ay: f32, sx: f32, sy: f32) {
@@ -4565,7 +6671,12 @@ fn resize_about(kind: &mut ElementKind, ax: f32, ay: f32, sx: f32, sy: f32) {
         | ElementKind::RoundRect(b)
         | ElementKind::Star(b)
         | ElementKind::Hexagon(b) => {
-            resize_box(&mut b.x, &mut b.y, &mut b.w, &mut b.h, fx, fy);
+            let (x0, x1) = (fx(b.x), fx(b.x + b.w));
+            let (y0, y1) = (fy(b.y), fy(b.y + b.h));
+            b.x = x0.min(x1);
+            b.w = (x1 - x0).abs();
+            b.y = y0.min(y1);
+            b.h = (y1 - y0).abs();
         }
         ElementKind::Line(s) | ElementKind::Arrow(s) => {
             s.x1 = fx(s.x1);
@@ -4583,10 +6694,20 @@ fn resize_about(kind: &mut ElementKind, ax: f32, ay: f32, sx: f32, sy: f32) {
             t.size = (t.size * (sx.abs() * sy.abs()).sqrt()).max(0.5);
         }
         ElementKind::Embed(em) => {
-            resize_box(&mut em.x, &mut em.y, &mut em.w, &mut em.h, fx, fy);
+            let (x0, x1) = (fx(em.x), fx(em.x + em.w));
+            let (y0, y1) = (fy(em.y), fy(em.y + em.h));
+            em.x = x0.min(x1);
+            em.w = (x1 - x0).abs();
+            em.y = y0.min(y1);
+            em.h = (y1 - y0).abs();
         }
         ElementKind::Image(im) => {
-            resize_box(&mut im.x, &mut im.y, &mut im.w, &mut im.h, fx, fy);
+            let (x0, x1) = (fx(im.x), fx(im.x + im.w));
+            let (y0, y1) = (fy(im.y), fy(im.y + im.h));
+            im.x = x0.min(x1);
+            im.w = (x1 - x0).abs();
+            im.y = y0.min(y1);
+            im.h = (y1 - y0).abs();
         }
     }
 }
@@ -4642,6 +6763,7 @@ struct ElemPaint {
     stroke: Hsla,
     fill: Option<Hsla>,
     text: Option<TextOutline>,
+    mindmap_connector_style: Option<MindMapConnectorStyle>,
 }
 
 /// One slice of the board's z-order paint stack. Canvas-drawn elements collect
@@ -4664,7 +6786,15 @@ fn band_canvas(elems: Vec<ElemPaint>, cam: Camera) -> impl IntoElement {
                 // Shapes / lines / pen paint here; Text elements are a no-op in
                 // `paint_element`. Any text outline — a Text element's content or
                 // a shape's label — then paints on top.
-                paint_element(&ep.kind, cam, bounds.origin, ep.stroke, ep.fill, window);
+                paint_element(
+                    &ep.kind,
+                    ep.mindmap_connector_style,
+                    cam,
+                    bounds.origin,
+                    ep.stroke,
+                    ep.fill,
+                    window,
+                );
                 if let Some(t) = &ep.text {
                     paint_text(t, cam, bounds.origin, window);
                 }
@@ -4675,13 +6805,418 @@ fn band_canvas(elems: Vec<ElemPaint>, cam: Camera) -> impl IntoElement {
     .size_full()
 }
 
+#[allow(clippy::too_many_arguments)]
+fn build_thumbnail_layers(
+    scene: &Scene,
+    font: &Font,
+    cam: Camera,
+    ink: Hsla,
+    text: Hsla,
+    grid: Hsla,
+    panel: Hsla,
+    viewport: Option<WorldViewport>,
+    mut text_layout_cache: Option<&mut HashMap<u64, CachedTextLayout>>,
+    mut label_layout_cache: Option<&mut HashMap<u64, CachedLabelLayout>>,
+) -> Vec<Layer> {
+    let mindmap_connector_styles: HashMap<u64, MindMapConnectorStyle> = scene
+        .elements
+        .iter()
+        .filter_map(|element| {
+            thumbnail_mindmap_connector_style_for_element(scene, &element.kind)
+                .map(|style| (element.id, style))
+        })
+        .collect();
+    let mut layers: Vec<Layer> = Vec::new();
+    let mut band: Vec<ElemPaint> = Vec::new();
+    for e in &scene.elements {
+        if viewport.is_some_and(|viewport| !viewport.intersects(bbox(&e.kind))) {
+            continue;
+        }
+        let id = e.id;
+        let stroke = e.stroke.map_or(ink, u32_to_hsla);
+        let fill = e.fill.map(u32_to_hsla);
+        let label = e.label.as_deref();
+        let label_color = e.label_color;
+        let styles = e.styles.as_slice();
+        match &e.kind {
+            ElementKind::Embed(em) => {
+                if !band.is_empty() {
+                    layers.push(Layer::Band(std::mem::take(&mut band)));
+                }
+                layers.push(Layer::Overlay(
+                    div()
+                        .absolute()
+                        .left(px((em.x - cam.x) * cam.zoom.max(MIN_ZOOM)))
+                        .top(px((em.y - cam.y) * cam.zoom.max(MIN_ZOOM)))
+                        .w(px(em.w * cam.zoom.max(MIN_ZOOM)))
+                        .h(px(em.h * cam.zoom.max(MIN_ZOOM)))
+                        .bg(panel)
+                        .border_1()
+                        .border_color(grid)
+                        .rounded(px(8.0))
+                        .overflow_hidden()
+                        .p(px(10.0 * cam.zoom.max(MIN_ZOOM)))
+                        .flex()
+                        .flex_col()
+                        .gap(px(3.0 * cam.zoom.max(MIN_ZOOM)))
+                        .child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .gap(px(6.0 * cam.zoom.max(MIN_ZOOM)))
+                                .text_size(px(14.0 * cam.zoom.max(MIN_ZOOM)))
+                                .text_color(ink)
+                                .child(div().child("▤"))
+                                .child(SharedString::from(em.title.clone())),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(11.0 * cam.zoom.max(MIN_ZOOM)))
+                                .text_color(text)
+                                .child("Page"),
+                        )
+                        .into_any_element(),
+                ));
+            }
+            ElementKind::Image(im) => {
+                if !band.is_empty() {
+                    layers.push(Layer::Band(std::mem::take(&mut band)));
+                }
+                let rot = snap_quarter(im.rotation);
+                let (bx, by, bw, bh) = if rot.abs() < ROT_EPS {
+                    (im.x, im.y, im.w, im.h)
+                } else {
+                    let c = box_padded_corners(im.x, im.y, im.w, im.h, rot, 0.0);
+                    let (x0, y0, x1, y1) = aabb(&c);
+                    (x0, y0, x1 - x0, y1 - y0)
+                };
+                let zoom = cam.zoom.max(MIN_ZOOM);
+                layers.push(Layer::Overlay(
+                    div()
+                        .absolute()
+                        .left(px((bx - cam.x) * zoom))
+                        .top(px((by - cam.y) * zoom))
+                        .w(px(bw * zoom))
+                        .h(px(bh * zoom))
+                        .rounded(px(2.0))
+                        .bg(panel)
+                        .border_1()
+                        .border_color(grid)
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .child(
+                            div()
+                                .text_size(px(11.0 * zoom))
+                                .text_color(text)
+                                .child("Image"),
+                        )
+                        .into_any_element(),
+                ));
+            }
+            kind => {
+                let text_outline = thumbnail_text_outline(
+                    font,
+                    kind,
+                    stroke,
+                    label,
+                    label_color,
+                    styles,
+                    id,
+                    text_layout_cache.as_deref_mut(),
+                    label_layout_cache.as_deref_mut(),
+                );
+                band.push(ElemPaint {
+                    kind: kind.clone(),
+                    stroke,
+                    fill,
+                    text: text_outline,
+                    mindmap_connector_style: mindmap_connector_styles.get(&id).copied(),
+                });
+            }
+        }
+    }
+    if !band.is_empty() {
+        layers.push(Layer::Band(band));
+    }
+    layers
+}
+
+#[allow(clippy::too_many_arguments)]
+fn thumbnail_text_outline(
+    font: &Font,
+    kind: &ElementKind,
+    stroke: Hsla,
+    label: Option<&str>,
+    label_color: Option<u32>,
+    styles: &[StyleSpan],
+    element_id: u64,
+    mut text_layout_cache: Option<&mut HashMap<u64, CachedTextLayout>>,
+    label_layout_cache: Option<&mut HashMap<u64, CachedLabelLayout>>,
+) -> Option<TextOutline> {
+    if let ElementKind::Text(t) = kind {
+        let layout = match text_layout_cache.as_deref_mut() {
+            Some(cache) => {
+                cached_text_layout(cache, font, element_id, &t.content, t.size, None, styles)
+            }
+            None => prepare_text_layout(font, &t.content, t.size, None, styles, 0),
+        };
+        return Some(TextOutline {
+            segs: layout.segs.clone(),
+            bold_segs: layout.bold_segs.clone(),
+            bold_width: layout.bold_width,
+            color: stroke,
+            x: t.x,
+            y: t.y,
+            rotation: t.rotation,
+            pivot: [t.x + layout.width / 2.0, t.y + layout.height / 2.0],
+            line_height: layout.line_height,
+            caret: None,
+            selection: Vec::new(),
+            sel_color: hsla(0.0, 0.0, 0.0, 0.0),
+            decorations: layout.decorations.clone(),
+        });
+    }
+    if is_closed_shape(kind)
+        && let Some((bx, by, bw, bh, rot)) = box_like(kind)
+        && label.is_some_and(|s| !s.trim().is_empty())
+    {
+        let text = label.map_or("", str::trim);
+        let cached_label = label_layout_cache.map(|cache| {
+            cached_label_layout(cache, font, element_id, kind, bx, by, bw, bh, text, styles)
+        });
+        let (x, y, layout) = if let Some(label) = cached_label {
+            (bx + label.offset_x, by + label.offset_y, label.text)
+        } else {
+            let block = shape_label_block(font, kind, bx, by, bw, bh, text);
+            let layout = match text_layout_cache {
+                Some(cache) => cached_text_layout(
+                    cache,
+                    font,
+                    element_id,
+                    text,
+                    block.size,
+                    Some(block.wrap),
+                    styles,
+                ),
+                None => prepare_text_layout(font, text, block.size, Some(block.wrap), styles, 0),
+            };
+            (block.x, block.y, layout)
+        };
+        return Some(TextOutline {
+            segs: layout.segs.clone(),
+            bold_segs: layout.bold_segs.clone(),
+            bold_width: layout.bold_width,
+            color: label_color.map_or(stroke, u32_to_hsla),
+            x,
+            y,
+            rotation: rot,
+            pivot: [bx + bw / 2.0, by + bh / 2.0],
+            line_height: layout.line_height,
+            caret: None,
+            selection: Vec::new(),
+            sel_color: hsla(0.0, 0.0, 0.0, 0.0),
+            decorations: layout.decorations.clone(),
+        });
+    }
+    None
+}
+
+fn thumbnail_mindmap_meta(scene: &Scene, id: u64) -> Option<MindMapNodeMeta> {
+    scene
+        .elements
+        .iter()
+        .find(|e| e.id == id)
+        .and_then(|e| e.mindmap)
+}
+
+fn thumbnail_mindmap_root_of(scene: &Scene, id: u64) -> Option<u64> {
+    let mut current = id;
+    loop {
+        let meta = thumbnail_mindmap_meta(scene, current)?;
+        match meta.parent {
+            Some(parent) => current = parent,
+            None => return Some(current),
+        }
+    }
+}
+
+fn thumbnail_mindmap_connector_style_for_root(
+    scene: &Scene,
+    root_id: u64,
+) -> MindMapConnectorStyle {
+    thumbnail_mindmap_meta(scene, root_id)
+        .map(|meta| meta.connector_style)
+        .unwrap_or_default()
+}
+
+fn thumbnail_mindmap_connector_style_for_element(
+    scene: &Scene,
+    kind: &ElementKind,
+) -> Option<MindMapConnectorStyle> {
+    let seg = match kind {
+        ElementKind::Line(seg) | ElementKind::Arrow(seg) => seg,
+        _ => return None,
+    };
+    let start_root = seg
+        .start_anchor
+        .and_then(|anchor| thumbnail_mindmap_root_of(scene, anchor.element_id));
+    let end_root = seg
+        .end_anchor
+        .and_then(|anchor| thumbnail_mindmap_root_of(scene, anchor.element_id));
+    match (start_root, end_root) {
+        (Some(a), Some(b)) if a == b => Some(thumbnail_mindmap_connector_style_for_root(scene, a)),
+        _ => None,
+    }
+}
+
 /// A text element's glyph outlines (text-local space) plus placement, captured
 /// for the paint closure to transform (camera + rotation) and fill.
+#[derive(Clone)]
+struct CachedTextLayout {
+    signature: u64,
+    segs: Arc<[font::Seg]>,
+    bold_segs: Arc<[font::Seg]>,
+    bold_width: f32,
+    decorations: Arc<[font::Decoration]>,
+    width: f32,
+    height: f32,
+    line_height: f32,
+}
+
+#[derive(Clone)]
+struct CachedLabelLayout {
+    signature: u64,
+    offset_x: f32,
+    offset_y: f32,
+    size: f32,
+    wrap: f32,
+    text: CachedTextLayout,
+}
+
+fn hash_text_styles(styles: &[StyleSpan], hasher: &mut impl Hasher) {
+    for span in styles {
+        span.start.hash(hasher);
+        span.end.hash(hasher);
+        span.style.bold.hash(hasher);
+        span.style.italic.hash(hasher);
+        span.style.underline.hash(hasher);
+        span.style.strike.hash(hasher);
+        span.style.highlight.hash(hasher);
+    }
+}
+
+fn text_layout_signature(
+    content: &str,
+    size: f32,
+    max_width: Option<f32>,
+    styles: &[StyleSpan],
+) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    content.hash(&mut hasher);
+    size.to_bits().hash(&mut hasher);
+    max_width.map(f32::to_bits).hash(&mut hasher);
+    hash_text_styles(styles, &mut hasher);
+    hasher.finish()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cached_label_layout(
+    cache: &mut HashMap<u64, CachedLabelLayout>,
+    font: &Font,
+    element_id: u64,
+    kind: &ElementKind,
+    bx: f32,
+    by: f32,
+    bw: f32,
+    bh: f32,
+    content: &str,
+    styles: &[StyleSpan],
+) -> CachedLabelLayout {
+    let mut hasher = DefaultHasher::new();
+    content.hash(&mut hasher);
+    bw.to_bits().hash(&mut hasher);
+    bh.to_bits().hash(&mut hasher);
+    std::mem::discriminant(kind).hash(&mut hasher);
+    hash_text_styles(styles, &mut hasher);
+    let signature = hasher.finish();
+    if let Some(layout) = cache
+        .get(&element_id)
+        .filter(|layout| layout.signature == signature)
+    {
+        return layout.clone();
+    }
+
+    let block = shape_label_block(font, kind, bx, by, bw, bh, content);
+    let text = prepare_text_layout(
+        font,
+        content,
+        block.size,
+        Some(block.wrap),
+        styles,
+        signature,
+    );
+    let cached = CachedLabelLayout {
+        signature,
+        offset_x: block.x - bx,
+        offset_y: block.y - by,
+        size: block.size,
+        wrap: block.wrap,
+        text,
+    };
+    cache.insert(element_id, cached.clone());
+    cached
+}
+
+fn cached_text_layout(
+    cache: &mut HashMap<u64, CachedTextLayout>,
+    font: &Font,
+    element_id: u64,
+    content: &str,
+    size: f32,
+    max_width: Option<f32>,
+    styles: &[StyleSpan],
+) -> CachedTextLayout {
+    let signature = text_layout_signature(content, size, max_width, styles);
+    if let Some(layout) = cache
+        .get(&element_id)
+        .filter(|layout| layout.signature == signature)
+    {
+        return layout.clone();
+    }
+    let cached = prepare_text_layout(font, content, size, max_width, styles, signature);
+    cache.insert(element_id, cached.clone());
+    cached
+}
+
+fn prepare_text_layout(
+    font: &Font,
+    content: &str,
+    size: f32,
+    max_width: Option<f32>,
+    styles: &[StyleSpan],
+    signature: u64,
+) -> CachedTextLayout {
+    let layout = font.layout_styled(content, size, max_width, |byte| {
+        glyph_style(style_at(styles, byte))
+    });
+    CachedTextLayout {
+        signature,
+        segs: layout.segs.into(),
+        bold_segs: layout.bold_segs.into(),
+        bold_width: layout.bold_width,
+        decorations: layout.decorations.into(),
+        width: layout.width,
+        height: layout.height,
+        line_height: layout.line_height,
+    }
+}
+
 struct TextOutline {
-    segs: Vec<font::Seg>,
+    segs: Arc<[font::Seg]>,
     /// Bold glyphs' outlines, stroked over the fill (synthetic bold), + the
     /// local stroke width.
-    bold_segs: Vec<font::Seg>,
+    bold_segs: Arc<[font::Seg]>,
     bold_width: f32,
     /// Glyph fill color — a Text element's ink, or a shape label's color.
     color: Hsla,
@@ -4699,7 +7234,7 @@ struct TextOutline {
     /// Fill color for the selection highlight.
     sel_color: Hsla,
     /// Underline / strikethrough / highlight runs (text-local), from the styling.
-    decorations: Vec<font::Decoration>,
+    decorations: Arc<[font::Decoration]>,
 }
 
 /// Paint a text element's vector outlines (and, when editing, its caret). Local
@@ -4733,7 +7268,7 @@ fn paint_text(t: &TextOutline, cam: Camera, origin: Point<Pixels>, window: &mut 
         pb.build().ok()
     };
     // Highlights, then the editing selection — both behind the glyphs.
-    for d in &t.decorations {
+    for d in t.decorations.iter() {
         if let font::DecoKind::Highlight(c) = d.kind
             && let Some(path) = rect_path(d.rect)
         {
@@ -4790,7 +7325,7 @@ fn paint_text(t: &TextOutline, cam: Camera, origin: Point<Pixels>, window: &mut 
         }
     }
     // Underline / strikethrough bars, in the text color, over the glyphs.
-    for d in &t.decorations {
+    for d in t.decorations.iter() {
         if matches!(d.kind, font::DecoKind::Underline | font::DecoKind::Strike)
             && let Some(path) = rect_path(d.rect)
         {
@@ -4810,6 +7345,7 @@ fn paint_text(t: &TextOutline, cam: Camera, origin: Point<Pixels>, window: &mut 
 /// Paint one element at the current camera.
 fn paint_element(
     kind: &ElementKind,
+    mindmap_connector_style: Option<MindMapConnectorStyle>,
     cam: Camera,
     origin: Point<Pixels>,
     ink: Hsla,
@@ -4831,8 +7367,24 @@ fn paint_element(
         ElementKind::Hexagon(b) => {
             paint_box_polygon(b, &hexagon_unit(), cam, origin, ink, fill, window)
         }
-        ElementKind::Line(s) => paint_segment(s, false, cam, origin, ink, window),
-        ElementKind::Arrow(s) => paint_segment(s, true, cam, origin, ink, window),
+        ElementKind::Line(s) => paint_segment(
+            s,
+            false,
+            mindmap_connector_style.unwrap_or(MindMapConnectorStyle::Straight),
+            cam,
+            origin,
+            ink,
+            window,
+        ),
+        ElementKind::Arrow(s) => paint_segment(
+            s,
+            true,
+            mindmap_connector_style.unwrap_or(MindMapConnectorStyle::Straight),
+            cam,
+            origin,
+            ink,
+            window,
+        ),
         // Text / cards / images are drawn as overlay elements in render(), not here.
         ElementKind::Text(_) | ElementKind::Embed(_) | ElementKind::Image(_) => {}
     }
@@ -4860,31 +7412,6 @@ fn paint_stroke(
     }
 }
 
-/// Fill (when `fill` is `Some`) then stroke a closed path built by `trace`.
-/// The stroke width is the world `width` scaled to screen by `z`, floored at
-/// 0.5px. Shared epilogue of the box-shape painters.
-fn fill_then_stroke(
-    trace: impl Fn(&mut PathBuilder),
-    width: f32,
-    z: f32,
-    ink: Hsla,
-    fill: Option<Hsla>,
-    window: &mut Window,
-) {
-    if let Some(fill) = fill {
-        let mut fb = PathBuilder::fill();
-        trace(&mut fb);
-        if let Ok(path) = fb.build() {
-            window.paint_path(path, fill);
-        }
-    }
-    let mut pb = PathBuilder::stroke(px((width * z).max(0.5)));
-    trace(&mut pb);
-    if let Ok(path) = pb.build() {
-        window.paint_path(path, ink);
-    }
-}
-
 fn paint_rect(
     b: &BoxGeom,
     cam: Camera,
@@ -4902,7 +7429,18 @@ fn paint_rect(
         pb.line_to(to_screen(c[3][0], c[3][1], cam, origin));
         pb.close();
     };
-    fill_then_stroke(trace, b.width, z, ink, fill, window);
+    if let Some(fill) = fill {
+        let mut fb = PathBuilder::fill();
+        trace(&mut fb);
+        if let Ok(path) = fb.build() {
+            window.paint_path(path, fill);
+        }
+    }
+    let mut pb = PathBuilder::stroke(px((b.width * z).max(0.5)));
+    trace(&mut pb);
+    if let Ok(path) = pb.build() {
+        window.paint_path(path, ink);
+    }
 }
 
 fn paint_ellipse(
@@ -4931,7 +7469,18 @@ fn paint_ellipse(
         pb.cubic_bezier_to(s(cx + rx, cy), s(cx + kx, cy - ry), s(cx + rx, cy - ky));
         pb.close();
     };
-    fill_then_stroke(trace, b.width, z, ink, fill, window);
+    if let Some(fill) = fill {
+        let mut fb = PathBuilder::fill();
+        trace(&mut fb);
+        if let Ok(path) = fb.build() {
+            window.paint_path(path, fill);
+        }
+    }
+    let mut pb = PathBuilder::stroke(px((b.width * z).max(0.5)));
+    trace(&mut pb);
+    if let Ok(path) = pb.build() {
+        window.paint_path(path, ink);
+    }
 }
 
 /// Vertices of box-fitting polygons in box-relative coords: `(±1, ±1)` is the
@@ -4994,7 +7543,18 @@ fn paint_box_polygon(
             pb.close();
         }
     };
-    fill_then_stroke(trace, b.width, z, ink, fill, window);
+    if let Some(fill) = fill {
+        let mut fb = PathBuilder::fill();
+        trace(&mut fb);
+        if let Ok(path) = fb.build() {
+            window.paint_path(path, fill);
+        }
+    }
+    let mut pb = PathBuilder::stroke(px((b.width * z).max(0.5)));
+    trace(&mut pb);
+    if let Ok(path) = pb.build() {
+        window.paint_path(path, ink);
+    }
 }
 
 /// A rounded rectangle: straight edges joined by quarter-circle corners (radius
@@ -5029,12 +7589,24 @@ fn paint_round_rect(
         pb.cubic_bezier_to(s(x0 + r, y0), s(x0, y0 + r - k), s(x0 + r - k, y0));
         pb.close();
     };
-    fill_then_stroke(trace, b.width, z, ink, fill, window);
+    if let Some(fill) = fill {
+        let mut fb = PathBuilder::fill();
+        trace(&mut fb);
+        if let Ok(path) = fb.build() {
+            window.paint_path(path, fill);
+        }
+    }
+    let mut pb = PathBuilder::stroke(px((b.width * z).max(0.5)));
+    trace(&mut pb);
+    if let Ok(path) = pb.build() {
+        window.paint_path(path, ink);
+    }
 }
 
 fn paint_segment(
     seg: &SegGeom,
     arrow: bool,
+    style: MindMapConnectorStyle,
     cam: Camera,
     origin: Point<Pixels>,
     ink: Hsla,
@@ -5043,16 +7615,48 @@ fn paint_segment(
     let z = cam.zoom.max(MIN_ZOOM);
     let p1 = to_screen(seg.x1, seg.y1, cam, origin);
     let p2 = to_screen(seg.x2, seg.y2, cam, origin);
-    let mut pb = PathBuilder::stroke(px((seg.width * z).max(0.5)));
-    pb.move_to(p1);
-    pb.line_to(p2);
-    if let Ok(path) = pb.build() {
-        window.paint_path(path, ink);
-    }
+    let p1f = [f32::from(p1.x), f32::from(p1.y)];
+    let p2f = [f32::from(p2.x), f32::from(p2.y)];
+    let stroke_px = (seg.width * z).max(0.5);
+    let mut points = vec![p1f];
+    let (dxw, _dyw) = (seg.x2 - seg.x1, seg.y2 - seg.y1);
+    let (end_dx, end_dy) = match style {
+        MindMapConnectorStyle::Straight => {
+            points.push(p2f);
+            (p2f[0] - p1f[0], p2f[1] - p1f[1])
+        }
+        MindMapConnectorStyle::Bezier => {
+            let cx1 = seg.x1 + dxw * 0.35;
+            let cy1 = seg.y1;
+            let cx2 = seg.x2 - dxw * 0.35;
+            let cy2 = seg.y2;
+            let c1 = to_screen(cx1, cy1, cam, origin);
+            let c2 = to_screen(cx2, cy2, cam, origin);
+            let c1f = [f32::from(c1.x), f32::from(c1.y)];
+            let c2f = [f32::from(c2.x), f32::from(c2.y)];
+            for i in 1..=24 {
+                let t = i as f32 / 24.0;
+                points.push(cubic_point(p1f, c1f, c2f, p2f, t));
+            }
+            (3.0 * (p2f[0] - c2f[0]), 3.0 * (p2f[1] - c2f[1]))
+        }
+        MindMapConnectorStyle::Orthogonal => {
+            let mid_x = seg.x1 + dxw * 0.5;
+            let m1 = to_screen(mid_x, seg.y1, cam, origin);
+            let m2 = to_screen(mid_x, seg.y2, cam, origin);
+            let m1f = [f32::from(m1.x), f32::from(m1.y)];
+            let m2f = [f32::from(m2.x), f32::from(m2.y)];
+            points.push(m1f);
+            points.push(m2f);
+            points.push(p2f);
+            (p2f[0] - m2f[0], p2f[1] - m2f[1])
+        }
+    };
+    paint_polyline(points.as_slice(), stroke_px, seg.style, ink, window);
     if !arrow {
         return;
     }
-    let (dx, dy) = (f32::from(p2.x - p1.x), f32::from(p2.y - p1.y));
+    let (dx, dy) = (end_dx, end_dy);
     let len = (dx * dx + dy * dy).sqrt();
     if len < 1.0 {
         return;
@@ -5076,34 +7680,164 @@ fn paint_segment(
     }
 }
 
-/// A solid accent square handle centered at a screen point.
-fn draw_handle(hx: f32, hy: f32, color: Hsla, window: &mut Window) {
-    let h = HANDLE_HALF;
-    window.paint_quad(fill(
-        Bounds {
-            origin: point(px(hx - h), px(hy - h)),
-            size: size(px(h * 2.0), px(h * 2.0)),
-        },
-        color,
-    ));
+fn cubic_point(p0: [f32; 2], p1: [f32; 2], p2: [f32; 2], p3: [f32; 2], t: f32) -> [f32; 2] {
+    let mt = 1.0 - t;
+    let a = mt * mt * mt;
+    let b = 3.0 * mt * mt * t;
+    let c = 3.0 * mt * t * t;
+    let d = t * t * t;
+    [
+        a * p0[0] + b * p1[0] + c * p2[0] + d * p3[0],
+        a * p0[1] + b * p1[1] + c * p2[1] + d * p3[1],
+    ]
 }
 
-/// A filled circular handle (distinct from the square resize handles) marking
-/// the rotation grip, centered at a screen point.
-fn draw_rotate_handle(hx: f32, hy: f32, color: Hsla, window: &mut Window) {
-    let r = HANDLE_HALF + 0.5;
-    const K: f32 = 0.552_284_8;
-    let k = r * K;
-    let p = |x: f32, y: f32| point(px(x), px(y));
-    let mut pb = PathBuilder::fill();
-    pb.move_to(p(hx + r, hy));
-    pb.cubic_bezier_to(p(hx, hy + r), p(hx + r, hy + k), p(hx + k, hy + r));
-    pb.cubic_bezier_to(p(hx - r, hy), p(hx - k, hy + r), p(hx - r, hy + k));
-    pb.cubic_bezier_to(p(hx, hy - r), p(hx - r, hy - k), p(hx - k, hy - r));
-    pb.cubic_bezier_to(p(hx + r, hy), p(hx + k, hy - r), p(hx + r, hy - k));
-    pb.close();
+fn paint_polyline(
+    points: &[[f32; 2]],
+    stroke_px: f32,
+    style: SegmentStyle,
+    ink: Hsla,
+    window: &mut Window,
+) {
+    if points.len() < 2 {
+        return;
+    }
+    let mut pb = PathBuilder::stroke(px(stroke_px));
+    match style {
+        SegmentStyle::Solid => {
+            pb.move_to(point(px(points[0][0]), px(points[0][1])));
+            for p in &points[1..] {
+                pb.line_to(point(px(p[0]), px(p[1])));
+            }
+        }
+        SegmentStyle::Dashed => {
+            let dash = (stroke_px * 4.5).max(10.0);
+            let gap = (stroke_px * 2.5).max(6.0);
+            let cycle = dash + gap;
+            let mut traveled = 0.0;
+            for seg in points.windows(2) {
+                let a = seg[0];
+                let b = seg[1];
+                let dx = b[0] - a[0];
+                let dy = b[1] - a[1];
+                let len = (dx * dx + dy * dy).sqrt();
+                if len <= 0.01 {
+                    continue;
+                }
+                let ux = dx / len;
+                let uy = dy / len;
+                let mut local = 0.0;
+                while local < len {
+                    let at = traveled + local;
+                    let phase = at % cycle;
+                    let draw = if phase < dash { dash - phase } else { 0.0 };
+                    if draw > 0.0 {
+                        let s = local;
+                        let e = (local + draw).min(len);
+                        let p0 = [a[0] + ux * s, a[1] + uy * s];
+                        let p1 = [a[0] + ux * e, a[1] + uy * e];
+                        pb.move_to(point(px(p0[0]), px(p0[1])));
+                        pb.line_to(point(px(p1[0]), px(p1[1])));
+                        local = e;
+                    } else {
+                        local = (local + (cycle - phase)).min(len);
+                    }
+                }
+                traveled += len;
+            }
+        }
+    }
     if let Ok(path) = pb.build() {
+        window.paint_path(path, ink);
+    }
+}
+
+fn draw_filled_circle(hx: f32, hy: f32, radius: f32, color: Hsla, window: &mut Window) {
+    const K: f32 = 0.552_284_8;
+    let k = radius * K;
+    let p = |x: f32, y: f32| point(px(x), px(y));
+    let mut path = PathBuilder::fill();
+    path.move_to(p(hx + radius, hy));
+    path.cubic_bezier_to(
+        p(hx, hy + radius),
+        p(hx + radius, hy + k),
+        p(hx + k, hy + radius),
+    );
+    path.cubic_bezier_to(
+        p(hx - radius, hy),
+        p(hx - k, hy + radius),
+        p(hx - radius, hy + k),
+    );
+    path.cubic_bezier_to(
+        p(hx, hy - radius),
+        p(hx - radius, hy - k),
+        p(hx - k, hy - radius),
+    );
+    path.cubic_bezier_to(
+        p(hx + radius, hy),
+        p(hx + k, hy - radius),
+        p(hx + radius, hy - k),
+    );
+    path.close();
+    if let Ok(path) = path.build() {
         window.paint_path(path, color);
+    }
+}
+
+/// Compact circular resize handle matching the whiteboard connector controls.
+fn draw_handle(hx: f32, hy: f32, color: Hsla, window: &mut Window) {
+    draw_filled_circle(hx, hy, HANDLE_HALF + 1.0, hsla(0.0, 0.0, 1.0, 1.0), window);
+    draw_filled_circle(hx, hy, HANDLE_HALF, color, window);
+}
+
+/// Screen-space centers for the top/right/bottom/left connector buttons. Each
+/// button is pushed outward from the selected element while its line still
+/// starts at the true edge connector point.
+fn connector_button_centers(
+    kind: &ElementKind,
+    cam: Camera,
+    origin: Point<Pixels>,
+) -> [Point<Pixels>; 4] {
+    let points = connector_points(kind);
+    let edges = [
+        to_screen(points[0][0], points[0][1], cam, origin),
+        to_screen(points[1][0], points[1][1], cam, origin),
+        to_screen(points[2][0], points[2][1], cam, origin),
+        to_screen(points[3][0], points[3][1], cam, origin),
+    ];
+    let center = edges.iter().fold((0.0, 0.0), |(x, y), point| {
+        (x + f32::from(point.x), y + f32::from(point.y))
+    });
+    let center = (center.0 / 4.0, center.1 / 4.0);
+    edges.map(|edge| {
+        let dx = f32::from(edge.x) - center.0;
+        let dy = f32::from(edge.y) - center.1;
+        let length = (dx * dx + dy * dy).sqrt().max(1.0);
+        point(
+            edge.x + px(dx / length * CONNECTOR_BUTTON_GAP),
+            edge.y + px(dy / length * CONNECTOR_BUTTON_GAP),
+        )
+    })
+}
+
+fn paint_snap_points(
+    kind: &ElementKind,
+    active: usize,
+    cam: Camera,
+    origin: Point<Pixels>,
+    color: Hsla,
+    window: &mut Window,
+) {
+    for (index, point) in connector_points(kind).into_iter().enumerate() {
+        let screen = to_screen(point[0], point[1], cam, origin);
+        let radius = if index == active {
+            HANDLE_HALF + 1.5
+        } else {
+            HANDLE_HALF
+        };
+        let (x, y) = (f32::from(screen.x), f32::from(screen.y));
+        draw_filled_circle(x, y, radius + 1.0, hsla(0.0, 0.0, 1.0, 1.0), window);
+        draw_filled_circle(x, y, radius, color, window);
     }
 }
 
@@ -5121,26 +7855,14 @@ fn paint_selection(
             let p = to_screen(wx, wy, cam, origin);
             draw_handle(f32::from(p.x), f32::from(p.y), color, window);
         }
-        let (rx, ry) = rotate_handle_screen(kind, cam, origin);
-        draw_rotate_handle(rx, ry, color, window);
         return;
     }
     // Box-like (rect/ellipse/text): the (possibly rotated) box outline, four
     // corner handles, and a rotate grip. Edge-midpoint handles (per-axis stretch)
     // show only when upright — a rotated box's edges aren't world-axis-aligned.
     if let Some((x, y, w, h, rot)) = box_like(kind) {
-        let z = cam.zoom.max(MIN_ZOOM);
-        let s = box_padded_corners(x, y, w, h, rot, SEL_PAD_PX / z)
-            .map(|p| to_screen(p[0], p[1], cam, origin));
-        let mut pb = PathBuilder::stroke(px(1.5));
-        pb.move_to(s[0]);
-        pb.line_to(s[1]);
-        pb.line_to(s[2]);
-        pb.line_to(s[3]);
-        pb.close();
-        if let Ok(path) = pb.build() {
-            window.paint_path(path, color);
-        }
+        let s =
+            box_padded_corners(x, y, w, h, rot, 0.0).map(|p| to_screen(p[0], p[1], cam, origin));
         for p in &s {
             draw_handle(f32::from(p.x), f32::from(p.y), color, window);
         }
@@ -5160,8 +7882,6 @@ fn paint_selection(
                 draw_handle(hx, hy, color, window);
             }
         }
-        let (rx, ry) = rotate_handle_screen(kind, cam, origin);
-        draw_rotate_handle(rx, ry, color, window);
         return;
     }
     // Draw / Embed: a padded AABB box + four corner handles. Freehand strokes
@@ -5169,18 +7889,9 @@ fn paint_selection(
     let bb = bbox(kind);
     let tl = to_screen(bb.0, bb.1, cam, origin);
     let br = to_screen(bb.2, bb.3, cam, origin);
-    let m = SEL_PAD_PX;
+    let m = 0.0;
     let (x0, y0) = (f32::from(tl.x) - m, f32::from(tl.y) - m);
     let (x1, y1) = (f32::from(br.x) + m, f32::from(br.y) + m);
-    let mut pb = PathBuilder::stroke(px(1.5));
-    pb.move_to(point(px(x0), px(y0)));
-    pb.line_to(point(px(x1), px(y0)));
-    pb.line_to(point(px(x1), px(y1)));
-    pb.line_to(point(px(x0), px(y1)));
-    pb.close();
-    if let Ok(path) = pb.build() {
-        window.paint_path(path, color);
-    }
     let (mx, my) = ((x0 + x1) / 2.0, (y0 + y1) / 2.0);
     for (hx, hy) in [
         (x0, y0),
@@ -5193,35 +7904,6 @@ fn paint_selection(
         (x0, my),
     ] {
         draw_handle(hx, hy, color, window);
-    }
-    if rotatable(kind) {
-        let (rx, ry) = rotate_handle_screen(kind, cam, origin);
-        draw_rotate_handle(rx, ry, color, window);
-    }
-}
-
-/// A thin selection outline (no handles) — used for each element in a
-/// multi-selection.
-fn paint_box_outline(
-    bb: (f32, f32, f32, f32),
-    cam: Camera,
-    origin: Point<Pixels>,
-    color: Hsla,
-    window: &mut Window,
-) {
-    let tl = to_screen(bb.0, bb.1, cam, origin);
-    let br = to_screen(bb.2, bb.3, cam, origin);
-    let m = SEL_PAD_PX;
-    let (x0, y0) = (f32::from(tl.x) - m, f32::from(tl.y) - m);
-    let (x1, y1) = (f32::from(br.x) + m, f32::from(br.y) + m);
-    let mut pb = PathBuilder::stroke(px(1.5));
-    pb.move_to(point(px(x0), px(y0)));
-    pb.line_to(point(px(x1), px(y0)));
-    pb.line_to(point(px(x1), px(y1)));
-    pb.line_to(point(px(x0), px(y1)));
-    pb.close();
-    if let Ok(p) = pb.build() {
-        window.paint_path(p, color);
     }
 }
 
@@ -5262,8 +7944,335 @@ fn paint_marquee(
     }
 }
 
+fn paint_alignment_guides(
+    guides: AlignmentGuides,
+    bounds: Bounds<Pixels>,
+    cam: Camera,
+    color: Hsla,
+    window: &mut Window,
+) {
+    let mut color = color;
+    color.a = 0.8;
+    if let Some(x) = guides.vertical {
+        let screen = to_screen(x, 0.0, cam, bounds.origin);
+        let mut path = PathBuilder::stroke(px(1.0));
+        path.move_to(point(screen.x, bounds.top()));
+        path.line_to(point(screen.x, bounds.bottom()));
+        if let Ok(path) = path.build() {
+            window.paint_path(path, color);
+        }
+    }
+    if let Some(y) = guides.horizontal {
+        let screen = to_screen(0.0, y, cam, bounds.origin);
+        let mut path = PathBuilder::stroke(px(1.0));
+        path.move_to(point(bounds.left(), screen.y));
+        path.line_to(point(bounds.right(), screen.y));
+        if let Ok(path) = path.build() {
+            window.paint_path(path, color);
+        }
+    }
+}
+
+impl EntityInputHandler for WhiteboardView {
+    fn text_for_range(
+        &mut self,
+        range_utf16: Range<usize>,
+        actual_range: &mut Option<Range<usize>>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<String> {
+        let text = self.editing_content()?;
+        let range = Self::utf16_range_to_utf8_in(&text, &range_utf16);
+        actual_range.replace(Self::utf8_range_to_utf16_in(&text, &range));
+        Some(text[range].to_string())
+    }
+
+    fn selected_text_range(
+        &mut self,
+        _ignore_disabled_input: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<UTF16Selection> {
+        let text = self.editing_content()?;
+        let range = {
+            let (s, e) = self.sel_range();
+            s..e
+        };
+        Some(UTF16Selection {
+            range: Self::utf8_range_to_utf16_in(&text, &range),
+            reversed: self.caret < self.sel_anchor,
+        })
+    }
+
+    fn marked_text_range(
+        &self,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<Range<usize>> {
+        let text = self.editing_content()?;
+        self.marked_range
+            .as_ref()
+            .map(|range| Self::utf8_range_to_utf16_in(&text, range))
+    }
+
+    fn unmark_text(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
+        self.marked_range = None;
+    }
+
+    fn replace_text_in_range(
+        &mut self,
+        range_utf16: Option<Range<usize>>,
+        new_text: &str,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(text) = self.editing_content() else {
+            return;
+        };
+        let visible_range = range_utf16
+            .as_ref()
+            .map(|range| Self::utf16_range_to_utf8_in(&text, range))
+            .or(self.marked_range.clone())
+            .unwrap_or_else(|| {
+                let (start, end) = self.sel_range();
+                start..end
+            });
+        self.replace_text_in_visible_range(visible_range, new_text, None, false, cx);
+    }
+
+    fn replace_and_mark_text_in_range(
+        &mut self,
+        range_utf16: Option<Range<usize>>,
+        new_text: &str,
+        new_selected_range_utf16: Option<Range<usize>>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(text) = self.editing_content() else {
+            return;
+        };
+        let visible_range = range_utf16
+            .as_ref()
+            .map(|range| Self::utf16_range_to_utf8_in(&text, range))
+            .or(self.marked_range.clone())
+            .unwrap_or_else(|| {
+                let (start, end) = self.sel_range();
+                start..end
+            });
+        let selected_range_relative = new_selected_range_utf16
+            .as_ref()
+            .map(|range_utf16| Self::utf16_range_to_utf8_in(new_text, range_utf16))
+            .map(|relative| relative.start..relative.end);
+
+        self.replace_text_in_visible_range(
+            visible_range,
+            new_text,
+            selected_range_relative,
+            !new_text.is_empty(),
+            cx,
+        );
+    }
+
+    fn bounds_for_range(
+        &mut self,
+        range_utf16: Range<usize>,
+        bounds: Bounds<Pixels>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<Bounds<Pixels>> {
+        let id = self.editing?;
+        let tg = self.edit_target(id)?;
+        let range = Self::utf16_range_to_utf8_in(&tg.content, &range_utf16);
+        let caret = self
+            .font
+            .caret_pos_wrapped(&tg.content, tg.size, tg.wrap, range.end);
+        let (wx, wy) = block_world(tg.x, tg.y, tg.rotation, tg.pivot, caret);
+        let sp = to_screen(wx, wy, self.scene.camera, bounds.origin);
+        Some(Bounds {
+            origin: sp,
+            size: size(
+                px(1.0),
+                px((tg.size * self.scene.camera.zoom.max(MIN_ZOOM)).max(12.0)),
+            ),
+        })
+    }
+
+    fn character_index_for_point(
+        &mut self,
+        pt: Point<Pixels>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<usize> {
+        let id = self.editing?;
+        let tg = self.edit_target(id)?;
+        let p = self.event_to_world(pt);
+        let local = block_local(tg.x, tg.y, tg.rotation, tg.pivot, p);
+        let idx = self
+            .font
+            .index_at_wrapped(&tg.content, tg.size, tg.wrap, local);
+        Some(Self::utf8_to_utf16_in(&tg.content, idx))
+    }
+}
+
+struct WhiteboardInputElement {
+    input: Entity<WhiteboardView>,
+}
+
+impl WhiteboardInputElement {
+    fn new(input: Entity<WhiteboardView>) -> Self {
+        Self { input }
+    }
+}
+
+impl IntoElement for WhiteboardInputElement {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl gpui::Element for WhiteboardInputElement {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut style = Style::default();
+        style.size.width = relative(1.0).into();
+        style.size.height = relative(1.0).into();
+        (window.request_layout(style, [], cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> Self::PrepaintState {
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let focus_handle = self.input.read(cx).focus.clone();
+        if focus_handle.is_focused(window) {
+            window.handle_input(
+                &focus_handle,
+                ElementInputHandler::new(bounds, self.input.clone()),
+                cx,
+            );
+        }
+    }
+}
+
+impl WhiteboardView {
+    fn render_read_only(&mut self, window: &Window, cx: &mut Context<Self>) -> AnyElement {
+        let WhiteboardStyle {
+            bg,
+            grid,
+            text,
+            ink,
+            panel,
+            ..
+        } = (self.style)();
+        let camera = self.scene.camera;
+        let bounds_cell = self.bounds.clone();
+        let render_viewport = self.render_viewport(Some(window.viewport_size()));
+        let visible_element_ids = self
+            .scene
+            .elements
+            .iter()
+            .filter(|element| {
+                render_viewport.is_none_or(|viewport| viewport.intersects(bbox(&element.kind)))
+            })
+            .map(|element| element.id)
+            .collect::<HashSet<_>>();
+        self.text_layout_cache
+            .retain(|element_id, _| visible_element_ids.contains(element_id));
+        self.label_layout_cache
+            .retain(|element_id, _| visible_element_ids.contains(element_id));
+        let layers = build_thumbnail_layers(
+            &self.scene,
+            &self.font,
+            camera,
+            ink,
+            text,
+            grid,
+            panel,
+            render_viewport,
+            Some(&mut self.text_layout_cache),
+            Some(&mut self.label_layout_cache),
+        );
+        let board_layer = canvas(
+            move |bounds, _, _| bounds_cell.set(bounds),
+            move |bounds, _, window, _| paint_board(bounds, camera, bg, grid, window),
+        )
+        .absolute()
+        .size_full();
+        let element_layers = layers.into_iter().map(|layer| match layer {
+            Layer::Band(elements) => band_canvas(elements, camera).into_any_element(),
+            Layer::Overlay(element) => element,
+        });
+
+        div()
+            .size_full()
+            .relative()
+            .overflow_hidden()
+            .cursor(if self.panning {
+                CursorStyle::ClosedHand
+            } else {
+                CursorStyle::OpenHand
+            })
+            .child(board_layer)
+            .children(element_layers)
+            .on_mouse_down(MouseButton::Left, cx.listener(Self::on_left_down))
+            .on_mouse_up(MouseButton::Left, cx.listener(Self::on_left_up))
+            .on_mouse_down(MouseButton::Middle, cx.listener(Self::on_middle_down))
+            .on_mouse_up(MouseButton::Middle, cx.listener(Self::on_middle_up))
+            .on_mouse_move(cx.listener(Self::on_move))
+            .on_pinch(cx.listener(Self::on_pinch))
+            .child(
+                div()
+                    .absolute()
+                    .left(px(10.0))
+                    .bottom(px(8.0))
+                    .text_size(px(11.0))
+                    .text_color(text)
+                    .child(SharedString::from(format!("{:.0}%", camera.zoom * 100.0))),
+            )
+            .into_any_element()
+    }
+}
+
 impl Render for WhiteboardView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if self.read_only {
+            return self.render_read_only(window, cx);
+        }
         let WhiteboardStyle {
             bg,
             grid,
@@ -5278,6 +8287,21 @@ impl Render for WhiteboardView {
         let cam = self.scene.camera;
         let zoom = cam.zoom.max(MIN_ZOOM);
         let bounds_cell = self.bounds.clone();
+        let board_bounds = self.bounds.get();
+        let render_viewport = self.render_viewport(Some(window.viewport_size()));
+        let visible_element_ids = self
+            .scene
+            .elements
+            .iter()
+            .filter(|element| {
+                render_viewport.is_none_or(|viewport| viewport.intersects(bbox(&element.kind)))
+            })
+            .map(|element| element.id)
+            .collect::<HashSet<_>>();
+        self.text_layout_cache
+            .retain(|element_id, _| visible_element_ids.contains(element_id));
+        self.label_layout_cache
+            .retain(|element_id, _| visible_element_ids.contains(element_id));
 
         // Decoded bitmaps for image elements, fetched from the host (which decodes
         // off-thread and re-renders when ready). Pre-fetched here — before the
@@ -5292,6 +8316,7 @@ impl Render for WhiteboardView {
                 .scene
                 .elements
                 .iter()
+                .filter(|element| visible_element_ids.contains(&element.id))
                 .filter_map(|e| match &e.kind {
                     ElementKind::Image(im) => {
                         Some((e.id, im.src.clone(), snap_quarter(im.rotation)))
@@ -5316,15 +8341,31 @@ impl Render for WhiteboardView {
         // or page-card flushes the band and adds its overlay div, so a shape can
         // sit above or below an image. Text is laid out here (measured extent for
         // selection/hit-test + outline segments) so it z-orders and rotates with
-        // shapes. Re-laid each frame for now; see the path-cache note at the top.
+        // shapes. Camera-independent glyph outlines are cached by content/style;
+        // camera movement only rebuilds their screen-space paths.
         let font = self.font.clone();
         let editing = self.editing;
         let (caret_at, sel_anchor) = (self.caret, self.sel_anchor);
         // A translucent accent fills the selected glyphs (kept readable).
         let sel_fill = gpui::hsla(selection.h, selection.s, selection.l, 0.30);
+        let mindmap_connector_styles: HashMap<u64, MindMapConnectorStyle> = self
+            .scene
+            .elements
+            .iter()
+            .filter(|element| visible_element_ids.contains(&element.id))
+            .filter_map(|element| {
+                self.mindmap_connector_style_for_element(&element.kind)
+                    .map(|style| (element.id, style))
+            })
+            .collect();
+        let text_layout_cache = &mut self.text_layout_cache;
+        let label_layout_cache = &mut self.label_layout_cache;
         let mut layers: Vec<Layer> = Vec::new();
         let mut band: Vec<ElemPaint> = Vec::new();
         for e in self.scene.elements.iter_mut() {
+            if !visible_element_ids.contains(&e.id) {
+                continue;
+            }
             let id = e.id;
             let stroke = e.stroke.map_or(ink, u32_to_hsla);
             let fill = e.fill.map(u32_to_hsla);
@@ -5429,9 +8470,15 @@ impl Render for WhiteboardView {
                 // Canvas-drawn kinds: shapes / lines / pen / text.
                 kind => {
                     let text = if let ElementKind::Text(t) = kind {
-                        let layout = font.layout_styled(&t.content, t.size, None, |b| {
-                            glyph_style(style_at(styles, b))
-                        });
+                        let layout = cached_text_layout(
+                            text_layout_cache,
+                            &font,
+                            id,
+                            &t.content,
+                            t.size,
+                            None,
+                            styles,
+                        );
                         t.measured_w = layout.width;
                         t.measured_h = layout.height;
                         // While editing: the caret at its byte offset and the
@@ -5445,8 +8492,8 @@ impl Render for WhiteboardView {
                             Vec::new()
                         };
                         Some(TextOutline {
-                            segs: layout.segs,
-                            bold_segs: layout.bold_segs,
+                            segs: layout.segs.clone(),
+                            bold_segs: layout.bold_segs.clone(),
                             bold_width: layout.bold_width,
                             color: stroke,
                             x: t.x,
@@ -5457,7 +8504,7 @@ impl Render for WhiteboardView {
                             caret,
                             selection,
                             sel_color: sel_fill,
-                            decorations: layout.decorations,
+                            decorations: layout.decorations.clone(),
                         })
                     } else if is_closed_shape(kind)
                         && let Some((bx, by, bw, bh, rot)) = box_like(kind)
@@ -5471,33 +8518,52 @@ impl Render for WhiteboardView {
                         // moment you double-click (before the first keystroke).
                         let active = editing == Some(id);
                         let text = label.map_or("", str::trim);
-                        let blk = shape_label_block(&font, kind, bx, by, bw, bh, text);
-                        let layout = font.layout_styled(text, blk.size, Some(blk.wrap), |b| {
-                            glyph_style(style_at(styles, b))
-                        });
+                        let label_layout = cached_label_layout(
+                            label_layout_cache,
+                            &font,
+                            id,
+                            kind,
+                            bx,
+                            by,
+                            bw,
+                            bh,
+                            text,
+                            styles,
+                        );
                         let caret = active.then(|| {
-                            font.caret_pos_wrapped(text, blk.size, Some(blk.wrap), caret_at)
+                            font.caret_pos_wrapped(
+                                text,
+                                label_layout.size,
+                                Some(label_layout.wrap),
+                                caret_at,
+                            )
                         });
                         let (s, e) = (caret_at.min(sel_anchor), caret_at.max(sel_anchor));
                         let selection = if active {
-                            font.selection_rects_wrapped(text, blk.size, Some(blk.wrap), s, e)
+                            font.selection_rects_wrapped(
+                                text,
+                                label_layout.size,
+                                Some(label_layout.wrap),
+                                s,
+                                e,
+                            )
                         } else {
                             Vec::new()
                         };
                         Some(TextOutline {
-                            segs: layout.segs,
-                            bold_segs: layout.bold_segs,
-                            bold_width: layout.bold_width,
+                            segs: label_layout.text.segs.clone(),
+                            bold_segs: label_layout.text.bold_segs.clone(),
+                            bold_width: label_layout.text.bold_width,
                             color: label_color.map_or(stroke, u32_to_hsla),
-                            x: blk.x,
-                            y: blk.y,
+                            x: bx + label_layout.offset_x,
+                            y: by + label_layout.offset_y,
                             rotation: rot,
                             pivot: [bx + bw / 2.0, by + bh / 2.0],
-                            line_height: layout.line_height,
+                            line_height: label_layout.text.line_height,
                             caret,
                             selection,
                             sel_color: sel_fill,
-                            decorations: layout.decorations,
+                            decorations: label_layout.text.decorations.clone(),
                         })
                     } else {
                         None
@@ -5507,6 +8573,7 @@ impl Render for WhiteboardView {
                         stroke,
                         fill,
                         text,
+                        mindmap_connector_style: mindmap_connector_styles.get(&id).copied(),
                     });
                 }
             }
@@ -5534,12 +8601,102 @@ impl Render for WhiteboardView {
             .flatten()
             .map(|bb| (bb, self.group_rotatable()));
         let marquee = self.marquee;
+        let alignment_guides = self.alignment_guides;
+        let snap_target = self.connecting.and_then(|connection| {
+            self.hovered_connector
+                .filter(|target| target.id != connection.from.id)
+                .and_then(|target| {
+                    self.scene
+                        .elements
+                        .iter()
+                        .find(|element| element.id == target.id)
+                        .map(|element| (element.kind.clone(), target.index))
+                })
+        });
+        const CONNECTOR_ICONS: [(&str, &[u8]); 4] = [
+            ("wb-connector-up", include_bytes!("../assets/icons/up.svg")),
+            (
+                "wb-connector-right",
+                include_bytes!("../assets/icons/right.svg"),
+            ),
+            (
+                "wb-connector-down",
+                include_bytes!("../assets/icons/down.svg"),
+            ),
+            (
+                "wb-connector-left",
+                include_bytes!("../assets/icons/left.svg"),
+            ),
+        ];
+        let connector_buttons: Vec<gpui::AnyElement> = single_sel
+            .as_ref()
+            .filter(|_| self.connecting.is_none() && self.pending.is_none())
+            .filter(|kind| connector_capable(kind))
+            .map(|kind| {
+                connector_button_centers(kind, cam, board_bounds.origin)
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, center)| {
+                        let (key, bytes) = CONNECTOR_ICONS[index];
+                        div()
+                            .id(("wb-connector-button", index))
+                            .absolute()
+                            .left(
+                                center.x - board_bounds.origin.x - px(CONNECTOR_BUTTON_SIZE / 2.0),
+                            )
+                            .top(center.y - board_bounds.origin.y - px(CONNECTOR_BUTTON_SIZE / 2.0))
+                            .size(px(CONNECTOR_BUTTON_SIZE))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .rounded_full()
+                            .bg(panel_strong)
+                            .text_color(selection)
+                            .shadow_sm()
+                            .cursor_pointer()
+                            .child(svg_icon(key, bytes, selection, CONNECTOR_BUTTON_SIZE))
+                            .into_any_element()
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        const ROTATE_ICON: &[u8] = include_bytes!("../assets/icons/refresh.svg");
+        let rotate_position = single_sel
+            .as_ref()
+            .filter(|kind| rotatable(kind))
+            .map(|kind| rotate_handle_screen(kind, cam, board_bounds.origin))
+            .or_else(|| {
+                group_sel
+                    .filter(|(_, can_rotate)| *can_rotate)
+                    .map(|(bounds, _)| rotate_handle_for_bbox(bounds, cam, board_bounds.origin))
+            });
+        let rotate_button = rotate_position.map(|(x, y)| {
+            div()
+                .id("wb-rotate-button")
+                .absolute()
+                .left(px(x) - board_bounds.origin.x - px(CONNECTOR_BUTTON_SIZE / 2.0))
+                .top(px(y) - board_bounds.origin.y - px(CONNECTOR_BUTTON_SIZE / 2.0))
+                .size(px(CONNECTOR_BUTTON_SIZE))
+                .flex()
+                .items_center()
+                .justify_center()
+                .rounded_full()
+                .bg(panel_strong)
+                .shadow_sm()
+                .cursor_pointer()
+                .child(svg_icon(
+                    "wb-icon-refresh",
+                    ROTATE_ICON,
+                    selection,
+                    CONNECTOR_BUTTON_SIZE - 4.0,
+                ))
+        });
+        let selected_mindmap_root = self.selected_mindmap_root();
 
         // Tool palette + actions (top-center). The pill `occlude()`s so a press
         // on a button doesn't also act on the board beneath it. Layout, left→right:
-        //   pan · select · color │ shapes&text▾ · pages&images▾ │ undo · redo · delete
-        // The two bracketed buttons are categories: clicking one opens a flyout
-        // (built below) of that group's tools, keeping the main bar trim.
+        //   pan · select · mindmap · color │ shapes&text▾ · pages&images▾ │ undo · redo · delete
+        // `MindMap` is promoted to a first-class toolbar button in the main tool area.
         let active = self.tool;
         let open_group = self.open_group;
 
@@ -5809,7 +8966,7 @@ impl Render for WhiteboardView {
         if vertical {
             pill = pill.flex_col();
         }
-        let pill = pill
+        let mut pill = pill
             .child(
                 canvas(move |b, _, _| pill_cell.set(b), |_, _, _, _| {})
                     .absolute()
@@ -5827,15 +8984,193 @@ impl Render for WhiteboardView {
                 tool_btn(Tool::Select)
                     .tooltip(self.tip(Tool::Select.label()))
                     .on_click(cx.listener(|this, _ev, _w, cx| this.set_tool(Tool::Select, cx))),
-            )
-            .child(color_btn)
-            .child(width_btn)
-            .children(font_btn)
-            .children(format_btn)
-            .child(toolbar_divider(grid, vertical))
-            // tool categories (each opens a flyout of its tools)
-            .children(cats)
-            .child(templates_btn)
+            );
+        if let Some(root_id) = selected_mindmap_root {
+            let direction = self.mindmap_root_direction(root_id);
+            let connector_style = self.mindmap_connector_style_for_root(root_id);
+            let chip = |id: &'static str, active: bool, icon: gpui::AnyElement| {
+                let mut d = div()
+                    .id(id)
+                    .px(px(8.0))
+                    .h(px(24.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(px(6.0))
+                    .text_size(px(11.0))
+                    .text_color(ink);
+                if active {
+                    d = d.bg(accent);
+                } else {
+                    d = d.hover(|s| s.bg(grid));
+                }
+                d.child(icon)
+            };
+            let icon_color = ink;
+            let draw_mm_icon = move |_id: &'static str, kind: &'static str| -> gpui::AnyElement {
+                canvas(
+                    |_, _, _| {},
+                    move |bounds, _, window, _| {
+                        let w = f32::from(bounds.size.width);
+                        let h = f32::from(bounds.size.height);
+                        let ox = f32::from(bounds.origin.x);
+                        let oy = f32::from(bounds.origin.y);
+                        let p = |x: f32, y: f32| point(px(ox + x), px(oy + y));
+                        let mut stroke = |segments: &[([f32; 2], [f32; 2])]| {
+                            let mut pb = PathBuilder::stroke(px(1.75));
+                            for &([x1, y1], [x2, y2]) in segments {
+                                pb.move_to(p(x1, y1));
+                                pb.line_to(p(x2, y2));
+                            }
+                            if let Ok(path) = pb.build() {
+                                window.paint_path(path, icon_color);
+                            }
+                        };
+                        match kind {
+                            "dir-both" => stroke(&[
+                                ([3.0, h / 2.0], [w - 3.0, h / 2.0]),
+                                ([3.0, h / 2.0], [6.0, h / 2.0 - 3.0]),
+                                ([3.0, h / 2.0], [6.0, h / 2.0 + 3.0]),
+                                ([w - 3.0, h / 2.0], [w - 6.0, h / 2.0 - 3.0]),
+                                ([w - 3.0, h / 2.0], [w - 6.0, h / 2.0 + 3.0]),
+                            ]),
+                            "dir-right" => stroke(&[
+                                ([3.0, h / 2.0], [w - 3.0, h / 2.0]),
+                                ([w - 3.0, h / 2.0], [w - 6.0, h / 2.0 - 3.0]),
+                                ([w - 3.0, h / 2.0], [w - 6.0, h / 2.0 + 3.0]),
+                            ]),
+                            "dir-left" => stroke(&[
+                                ([3.0, h / 2.0], [w - 3.0, h / 2.0]),
+                                ([3.0, h / 2.0], [6.0, h / 2.0 - 3.0]),
+                                ([3.0, h / 2.0], [6.0, h / 2.0 + 3.0]),
+                            ]),
+                            "line-straight" => stroke(&[([3.0, h / 2.0], [w - 3.0, h / 2.0])]),
+                            "line-bezier" => {
+                                let mut pb = PathBuilder::stroke(px(1.75));
+                                pb.move_to(p(2.5, h - 4.0));
+                                pb.cubic_bezier_to(
+                                    p(w - 2.5, 4.0),
+                                    p(w * 0.35, h - 4.0),
+                                    p(w * 0.65, 4.0),
+                                );
+                                if let Ok(path) = pb.build() {
+                                    window.paint_path(path, icon_color);
+                                }
+                            }
+                            "line-orthogonal" => stroke(&[
+                                ([3.0, h - 4.0], [w * 0.45, h - 4.0]),
+                                ([w * 0.45, h - 4.0], [w * 0.45, 4.0]),
+                                ([w * 0.45, 4.0], [w - 3.0, 4.0]),
+                            ]),
+                            _ => {}
+                        }
+                    },
+                )
+                .w(px(14.0))
+                .h(px(14.0))
+                .into_any_element()
+            };
+            pill = pill
+                .child(toolbar_divider(grid, vertical))
+                .child(
+                    div()
+                        .px(px(4.0))
+                        .text_size(px(11.0))
+                        .text_color(text)
+                        .child("Direction"),
+                )
+                .child(
+                    chip(
+                        "wb-mm-dir-both",
+                        direction == MindMapRootDirection::Both,
+                        draw_mm_icon("wb-mm-dir-both-icon", "dir-both"),
+                    )
+                    .on_click(cx.listener(move |this, _ev, _window, cx| {
+                        this.set_mindmap_root_direction(root_id, MindMapRootDirection::Both, cx);
+                    })),
+                )
+                .child(
+                    chip(
+                        "wb-mm-dir-right",
+                        direction == MindMapRootDirection::Right,
+                        draw_mm_icon("wb-mm-dir-right-icon", "dir-right"),
+                    )
+                    .on_click(cx.listener(move |this, _ev, _window, cx| {
+                        this.set_mindmap_root_direction(root_id, MindMapRootDirection::Right, cx);
+                    })),
+                )
+                .child(
+                    chip(
+                        "wb-mm-dir-left",
+                        direction == MindMapRootDirection::Left,
+                        draw_mm_icon("wb-mm-dir-left-icon", "dir-left"),
+                    )
+                    .on_click(cx.listener(move |this, _ev, _window, cx| {
+                        this.set_mindmap_root_direction(root_id, MindMapRootDirection::Left, cx);
+                    })),
+                )
+                .child(toolbar_divider(grid, vertical))
+                .child(
+                    div()
+                        .px(px(4.0))
+                        .text_size(px(11.0))
+                        .text_color(text)
+                        .child("Connector"),
+                )
+                .child(
+                    chip(
+                        "wb-mm-line-straight",
+                        connector_style == MindMapConnectorStyle::Straight,
+                        draw_mm_icon("wb-mm-line-straight-icon", "line-straight"),
+                    )
+                    .on_click(cx.listener(move |this, _ev, _window, cx| {
+                        this.set_mindmap_connector_style(
+                            root_id,
+                            MindMapConnectorStyle::Straight,
+                            cx,
+                        );
+                    })),
+                )
+                .child(
+                    chip(
+                        "wb-mm-line-bezier",
+                        connector_style == MindMapConnectorStyle::Bezier,
+                        draw_mm_icon("wb-mm-line-bezier-icon", "line-bezier"),
+                    )
+                    .on_click(cx.listener(move |this, _ev, _window, cx| {
+                        this.set_mindmap_connector_style(
+                            root_id,
+                            MindMapConnectorStyle::Bezier,
+                            cx,
+                        );
+                    })),
+                )
+                .child(
+                    chip(
+                        "wb-mm-line-orthogonal",
+                        connector_style == MindMapConnectorStyle::Orthogonal,
+                        draw_mm_icon("wb-mm-line-orthogonal-icon", "line-orthogonal"),
+                    )
+                    .on_click(cx.listener(move |this, _ev, _window, cx| {
+                        this.set_mindmap_connector_style(
+                            root_id,
+                            MindMapConnectorStyle::Orthogonal,
+                            cx,
+                        );
+                    })),
+                );
+        } else {
+            pill = pill
+                .child(color_btn)
+                .child(width_btn)
+                .children(font_btn)
+                .children(format_btn)
+                .child(toolbar_divider(grid, vertical))
+                // tool categories (each opens a flyout of its tools)
+                .children(cats)
+                .child(templates_btn);
+        }
+        let pill = pill
             .child(toolbar_divider(grid, vertical))
             // actions
             .child(
@@ -5904,25 +9239,27 @@ impl Render for WhiteboardView {
         // group is open. Occluded like the main bar; picking a tool activates it
         // and closes the flyout (via `set_tool`), and a press elsewhere on the
         // canvas closes it (see `on_left_down`).
-        let flyout = open_group.map(|g| {
-            let mut row = div()
-                .flex()
-                .items_center()
-                .gap(px(2.0))
-                .p(px(3.0))
-                .rounded(px(9.0))
-                .bg(panel_strong)
-                .shadow_lg()
-                .occlude();
-            for &t in g.tools() {
-                row = row.child(
-                    tool_btn(t)
-                        .tooltip(self.tip(t.label()))
-                        .on_click(cx.listener(move |this, _ev, _w, cx| this.set_tool(t, cx))),
-                );
-            }
-            popover_anchor().child(row)
-        });
+        let flyout =
+            open_group.map(|g| {
+                let mut row = div()
+                    .flex()
+                    .items_center()
+                    .gap(px(2.0))
+                    .p(px(3.0))
+                    .rounded(px(9.0))
+                    .bg(panel_strong)
+                    .shadow_lg()
+                    .occlude();
+                for &t in g.tools() {
+                    row = row.child(tool_btn(t).tooltip(self.tip(t.label())).on_click(
+                        cx.listener(move |this, _ev, window, cx| {
+                            this.focus.focus(window, cx);
+                            this.set_tool(t, cx);
+                        }),
+                    ));
+                }
+                popover_anchor().child(row)
+            });
 
         // The toolbar's text-formatting fly-out (the same panel as the right-click
         // submenu), shown while the "Format" button is toggled on during a text edit.
@@ -6716,18 +10053,28 @@ impl Render for WhiteboardView {
             |_, _, _| {},
             move |bounds, _, window, _| {
                 if let Some(k) = &pending {
-                    paint_element(k, cam, bounds.origin, pending_ink, pending_fill, window);
+                    paint_element(
+                        k,
+                        None,
+                        cam,
+                        bounds.origin,
+                        pending_ink,
+                        pending_fill,
+                        window,
+                    );
                 }
                 if let Some(k) = &single_sel {
                     paint_selection(k, cam, bounds.origin, selection, window);
                 }
-                // Group: an enclosing box with resize corners, plus a shared
-                // rotate grip above it when the group can rotate.
-                if let Some((bb, can_rotate)) = group_sel {
-                    paint_box_outline(bb, cam, bounds.origin, selection, window);
+                if let Some((kind, active)) = &snap_target {
+                    paint_snap_points(kind, *active, cam, bounds.origin, selection, window);
+                }
+                // Group: resize handles without an enclosing blue frame, plus a
+                // shared rotate grip when the group can rotate.
+                if let Some((bb, _can_rotate)) = group_sel {
                     let tl = to_screen(bb.0, bb.1, cam, bounds.origin);
                     let br = to_screen(bb.2, bb.3, cam, bounds.origin);
-                    let m = SEL_PAD_PX;
+                    let m = 0.0;
                     let (x0, y0) = (f32::from(tl.x) - m, f32::from(tl.y) - m);
                     let (x1, y1) = (f32::from(br.x) + m, f32::from(br.y) + m);
                     // Four corners (proportional) plus four edge midpoints (per-axis
@@ -6745,34 +10092,43 @@ impl Render for WhiteboardView {
                     ] {
                         draw_handle(hx, hy, selection, window);
                     }
-                    if can_rotate {
-                        let (rx, ry) = rotate_handle_for_bbox(bb, cam, bounds.origin);
-                        draw_rotate_handle(rx, ry, selection, window);
-                    }
                 }
                 if let Some((a, b)) = marquee {
                     paint_marquee(a, b, cam, bounds.origin, selection, window);
                 }
+                paint_alignment_guides(alignment_guides, bounds, cam, selection, window);
             },
         )
         .absolute()
         .size_full();
 
-        div()
+        let root = div()
             .track_focus(&self.focus)
             .size_full()
             .relative()
             .overflow_hidden()
             .cursor(board_cursor)
             .child(board_layer)
+            .children(connector_buttons)
+            .children(rotate_button)
+            .child(
+                div()
+                    .absolute()
+                    .size_full()
+                    .child(WhiteboardInputElement::new(cx.entity())),
+            )
             .on_mouse_down(MouseButton::Left, cx.listener(Self::on_left_down))
             .on_mouse_up(MouseButton::Left, cx.listener(Self::on_left_up))
             .on_mouse_down(MouseButton::Right, cx.listener(Self::on_right_down))
             .on_mouse_down(MouseButton::Middle, cx.listener(Self::on_middle_down))
             .on_mouse_up(MouseButton::Middle, cx.listener(Self::on_middle_up))
-            .on_mouse_move(cx.listener(Self::on_move))
-            .on_scroll_wheel(cx.listener(Self::on_scroll))
-            .on_pinch(cx.listener(Self::on_pinch))
+            .on_mouse_move(cx.listener(Self::on_move));
+        let root = if accepts_wheel_input(self.read_only) {
+            root.on_scroll_wheel(cx.listener(Self::on_scroll))
+        } else {
+            root
+        };
+        root.on_pinch(cx.listener(Self::on_pinch))
             .on_key_down(cx.listener(Self::on_key))
             // Files dragged from the OS land as `ExternalPaths`; hand them to the
             // host (which imports any images) at the drop point.
@@ -6804,6 +10160,7 @@ impl Render for WhiteboardView {
                     .text_color(text)
                     .child(SharedString::from(format!("{:.0}%", cam.zoom * 100.0))),
             )
+            .into_any_element()
     }
 }
 
@@ -6812,12 +10169,101 @@ mod tests {
     use super::*;
 
     #[test]
+    fn text_layout_cache_reuses_outlines_until_content_changes() {
+        let font = Font::default();
+        let mut cache = HashMap::new();
+        let first = cached_text_layout(&mut cache, &font, 9, "hello", 16.0, None, &[]);
+        let reused = cached_text_layout(&mut cache, &font, 9, "hello", 16.0, None, &[]);
+        let changed = cached_text_layout(&mut cache, &font, 9, "hello!", 16.0, None, &[]);
+
+        assert!(Arc::ptr_eq(&first.segs, &reused.segs));
+        assert!(!Arc::ptr_eq(&first.segs, &changed.segs));
+    }
+
+    #[test]
+    fn shape_label_cache_survives_movement_and_invalidates_on_resize() {
+        let font = Font::default();
+        let mut cache = HashMap::new();
+        let kind = ElementKind::RoundRect(BoxGeom {
+            x: 10.0,
+            y: 20.0,
+            w: 180.0,
+            h: 60.0,
+            width: 2.0,
+            rotation: 0.0,
+        });
+        let first = cached_label_layout(
+            &mut cache,
+            &font,
+            3,
+            &kind,
+            10.0,
+            20.0,
+            180.0,
+            60.0,
+            "Node",
+            &[],
+        );
+        let moved = cached_label_layout(
+            &mut cache,
+            &font,
+            3,
+            &kind,
+            80.0,
+            90.0,
+            180.0,
+            60.0,
+            "Node",
+            &[],
+        );
+        let resized = cached_label_layout(
+            &mut cache,
+            &font,
+            3,
+            &kind,
+            80.0,
+            90.0,
+            240.0,
+            80.0,
+            "Node",
+            &[],
+        );
+
+        assert!(Arc::ptr_eq(&first.text.segs, &moved.text.segs));
+        assert!(!Arc::ptr_eq(&first.text.segs, &resized.text.segs));
+    }
+
+    #[test]
+    fn read_only_embed_does_not_accept_wheel_input() {
+        assert!(!accepts_wheel_input(true));
+        assert!(accepts_wheel_input(false));
+    }
+
+    #[test]
     fn empty_or_garbage_loads_a_blank_board() {
         for s in ["", "   ", "not json", "{}", r#"{"camera":{"zoom":0}}"#] {
             let scene = Scene::from_json(s);
             assert_eq!(scene.camera.zoom, 1.0, "input {s:?}");
             assert!(scene.elements.is_empty(), "input {s:?}");
         }
+    }
+
+    #[test]
+    fn ime_offsets_bridge_utf16_and_utf8() {
+        // Chinese uses one UTF-16 code unit but three UTF-8 bytes; emoji uses a
+        // surrogate pair. These are the offsets GPUI's native IME APIs exchange.
+        let text = "A中😀B";
+        let utf8_boundaries = [0, 1, 4, 8, 9];
+        let utf16_boundaries = [0, 1, 2, 4, 5];
+        for (utf8, utf16) in utf8_boundaries.into_iter().zip(utf16_boundaries) {
+            assert_eq!(WhiteboardView::utf8_to_utf16_in(text, utf8), utf16);
+            assert_eq!(WhiteboardView::utf16_to_utf8_in(text, utf16), utf8);
+        }
+
+        // Like the editor bridge, offsets inside a code point advance to the next
+        // valid boundary, so slicing the scene's UTF-8 string remains safe.
+        assert_eq!(WhiteboardView::utf8_to_utf16_in(text, 3), 2);
+        assert_eq!(WhiteboardView::utf16_to_utf8_in(text, 3), 8);
     }
 
     #[test]
@@ -6836,6 +10282,46 @@ mod tests {
     }
 
     #[test]
+    fn all_content_thumbnail_snapshot_uses_scene_bounds_without_mounting_view() {
+        let scene = Scene {
+            elements: vec![Element {
+                id: 1,
+                kind: ElementKind::Rect(BoxGeom {
+                    x: 10.0,
+                    y: 20.0,
+                    w: 100.0,
+                    h: 60.0,
+                    width: 2.0,
+                    rotation: 0.0,
+                }),
+                stroke: None,
+                fill: None,
+                label: None,
+                label_color: None,
+                styles: Vec::new(),
+                mindmap: None,
+            }],
+            ..Scene::default()
+        };
+
+        let snapshot = LocalThumbnailSnapshot::for_scene_all_content(scene, 320.0, 180.0);
+
+        assert_eq!(snapshot.spec.scene_bounds, Some([10.0, 20.0, 110.0, 80.0]));
+        assert_eq!(snapshot.spec.focus_bounds, [10.0, 20.0, 110.0, 80.0]);
+        assert!(snapshot.spec.camera.zoom > 0.0);
+    }
+
+    #[test]
+    fn empty_scene_still_builds_a_renderable_thumbnail_snapshot() {
+        let snapshot =
+            LocalThumbnailSnapshot::for_scene_all_content(Scene::default(), 320.0, 180.0);
+
+        assert_eq!(snapshot.spec.scene_bounds, None);
+        assert_eq!(snapshot.spec.focus_bounds, [0.0, 0.0, 320.0, 180.0]);
+        assert_eq!(snapshot.spec.camera.zoom, 1.0);
+    }
+
+    #[test]
     fn every_element_kind_round_trips_through_json() {
         let scene = Scene {
             camera: Camera::default(),
@@ -6851,6 +10337,7 @@ mod tests {
                     label: None,
                     label_color: None,
                     styles: Vec::new(),
+                    mindmap: None,
                 },
                 Element {
                     id: 2,
@@ -6867,6 +10354,7 @@ mod tests {
                     label: Some("hi".into()),
                     label_color: Some(0x112233ff),
                     styles: Vec::new(),
+                    mindmap: None,
                 },
                 Element {
                     id: 3,
@@ -6876,12 +10364,16 @@ mod tests {
                         x2: 2.0,
                         y2: 8.0,
                         width: 2.5,
+                        style: SegmentStyle::Solid,
+                        start_anchor: None,
+                        end_anchor: None,
                     }),
                     stroke: None,
                     fill: None,
                     label: None,
                     label_color: None,
                     styles: Vec::new(),
+                    mindmap: None,
                 },
             ],
         };
@@ -7073,6 +10565,7 @@ mod tests {
                     ..Default::default()
                 },
             }],
+            mindmap: None,
         };
         let back: Element = serde_json::from_str(&serde_json::to_string(&el).unwrap()).unwrap();
         assert_eq!(back.styles.len(), 1);
@@ -7115,6 +10608,9 @@ mod tests {
             x2: 10.0,
             y2: 4.0,
             width: 1.0,
+            style: SegmentStyle::Solid,
+            start_anchor: None,
+            end_anchor: None,
         });
         assert_eq!(bbox(&k), (0.0, 0.0, 10.0, 4.0));
         translate(&mut k, 5.0, -2.0);
@@ -7305,6 +10801,9 @@ mod tests {
             x2: 10.0,
             y2: 0.0,
             width: 1.0,
+            style: SegmentStyle::Solid,
+            start_anchor: None,
+            end_anchor: None,
         });
         rotate_element(&mut seg, 0.0, 0.0, FRAC_PI_2);
         match seg {
@@ -7457,6 +10956,7 @@ mod tests {
             label: None,
             label_color: None,
             styles: Vec::new(),
+            mindmap: None,
         };
         let json = serde_json::to_string(&elem).unwrap();
         assert!(json.contains("\"image\""), "{json}");
@@ -7506,6 +11006,7 @@ mod tests {
                 label: None,
                 label_color: None,
                 styles: Vec::new(),
+                mindmap: None,
             };
             let json = serde_json::to_string(&elem).unwrap();
             assert!(json.contains(tag), "{tag} not in json: {json}");

--- a/crates/gpui-whiteboard/src/render_perf.rs
+++ b/crates/gpui-whiteboard/src/render_perf.rs
@@ -1,0 +1,65 @@
+/// World-space viewport used to skip elements that cannot affect the current
+/// canvas. The screen-space margin keeps strokes, arrowheads, and handles from
+/// popping at an edge while panning.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WorldViewport {
+    left: f32,
+    top: f32,
+    right: f32,
+    bottom: f32,
+}
+
+impl WorldViewport {
+    pub(crate) fn from_canvas(
+        width_px: f32,
+        height_px: f32,
+        camera_x: f32,
+        camera_y: f32,
+        zoom: f32,
+        margin_px: f32,
+    ) -> Option<Self> {
+        if width_px <= 1.0 || height_px <= 1.0 || !zoom.is_finite() || zoom <= 0.0 {
+            return None;
+        }
+        let margin = margin_px.max(0.0) / zoom;
+        Some(Self {
+            left: camera_x - margin,
+            top: camera_y - margin,
+            right: camera_x + width_px / zoom + margin,
+            bottom: camera_y + height_px / zoom + margin,
+        })
+    }
+
+    pub(crate) fn intersects(self, bounds: (f32, f32, f32, f32)) -> bool {
+        let (left, top, right, bottom) = bounds;
+        right >= self.left && left <= self.right && bottom >= self.top && top <= self.bottom
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn viewport_converts_screen_margin_to_world_units() {
+        let viewport = WorldViewport::from_canvas(800.0, 600.0, 100.0, 200.0, 2.0, 80.0)
+            .expect("valid viewport");
+
+        assert!(viewport.intersects((60.0, 160.0, 61.0, 161.0)));
+        assert!(viewport.intersects((539.0, 539.0, 540.0, 540.0)));
+        assert!(!viewport.intersects((40.0, 100.0, 50.0, 150.0)));
+        assert!(!viewport.intersects((541.0, 541.0, 600.0, 600.0)));
+    }
+
+    #[test]
+    fn unknown_canvas_size_disables_culling_for_first_paint() {
+        assert_eq!(
+            WorldViewport::from_canvas(0.0, 600.0, 0.0, 0.0, 1.0, 80.0),
+            None
+        );
+        assert_eq!(
+            WorldViewport::from_canvas(800.0, 0.0, 0.0, 0.0, 1.0, 80.0),
+            None
+        );
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -414,6 +414,13 @@ struct PdfFieldEdit {
     _sub: gpui::Subscription,
 }
 
+/// (level, page title, rows) — the slash flyout's cached item list.
+type FlyoutCache = (
+    slash::SlashLevel,
+    String,
+    std::rc::Rc<Vec<slash::PaletteItem>>,
+);
+
 pub struct AppView {
     db: Db,
     /// This view's window, so it can tell whether a cross-window tab drag is
@@ -492,13 +499,7 @@ pub struct AppView {
     pub slash_scroll: ScrollHandle,
     pub slash_flyout_scroll: ScrollHandle,
     /// Flyout rows cache — see [`Self::slash_flyout_items`].
-    slash_flyout_cache: std::cell::RefCell<
-        Option<(
-            slash::SlashLevel,
-            String,
-            std::rc::Rc<Vec<slash::PaletteItem>>,
-        )>,
-    >,
+    slash_flyout_cache: std::cell::RefCell<Option<FlyoutCache>>,
 
     /// The Windows/Linux in-titlebar menu bar (File/Edit/View). macOS shows the
     /// native menu bar instead; this gives the other OSes visual parity.

--- a/src/app.rs
+++ b/src/app.rs
@@ -474,6 +474,19 @@ pub struct AppView {
     pub loaded_days: usize,
     pub day_editors: HashMap<String, DayEditor>,
     pub feed_scroll: ScrollHandle,
+    /// Tracks the feed column's children (one bounds per day section) WITHOUT
+    /// scrolling it — feeds the reader-day windowing: offscreen days render as
+    /// fixed-height spacers instead of full markdown trees.
+    pub feed_items: ScrollHandle,
+    /// Last-known full height of each day section (by day index), so a
+    /// windowed-out day's spacer preserves the scroll geometry.
+    pub feed_day_heights: std::cell::RefCell<HashMap<usize, Pixels>>,
+    /// Day indices rendered as spacers last frame — their (spacer) bounds must
+    /// not overwrite the real heights.
+    pub feed_spacers: std::cell::RefCell<std::collections::HashSet<usize>>,
+    /// Feed viewport width the heights were measured at; a resize reflows
+    /// every day, so the cache clears when it changes.
+    pub feed_heights_width: std::cell::Cell<Pixels>,
     /// Scroll offset of the open completion menu — persists across the per-keystroke rebuild
     /// of `Slash`, so the list doesn't snap back to the top as the user types or arrows.
     pub slash_scroll: ScrollHandle,
@@ -883,6 +896,10 @@ impl AppView {
             last_tabs_saved: String::new(),
             whiteboard_views: HashMap::new(),
             feed_scroll: ScrollHandle::new(),
+            feed_items: ScrollHandle::new(),
+            feed_day_heights: std::cell::RefCell::new(HashMap::new()),
+            feed_spacers: std::cell::RefCell::new(std::collections::HashSet::new()),
+            feed_heights_width: std::cell::Cell::new(gpui::px(0.)),
             slash_scroll: ScrollHandle::new(),
             slash_flyout_scroll: ScrollHandle::new(),
             app_menu_bar: gpui_component::menu::AppMenuBar::new(cx),

--- a/src/app.rs
+++ b/src/app.rs
@@ -491,6 +491,14 @@ pub struct AppView {
     /// of `Slash`, so the list doesn't snap back to the top as the user types or arrows.
     pub slash_scroll: ScrollHandle,
     pub slash_flyout_scroll: ScrollHandle,
+    /// Flyout rows cache — see [`Self::slash_flyout_items`].
+    slash_flyout_cache: std::cell::RefCell<
+        Option<(
+            slash::SlashLevel,
+            String,
+            std::rc::Rc<Vec<slash::PaletteItem>>,
+        )>,
+    >,
 
     /// The Windows/Linux in-titlebar menu bar (File/Edit/View). macOS shows the
     /// native menu bar instead; this gives the other OSes visual parity.
@@ -902,6 +910,7 @@ impl AppView {
             feed_heights_width: std::cell::Cell::new(gpui::px(0.)),
             slash_scroll: ScrollHandle::new(),
             slash_flyout_scroll: ScrollHandle::new(),
+            slash_flyout_cache: std::cell::RefCell::new(None),
             app_menu_bar: gpui_component::menu::AppMenuBar::new(cx),
             page_editor: None,
             pages: Vec::new(),
@@ -2839,16 +2848,26 @@ impl AppView {
     }
 
     /// The open flyout's rows (unfiltered — categories only exist while the
-    /// query is empty). Empty unless the flyout is shown.
-    pub fn slash_flyout_items(&self) -> Vec<slash::PaletteItem> {
+    /// query is empty). Empty unless the flyout is shown. Cached per
+    /// (level, page title): the render loop and the arrow-key handlers all
+    /// read this every frame/keypress for a static list.
+    pub fn slash_flyout_items(&self) -> std::rc::Rc<Vec<slash::PaletteItem>> {
         let Some(level) = self.slash_flyout_level() else {
-            return Vec::new();
+            return std::rc::Rc::new(Vec::new());
         };
         let Some(target) = self.slash.as_ref().map(|s| s.target.clone()) else {
-            return Vec::new();
+            return std::rc::Rc::new(Vec::new());
         };
         let title = self.slash_title(&target);
-        slash::build_slash_items(level, "", &self.templates, &title)
+        if let Some((l, t, items)) = self.slash_flyout_cache.borrow().as_ref()
+            && *l == level
+            && *t == title
+        {
+            return items.clone();
+        }
+        let items = std::rc::Rc::new(slash::build_slash_items(level, "", &self.templates, &title));
+        *self.slash_flyout_cache.borrow_mut() = Some((level, title, items.clone()));
+        items
     }
 
     /// Keep the flyout's highlighted row inside its viewport (the main list's
@@ -2914,7 +2933,7 @@ impl AppView {
             .slash
             .as_ref()
             .and_then(|s| s.flyout)
-            .and_then(|fi| self.slash_flyout_items().into_iter().nth(fi));
+            .and_then(|fi| self.slash_flyout_items().get(fi).cloned());
         let act = {
             let Some(s) = self.slash.as_ref() else { return };
             let item = match &flyout_item {

--- a/src/app.rs
+++ b/src/app.rs
@@ -477,6 +477,7 @@ pub struct AppView {
     /// Scroll offset of the open completion menu — persists across the per-keystroke rebuild
     /// of `Slash`, so the list doesn't snap back to the top as the user types or arrows.
     pub slash_scroll: ScrollHandle,
+    pub slash_flyout_scroll: ScrollHandle,
 
     /// The Windows/Linux in-titlebar menu bar (File/Edit/View). macOS shows the
     /// native menu bar instead; this gives the other OSes visual parity.
@@ -883,6 +884,7 @@ impl AppView {
             whiteboard_views: HashMap::new(),
             feed_scroll: ScrollHandle::new(),
             slash_scroll: ScrollHandle::new(),
+            slash_flyout_scroll: ScrollHandle::new(),
             app_menu_bar: gpui_component::menu::AppMenuBar::new(cx),
             page_editor: None,
             pages: Vec::new(),
@@ -2748,12 +2750,13 @@ impl AppView {
         self.slash = Some(Slash {
             target,
             trigger,
-            query,
             start,
             caret,
             selected,
             level,
             items,
+            flyout_shown: false,
+            flyout: None,
         });
         // Keep the highlighted row visible as the list is filtered/rebuilt.
         self.scroll_slash_into_view();
@@ -2767,17 +2770,67 @@ impl AppView {
         let Some(s) = self.slash.as_ref() else {
             return;
         };
-        let top = s.selected as f32 * ui::slash_menu::ITEM_H;
-        let bot = top + ui::slash_menu::ITEM_H;
+        let item_h = ui::slash_menu::item_h(s.trigger);
+        let view_h = ui::slash_menu::view_h(s.trigger);
+        let top = s.selected as f32 * item_h;
+        let bot = top + item_h;
         let cur = -f32::from(self.slash_scroll.offset().y);
         let new = if top < cur {
             top
-        } else if bot > cur + ui::slash_menu::VIEW_H {
-            bot - ui::slash_menu::VIEW_H
+        } else if bot > cur + view_h {
+            bot - view_h
         } else {
             return;
         };
         self.slash_scroll.set_offset(gpui::point(px(0.0), px(-new)));
+    }
+
+    /// The category level the open flyout shows: the selected main-list row,
+    /// when it's a category AND the flyout has been opened (`flyout_shown`).
+    fn slash_flyout_level(&self) -> Option<SlashLevel> {
+        let s = self.slash.as_ref()?;
+        if !s.flyout_shown {
+            return None;
+        }
+        match s.items.get(s.selected)?.kind {
+            ItemKind::Category(level) => Some(level),
+            _ => None,
+        }
+    }
+
+    /// The open flyout's rows (unfiltered — categories only exist while the
+    /// query is empty). Empty unless the flyout is shown.
+    pub fn slash_flyout_items(&self) -> Vec<slash::PaletteItem> {
+        let Some(level) = self.slash_flyout_level() else {
+            return Vec::new();
+        };
+        let Some(target) = self.slash.as_ref().map(|s| s.target.clone()) else {
+            return Vec::new();
+        };
+        let title = self.slash_title(&target);
+        slash::build_slash_items(level, "", &self.templates, &title)
+    }
+
+    /// Keep the flyout's highlighted row inside its viewport (the main list's
+    /// scroll-into-view, against the flyout's own handle).
+    fn scroll_flyout_into_view(&self) {
+        let Some(fi) = self.slash.as_ref().and_then(|s| s.flyout) else {
+            return;
+        };
+        let item_h = ui::slash_menu::item_h(Trigger::Slash);
+        let view_h = ui::slash_menu::view_h(Trigger::Slash);
+        let top = fi as f32 * item_h;
+        let bot = top + item_h;
+        let cur = -f32::from(self.slash_flyout_scroll.offset().y);
+        let new = if top < cur {
+            top
+        } else if bot > cur + view_h {
+            bot - view_h
+        } else {
+            return;
+        };
+        self.slash_flyout_scroll
+            .set_offset(gpui::point(px(0.0), px(-new)));
     }
 
     /// Debounced spell-check for a body editor: re-run after a short idle so we
@@ -2810,20 +2863,32 @@ impl AppView {
     /// Confirm the selected entry: open a category submenu, or insert.
     fn confirm_slash(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         enum Act {
-            Enter(SlashLevel),
+            Enter,
             Insert(String, usize),
             OpenPicker(SlashTarget, usize, gpui::Bounds<gpui::Pixels>),
             Property(SlashTarget),
             Game,
         }
+        // With the flyout focused, Enter accepts ITS highlighted row.
+        let flyout_item = self
+            .slash
+            .as_ref()
+            .and_then(|s| s.flyout)
+            .and_then(|fi| self.slash_flyout_items().into_iter().nth(fi));
         let act = {
             let Some(s) = self.slash.as_ref() else { return };
-            let Some(item) = s.items.get(s.selected) else {
-                cx.notify();
-                return;
+            let item = match &flyout_item {
+                Some(it) => it,
+                None => match s.items.get(s.selected) {
+                    Some(it) => it,
+                    None => {
+                        cx.notify();
+                        return;
+                    }
+                },
             };
             match &item.kind {
-                ItemKind::Category(level) => Act::Enter(*level),
+                ItemKind::Category(_) => Act::Enter,
                 ItemKind::Insert { snippet, caret } => Act::Insert(snippet.clone(), *caret),
                 ItemKind::TablePicker => Act::OpenPicker(s.target.clone(), s.start, s.caret),
                 ItemKind::Property => Act::Property(s.target.clone()),
@@ -2831,7 +2896,18 @@ impl AppView {
             }
         };
         match act {
-            Act::Enter(level) => self.enter_slash_category(level, cx),
+            // A category doesn't switch the list — its flyout opens beside it
+            // (Cditor-style); Enter shows it (if not already) and moves the
+            // keyboard focus into it.
+            Act::Enter => {
+                if let Some(s) = self.slash.as_mut() {
+                    s.flyout_shown = true;
+                    s.flyout = Some(0);
+                    self.slash_flyout_scroll
+                        .set_offset(gpui::point(px(0.0), px(0.0)));
+                    cx.notify();
+                }
+            }
             Act::Game => {
                 // Remove the typed `/play`, then slip into the game.
                 self.insert_slash(String::new(), 0, window, cx);
@@ -2863,16 +2939,86 @@ impl AppView {
         }
     }
 
+    /// Arrow-step the open menu: within the flyout when it has focus, else the
+    /// main list. Propagates with no menu open (normal caret movement).
+    fn slash_step(&mut self, dir: i32, cx: &mut Context<Self>) {
+        let flyout_len = self
+            .slash
+            .as_ref()
+            .and_then(|s| s.flyout)
+            .map(|_| self.slash_flyout_items().len());
+        let Some(s) = self.slash.as_mut() else {
+            cx.propagate();
+            return;
+        };
+        match (s.flyout, flyout_len) {
+            (Some(fi), Some(n)) if n > 0 => {
+                let n = n as i32;
+                s.flyout = Some(((fi as i32 + dir).rem_euclid(n)) as usize);
+                self.scroll_flyout_into_view();
+            }
+            _ => {
+                let n = s.items.len().max(1) as i32;
+                s.selected = ((s.selected as i32 + dir).rem_euclid(n)) as usize;
+                // Arrowing onto a category previews its flyout beside the list.
+                s.flyout_shown = matches!(
+                    s.items.get(s.selected).map(|it| &it.kind),
+                    Some(ItemKind::Category(_))
+                );
+                s.flyout = None;
+                self.scroll_slash_into_view();
+            }
+        }
+        cx.notify();
+    }
+
     /// Hovering a slash-menu item moves the selection to it, so the highlighted
-    /// row is the one both a click and Enter accept.
+    /// row is the one both a click and Enter accept. Hovering a category shows
+    /// its flyout; hovering anything else hides it.
     pub fn slash_hover(&mut self, i: usize, cx: &mut Context<Self>) {
         if let Some(s) = self.slash.as_mut()
             && i < s.items.len()
-            && s.selected != i
         {
+            let is_category = matches!(
+                s.items.get(i).map(|it| &it.kind),
+                Some(ItemKind::Category(_))
+            );
+            if s.selected == i && s.flyout.is_none() && s.flyout_shown == is_category {
+                return;
+            }
             s.selected = i;
+            s.flyout_shown = is_category;
+            s.flyout = None;
+            self.slash_flyout_scroll
+                .set_offset(gpui::point(px(0.0), px(0.0)));
             cx.notify();
         }
+    }
+
+    /// Close the slash menu (a click outside it, from the overlay).
+    pub fn close_slash_menu(&mut self, cx: &mut Context<Self>) {
+        if self.slash.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    /// Hovering a flyout row highlights it (the row a click / Enter accepts).
+    pub fn slash_flyout_hover(&mut self, i: usize, cx: &mut Context<Self>) {
+        if let Some(s) = self.slash.as_mut()
+            && s.flyout != Some(i)
+        {
+            s.flyout = Some(i);
+            cx.notify();
+        }
+    }
+
+    /// Click a flyout row: highlight it, then accept like Enter.
+    pub fn click_slash_flyout(&mut self, i: usize, window: &mut Window, cx: &mut Context<Self>) {
+        match self.slash.as_mut() {
+            Some(s) => s.flyout = Some(i),
+            None => return,
+        }
+        self.confirm_slash(window, cx);
     }
 
     /// Click a slash-menu item: select it, then accept like Enter. Driven from the
@@ -2884,30 +3030,6 @@ impl AppView {
             _ => return,
         }
         self.confirm_slash(window, cx);
-    }
-
-    /// Switch the open menu to a level (root or a submenu) and rebuild it.
-    fn enter_slash_category(&mut self, level: SlashLevel, cx: &mut Context<Self>) {
-        let Some((query, target, start, caret)) = self
-            .slash
-            .as_ref()
-            .map(|s| (s.query.clone(), s.target.clone(), s.start, s.caret))
-        else {
-            return;
-        };
-        let title = self.slash_title(&target);
-        let items = slash::build_slash_items(level, &query, &self.templates, &title);
-        self.slash = Some(Slash {
-            target,
-            trigger: Trigger::Slash,
-            query,
-            start,
-            caret,
-            selected: 0,
-            level,
-            items,
-        });
-        cx.notify();
     }
 
     /// `InsertTab` handler: insert two spaces at the cursor of the focused
@@ -8516,12 +8638,61 @@ impl Render for AppView {
         }
 
         let slash_scroll = self.slash_scroll.clone();
+        let flyout_scroll = self.slash_flyout_scroll.clone();
+        let flyout_items = self.slash_flyout_items();
+        let win_h = f32::from(window.viewport_size().height);
+        let inset = window.client_inset().map_or(0.0, f32::from);
         let overlay = self.slash.as_ref().map(|s| {
+            // A transparent full-area backdrop under the menu catches clicks
+            // outside it (→ close). The menu paints on top and swallows its own
+            // clicks. The anchored element is only the main panel (the flyout
+            // floats beside it as an absolute child, so it doesn't change this
+            // size) — stable height, so `snap_to_window` places it cleanly below
+            // the caret without jumping when the flyout shows/hides.
+            //
+            // The flyout is an absolute child pinned to the main panel's top, so
+            // it can run off the window bottom. Replicate where `snap_to_window`
+            // lands the main panel, then shift the flyout up by whatever it would
+            // overflow (clamped so its top stays on-screen).
+            let caret_bottom = f32::from(s.caret.origin.y) + f32::from(s.caret.size.height);
+            let main_h = ui::slash_menu::panel_height(s.trigger, s.items.len());
+            let main_top = if caret_bottom + main_h > win_h - inset {
+                (win_h - inset - main_h).max(inset)
+            } else {
+                caret_bottom
+            };
+            let flyout_top_offset = if flyout_items.is_empty() {
+                0.0
+            } else {
+                let fly_h = ui::slash_menu::panel_height(Trigger::Slash, flyout_items.len());
+                if main_top + fly_h <= win_h - inset {
+                    0.0
+                } else {
+                    ((win_h - inset - fly_h) - main_top).max(inset - main_top)
+                }
+            };
             gpui::deferred(
-                gpui::anchored()
-                    .position(s.caret.bottom_left())
-                    .snap_to_window()
-                    .child(ui::slash_menu::render(s, &slash_scroll, cx)),
+                div()
+                    .absolute()
+                    .inset_0()
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this: &mut AppView, _: &MouseDownEvent, _, cx| {
+                            this.close_slash_menu(cx);
+                        }),
+                    )
+                    .child(
+                        gpui::anchored()
+                            .position(s.caret.bottom_left())
+                            .snap_to_window()
+                            .child(ui::slash_menu::render(
+                                s,
+                                &slash_scroll,
+                                (&flyout_items, &flyout_scroll),
+                                flyout_top_offset,
+                                cx,
+                            )),
+                    ),
             )
             .into_any_element()
         });
@@ -8950,34 +9121,10 @@ impl Render for AppView {
             // Slash-menu keys (gated: act only while the menu is open, else
             // let the editor handle the key normally).
             .on_action(cx.listener(|this: &mut AppView, _: &SlashUp, _, cx| {
-                let moved = if let Some(s) = this.slash.as_mut() {
-                    let n = s.items.len().max(1);
-                    s.selected = (s.selected + n - 1) % n;
-                    true
-                } else {
-                    false
-                };
-                if moved {
-                    this.scroll_slash_into_view();
-                    cx.notify();
-                } else {
-                    cx.propagate();
-                }
+                this.slash_step(-1, cx);
             }))
             .on_action(cx.listener(|this: &mut AppView, _: &SlashDown, _, cx| {
-                let moved = if let Some(s) = this.slash.as_mut() {
-                    let n = s.items.len().max(1);
-                    s.selected = (s.selected + 1) % n;
-                    true
-                } else {
-                    false
-                };
-                if moved {
-                    this.scroll_slash_into_view();
-                    cx.notify();
-                } else {
-                    cx.propagate();
-                }
+                this.slash_step(1, cx);
             }))
             .on_action(
                 cx.listener(|this: &mut AppView, _: &SlashConfirm, window, cx| {
@@ -8995,12 +9142,16 @@ impl Render for AppView {
                     // the focused editor swaps the page/day back to its rendered view via
                     // the editor's Blur handler (same path as clicking away). Otherwise it
                     // propagates (so dialogs etc. still get Esc).
-                    match this.slash.as_ref().map(|s| s.level) {
-                        Some(SlashLevel::Root) => {
+                    match this.slash.as_mut() {
+                        // The flyout takes the first Esc (back to the main list).
+                        Some(s) if s.flyout.is_some() => {
+                            s.flyout = None;
+                            cx.notify();
+                        }
+                        Some(_) => {
                             this.slash = None;
                             cx.notify();
                         }
-                        Some(_) => this.enter_slash_category(SlashLevel::Root, cx),
                         // A seated PDF form field drops without writing.
                         None if this.pdf_field_edit.is_some() => this.cancel_pdf_field_edit(cx),
                         // An open find bar takes Esc first (closes it).

--- a/src/app.rs
+++ b/src/app.rs
@@ -845,7 +845,7 @@ impl AppView {
             active: 0,
             searching: false,
             tab_scroll: ScrollHandle::new(),
-            mode: theme::Mode::Dark,
+            mode: theme::Mode::Auto,
             system_dark: true,
             settings_window: None,
             skins: skins::builtin_skins(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1061,6 +1061,18 @@ impl AppView {
             window,
             cx,
         );
+        // Scroll anchoring: an async block render (math/mermaid/image)
+        // finishing ABOVE the viewport would shift what's being read — the
+        // editor hands us the height delta and the feed scroll absorbs it.
+        {
+            let scroll = self.feed_scroll.clone();
+            state.update(cx, |e, _| {
+                e.set_scroll_compensator(move |delta, _, _| {
+                    let off = scroll.offset();
+                    scroll.set_offset(gpui::point(off.x, off.y - delta));
+                });
+            });
+        }
         self.ensure_content_images(&content, cx);
         self.ensure_content_mermaid(&content, cx);
         self.ensure_content_math(&content, cx);
@@ -2394,6 +2406,17 @@ impl AppView {
             window,
             cx,
         );
+        // Scroll anchoring, like the feed's (see load_feed): async renders
+        // above the viewport adjust the page scroll instead of jumping it.
+        {
+            let scroll = self.page_scroll.clone();
+            state.update(cx, |e, _| {
+                e.set_scroll_compensator(move |delta, _, _| {
+                    let off = scroll.offset();
+                    scroll.set_offset(gpui::point(off.x, off.y - delta));
+                });
+            });
+        }
         self.ensure_content_images(&page.content, cx);
         self.ensure_content_mermaid(&page.content, cx);
         self.ensure_content_math(&page.content, cx);

--- a/src/app.rs
+++ b/src/app.rs
@@ -9510,6 +9510,13 @@ fn make_editor(
         editor.set_block_math_em(crate::math::FONT_SIZE);
         // Tab / Shift+Tab indent by the configured number of spaces per level.
         editor.set_tab_indent(list_indent);
+        // The code card's language picker offers the compiled grammar set.
+        editor.set_code_languages(
+            crate::highlight::LANGUAGES
+                .iter()
+                .map(|l| gpui::SharedString::from(*l))
+                .collect(),
+        );
         editor
     });
     // Live-preview markdown styling when WYSIWYG is on — mirrors the rendered

--- a/src/app.rs
+++ b/src/app.rs
@@ -9016,24 +9016,37 @@ impl Render for AppView {
         let ctx_menu_overlay = self.ctx_menu.as_ref().map(|menu| {
             // Action ids: 0..=2 formula copy/export, 3 day/page Edit, 4..=6 align L/C/R (only
             // while editing the formula, where the in-line editor can re-justify it live).
-            let items: Vec<(&str, usize)> = match &menu.kind {
+            // `(label, icon face, action id)` — icons match the popup menus'.
+            let items: Vec<(&str, &str, usize)> = match &menu.kind {
                 CtxKind::Formula { alignable, .. } => {
-                    let mut v = vec![("Copy LaTeX", 0), ("Export PNG…", 1), ("Export SVG…", 2)];
+                    let mut v = vec![
+                        ("Copy LaTeX", "copy", 0),
+                        ("Export PNG…", "file-down", 1),
+                        ("Export SVG…", "file-down", 2),
+                    ];
                     if *alignable {
-                        v.extend([("Align left", 4), ("Align center", 5), ("Align right", 6)]);
+                        v.extend([
+                            ("Align left", "align-left", 4),
+                            ("Align center", "align-center", 5),
+                            ("Align right", "align-right", 6),
+                        ]);
                     }
                     v
                 }
-                CtxKind::Edit(_) => vec![("Edit", 3)],
+                CtxKind::Edit(_) => vec![("Edit", "pencil", 3)],
             };
             let mut rows = div().flex().flex_col().py(px(4.0));
-            for (label, action_id) in items {
+            for (label, face, action_id) in items {
                 rows = rows.child(
                     div()
                         .id(("ctx-menu-row", action_id))
                         .px(px(10.0))
                         .py(px(3.0))
                         .text_size(px(13.0))
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap_2()
                         .cursor_pointer()
                         .hover(|s| s.bg(theme::accent_tint()))
                         .on_mouse_down(
@@ -9051,6 +9064,11 @@ impl Render for AppView {
                                 }
                             }),
                         )
+                        .child(
+                            ui::menu_icon(face)
+                                .size_4()
+                                .text_color(theme::text_secondary()),
+                        )
                         .child(label),
                 );
             }
@@ -9061,11 +9079,12 @@ impl Render for AppView {
                     .child(
                         div()
                             .occlude()
-                            .min_w(px(140.0))
+                            .min_w(px(150.0))
                             .bg(theme::bg_sidebar())
                             .border_1()
                             .border_color(theme::border_subtle())
                             .rounded(px(8.0))
+                            .shadow_md()
                             .overflow_hidden()
                             .text_color(theme::text_primary())
                             .on_mouse_down_out(cx.listener(|this, _: &MouseDownEvent, _, cx| {

--- a/src/export_md.rs
+++ b/src/export_md.rs
@@ -698,7 +698,8 @@ mod tests {
     #[test]
     fn boards_export_as_json_canvas() {
         use gpui_whiteboard::{
-            BoxGeom, Element, ElementKind, EmbedGeom, ImageGeom, Scene, SegGeom, Stroke, TextGeom,
+            BoxGeom, Element, ElementKind, EmbedGeom, ImageGeom, Scene, SegGeom, SegmentStyle,
+            Stroke, TextGeom,
         };
         let el = |id: u64, kind: ElementKind| Element {
             id,
@@ -708,6 +709,17 @@ mod tests {
             label: None,
             label_color: None,
             styles: Vec::new(),
+            mindmap: None,
+        };
+        let seg = |x1, y1, x2, y2| SegGeom {
+            x1,
+            y1,
+            x2,
+            y2,
+            width: 2.0,
+            style: SegmentStyle::Solid,
+            start_anchor: None,
+            end_anchor: None,
         };
         let mut labeled = el(
             1,
@@ -748,27 +760,9 @@ mod tests {
                     }),
                 ),
                 // Arrow from the box's right edge to the card's left edge.
-                el(
-                    4,
-                    ElementKind::Arrow(SegGeom {
-                        x1: 205.0,
-                        y1: 50.0,
-                        x2: 395.0,
-                        y2: 50.0,
-                        width: 2.0,
-                    }),
-                ),
+                el(4, ElementKind::Arrow(seg(205.0, 50.0, 395.0, 50.0))),
                 // A line into empty space: unanchored, skipped + counted.
-                el(
-                    5,
-                    ElementKind::Line(SegGeom {
-                        x1: 1000.0,
-                        y1: 1000.0,
-                        x2: 1200.0,
-                        y2: 1000.0,
-                        width: 2.0,
-                    }),
-                ),
+                el(5, ElementKind::Line(seg(1000.0, 1000.0, 1200.0, 1000.0))),
                 // Freehand: no canvas equivalent.
                 el(
                     6,

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -18,6 +18,38 @@ use gpui_component::highlighter::{HighlightTheme, SyntaxHighlighter};
 
 type Styles = Rc<Vec<(Range<usize>, HighlightStyle)>>;
 
+/// The languages the editor's code-block picker offers: `text` (no
+/// highlighting), `mermaid` (renders as a diagram), and every grammar compiled
+/// in (the tree-sitter feature list on the `gpui-component` dependency, plus
+/// json in its base crate). Keep in step with Cargo.toml when features change.
+pub const LANGUAGES: &[&str] = &[
+    "text",
+    "mermaid",
+    "bash",
+    "c",
+    "cpp",
+    "csharp",
+    "css",
+    "diff",
+    "go",
+    "html",
+    "java",
+    "javascript",
+    "json",
+    "kotlin",
+    "lua",
+    "php",
+    "python",
+    "ruby",
+    "rust",
+    "sql",
+    "swift",
+    "toml",
+    "tsx",
+    "typescript",
+    "yaml",
+];
+
 /// Cache of highlighted blocks, keyed by `(language, code hash)`. Styles bake
 /// the active theme's colors in, so a theme switch clears it (`set_theme`).
 #[derive(Default)]

--- a/src/import/logseq.rs
+++ b/src/import/logseq.rs
@@ -30,7 +30,9 @@ use std::path::{Path, PathBuf};
 
 use base64::Engine as _;
 
-use gpui_whiteboard::{BoxGeom, Element, ElementKind, ImageGeom, Scene, SegGeom, Stroke, TextGeom};
+use gpui_whiteboard::{
+    BoxGeom, Element, ElementKind, ImageGeom, Scene, SegGeom, SegmentStyle, Stroke, TextGeom,
+};
 
 use super::edn::{self, Edn};
 use super::{AssetBytes, AssetCopy, ImportBundle, ImportDay, ImportPage, ImportWhiteboard};
@@ -346,6 +348,7 @@ fn image_element(
         label: None,
         label_color: None,
         styles: Vec::new(),
+        mindmap: None,
     }]
 }
 
@@ -434,6 +437,7 @@ fn shape_to_element(shape: &Edn, id: u64) -> Vec<Element> {
         label: None,
         label_color: None,
         styles: Vec::new(),
+        mindmap: None,
     }];
     // A box/ellipse keeps its text in `:label` → the shape's native label, which
     // the renderer centers and auto-shrinks to fit inside the outline.
@@ -489,6 +493,9 @@ fn line_or_arrow(shape: &Edn, x1: f32, y1: f32, x2: f32, y2: f32, width: f32) ->
         x2,
         y2,
         width,
+        style: SegmentStyle::Solid,
+        start_anchor: None,
+        end_anchor: None,
     };
     if arrow_at("end") {
         ElementKind::Arrow(seg(x1, y1, x2, y2))

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -415,6 +415,7 @@ mod tests {
                 label: None,
                 label_color: None,
                 styles: Vec::new(),
+                mindmap: None,
             }],
         };
         let bundle = ImportBundle {

--- a/src/import/obsidian.rs
+++ b/src/import/obsidian.rs
@@ -37,7 +37,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use gpui_whiteboard::{
-    BoxGeom, Element, ElementKind, EmbedGeom, ImageGeom, Scene, SegGeom, TextGeom,
+    BoxGeom, Element, ElementKind, EmbedGeom, ImageGeom, Scene, SegGeom, SegmentStyle, TextGeom,
 };
 
 use super::{AssetCopy, ImportBundle, ImportDay, ImportPage};
@@ -689,6 +689,7 @@ fn convert_canvas(json: &str, title: &str, conv: &mut Converter) -> Option<Strin
             label,
             label_color: color,
             styles: Vec::new(),
+            mindmap: None,
         };
         match n.kind.as_str() {
             "text" => {
@@ -716,6 +717,7 @@ fn convert_canvas(json: &str, title: &str, conv: &mut Converter) -> Option<Strin
                             label: None,
                             label_color: None,
                             styles: Vec::new(),
+                            mindmap: None,
                         });
                     } else {
                         conv.warnings
@@ -741,6 +743,7 @@ fn convert_canvas(json: &str, title: &str, conv: &mut Converter) -> Option<Strin
                         label: None,
                         label_color: None,
                         styles: Vec::new(),
+                        mindmap: None,
                     });
                 } else {
                     // PDFs, nested .canvas boards, audio, … — a named box.
@@ -761,6 +764,7 @@ fn convert_canvas(json: &str, title: &str, conv: &mut Converter) -> Option<Strin
                     label: n.label.clone(),
                     label_color: color,
                     styles: Vec::new(),
+                    mindmap: None,
                 });
             }
             other => {
@@ -794,6 +798,9 @@ fn convert_canvas(json: &str, title: &str, conv: &mut Converter) -> Option<Strin
                 x2,
                 y2,
                 width: 2.0,
+                style: SegmentStyle::Solid,
+                start_anchor: None,
+                end_anchor: None,
             }
         } else {
             SegGeom {
@@ -802,6 +809,9 @@ fn convert_canvas(json: &str, title: &str, conv: &mut Converter) -> Option<Strin
                 x2: x1,
                 y2: y1,
                 width: 2.0,
+                style: SegmentStyle::Solid,
+                start_anchor: None,
+                end_anchor: None,
             }
         };
         let kind = if to_arrow || from_arrow {
@@ -817,6 +827,7 @@ fn convert_canvas(json: &str, title: &str, conv: &mut Converter) -> Option<Strin
             label: None,
             label_color: None,
             styles: Vec::new(),
+            mindmap: None,
         });
         if let Some(label) = e.label.clone().filter(|l| !l.trim().is_empty()) {
             edges.push(Element {
@@ -835,6 +846,7 @@ fn convert_canvas(json: &str, title: &str, conv: &mut Converter) -> Option<Strin
                 label: None,
                 label_color: None,
                 styles: Vec::new(),
+                mindmap: None,
             });
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,14 @@ const LAYOUT_LIST: &[u8] = include_bytes!("../assets/icons/layout-list.svg");
 const WAYPOINTS: &[u8] = include_bytes!("../assets/icons/waypoints.svg");
 // Notebook-switcher row buttons (rename).
 const PENCIL: &[u8] = include_bytes!("../assets/icons/pencil.svg");
+// Context-menu row icons (the shared page menu + tab menu, Cditor-style).
+const TRASH: &[u8] = include_bytes!("../assets/icons/trash-2.svg");
+const APP_WINDOW: &[u8] = include_bytes!("../assets/icons/app-window.svg");
+const FILE_TEXT: &[u8] = include_bytes!("../assets/icons/file-text.svg");
+const FILE_DOWN: &[u8] = include_bytes!("../assets/icons/file-down.svg");
+// Formula context-menu alignment rows (align-left ships as a property icon).
+const ALIGN_CENTER: &[u8] = include_bytes!("../assets/icons/align-center.svg");
+const ALIGN_RIGHT: &[u8] = include_bytes!("../assets/icons/align-right.svg");
 // Property-key icons: ONE list drives both the picker's choices and the
 // embedded bytes, so a face offered on the Properties page can never be
 // missing from a release build (the on-disk lucide set is dev-only — a
@@ -190,6 +198,12 @@ impl AssetSource for Assets {
             "icons/layout-list.svg" => Some(LAYOUT_LIST),
             "icons/waypoints.svg" => Some(WAYPOINTS),
             "icons/pencil.svg" => Some(PENCIL),
+            "icons/trash-2.svg" => Some(TRASH),
+            "icons/app-window.svg" => Some(APP_WINDOW),
+            "icons/file-text.svg" => Some(FILE_TEXT),
+            "icons/file-down.svg" => Some(FILE_DOWN),
+            "icons/align-center.svg" => Some(ALIGN_CENTER),
+            "icons/align-right.svg" => Some(ALIGN_RIGHT),
             _ => property_icon_bytes(path),
         };
         if let Some(bytes) = custom {

--- a/src/slash.rs
+++ b/src/slash.rs
@@ -73,7 +73,6 @@ pub enum SlashTarget {
 pub struct Slash {
     pub target: SlashTarget,
     pub trigger: Trigger,
-    pub query: String,
     /// Byte offset of the `/` in the editor text.
     pub start: usize,
     /// Caret bounds (window space) used to anchor the popup.
@@ -83,6 +82,13 @@ pub struct Slash {
     pub level: SlashLevel,
     /// Filtered entries for the current level + query.
     pub items: Vec<PaletteItem>,
+    /// Whether the category flyout panel is shown. Off on a fresh `/` (so the
+    /// submenu doesn't pop the instant you type) — turned on only when the user
+    /// deliberately targets a category (hover, arrow onto it, or Enter).
+    pub flyout_shown: bool,
+    /// Keyboard focus inside the flyout (`None` = the main list has focus);
+    /// tracks which flyout row is highlighted once `flyout_shown`.
+    pub flyout: Option<usize>,
 }
 
 /// Detect a completion trigger ending at the caret: the trigger, the byte

--- a/src/slash.rs
+++ b/src/slash.rs
@@ -37,6 +37,7 @@ pub enum Trigger {
 }
 
 /// What a palette entry does when chosen.
+#[derive(Clone)]
 pub enum ItemKind {
     /// Open a submenu (rendered with a `›`).
     Category(SlashLevel),
@@ -51,6 +52,7 @@ pub enum ItemKind {
 }
 
 /// One entry in the open palette.
+#[derive(Clone)]
 pub struct PaletteItem {
     pub label: String,
     pub kind: ItemKind,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -352,6 +352,9 @@ pub fn editor_syntax_style() -> gpui_editor::SyntaxStyle {
         popover_fg: p.text_primary,
         popover_hover: p.accent_tint,
         popover_divider: p.divider,
+        // Destructive menu rows (Delete row/column/table). A Radix-red that
+        // reads on both light and dark surfaces.
+        popover_danger: gpui::rgb(0xE5484D).into(),
         mono: gpui::font(mono_font()),
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -361,12 +361,13 @@ pub fn editor_syntax_style() -> gpui_editor::SyntaxStyle {
 
 // --- Theme mode + application ---
 
-/// Light / Dark / Auto (follow the OS appearance).
+/// Light / Dark / Auto (follow the OS appearance). Auto is the default —
+/// a persisted "dark"/"light" choice always wins over it.
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum Mode {
     Light,
-    #[default]
     Dark,
+    #[default]
     Auto,
 }
 
@@ -383,8 +384,8 @@ impl Mode {
     pub fn from_str(s: &str) -> Self {
         match s {
             "light" => Mode::Light,
-            "auto" => Mode::Auto,
-            _ => Mode::Dark,
+            "dark" => Mode::Dark,
+            _ => Mode::Auto,
         }
     }
 

--- a/src/ui/journal.rs
+++ b/src/ui/journal.rs
@@ -9,6 +9,7 @@ use gpui::{
 };
 use gpui_component::Sizable;
 use gpui_component::input::Input;
+use gpui_component::scroll::Scrollbar;
 use gpui_component::{Icon, IconName};
 use gpui_editor::EditorState;
 
@@ -138,6 +139,16 @@ pub fn render(app: &AppView, day_min: Pixels, cx: &mut Context<AppView>) -> impl
                         .children(sections)
                         .child(load_older(cx)),
                 ),
+        )
+        // A visible scrollbar over the feed's right edge (Cditor-inspired).
+        .child(
+            div()
+                .absolute()
+                .top_0()
+                .left_0()
+                .right_0()
+                .bottom_0()
+                .child(Scrollbar::vertical(&app.feed_scroll).id("feed-scrollbar")),
         )
         .children(find_bar)
         .when(scrolled, |this| {

--- a/src/ui/journal.rs
+++ b/src/ui/journal.rs
@@ -176,7 +176,8 @@ pub fn render(app: &AppView, day_min: Pixels, cx: &mut Context<AppView>) -> impl
                                 })
                                 .max()
                                 .unwrap_or(px(28.0));
-                            d.pl(w.max(px(28.0)))
+                            // +24 leaves room for the drag grip left of the rail.
+                            d.pl(w.max(px(28.0)) + px(24.0))
                         })
                         .flex()
                         .flex_col()
@@ -262,6 +263,7 @@ fn day_section(
         if app.line_numbers() {
             let w =
                 super::page_view::gutter_width(state.read(cx).value().as_ref(), app.text_size());
+            state.update(cx, |s, _| s.set_grip_inset(w));
             editor
                 .child(super::page_view::line_gutter(
                     state.clone(),
@@ -270,6 +272,7 @@ fn day_section(
                 ))
                 .into_any_element()
         } else {
+            state.update(cx, |s, _| s.set_grip_inset(gpui::px(0.)));
             editor.into_any_element()
         }
     } else {

--- a/src/ui/journal.rs
+++ b/src/ui/journal.rs
@@ -18,13 +18,58 @@ use crate::slash::SlashTarget;
 use crate::theme;
 
 pub fn render(app: &AppView, day_min: Pixels, cx: &mut Context<AppView>) -> impl IntoElement {
-    let mut sections = Vec::new();
-    for i in 0..app.loaded_days {
-        let date = app::date_for_offset(i);
-        if let Some(day) = app.day_editors.get(&date) {
-            sections.push(day_section(app, i, &date, &day.state, day_min, cx).into_any_element());
+    // Reader-day windowing: a MarkdownView rebuilds its whole element tree
+    // every frame, so days far outside the viewport render as fixed-height
+    // spacers instead (their bounds come from `feed_items`, tracked last
+    // frame — spacers keep occupying the same geometry, so the bounds stay
+    // fresh). WYSIWYG days are one cached editor element each and stay cheap;
+    // the feed find needs every day's blocks painted — both render fully.
+    let viewport = app.feed_scroll.bounds();
+    if app.feed_heights_width.get() != viewport.size.width {
+        app.feed_day_heights.borrow_mut().clear();
+        app.feed_heights_width.set(viewport.size.width);
+    }
+    // The rendered days, in feed order — `pos` (index here) is the tracked
+    // child index `bounds_for_item` answers for, distinct from the day offset
+    // `i` when a date is missing from `day_editors`.
+    let days: Vec<(usize, String)> = (0..app.loaded_days)
+        .map(|i| (i, app::date_for_offset(i)))
+        .filter(|(_, date)| app.day_editors.contains_key(date))
+        .collect();
+    // Refresh the recorded height of every day that was fully rendered last
+    // frame (a spacer's bounds echo the recorded height — never re-measured).
+    {
+        let spacers = app.feed_spacers.borrow();
+        let mut heights = app.feed_day_heights.borrow_mut();
+        for pos in 0..days.len() {
+            if !spacers.contains(&pos)
+                && let Some(b) = app.feed_items.bounds_for_item(pos)
+            {
+                heights.insert(pos, b.size.height);
+            }
         }
     }
+    let margin = viewport.size.height.max(px(400.));
+    let windowable = !app.wysiwyg() && app.feed_find.is_none() && viewport.size.height > px(0.);
+    let mut spacers = std::collections::HashSet::new();
+    let mut sections = Vec::new();
+    for (pos, (i, date)) in days.iter().enumerate() {
+        let day = &app.day_editors[date];
+        let offscreen = app.feed_items.bounds_for_item(pos).is_some_and(|b| {
+            b.origin.y > viewport.bottom_right().y + margin
+                || b.origin.y + b.size.height < viewport.origin.y - margin
+        });
+        let spacer_h = (windowable && offscreen && !app.is_editing_day(date))
+            .then(|| app.feed_day_heights.borrow().get(&pos).copied())
+            .flatten();
+        if let Some(h) = spacer_h {
+            spacers.insert(pos);
+            sections.push(div().h(h).w_full().into_any_element());
+        } else {
+            sections.push(day_section(app, *i, date, &day.state, day_min, cx).into_any_element());
+        }
+    }
+    *app.feed_spacers.borrow_mut() = spacers;
 
     // Floating back-to-top, once the feed is meaningfully scrolled (like the
     // PDF viewer's nav) — offset.y goes negative as you scroll down.
@@ -136,6 +181,10 @@ pub fn render(app: &AppView, day_min: Pixels, cx: &mut Context<AppView>) -> impl
                         .flex()
                         .flex_col()
                         .gap(px(40.0))
+                        // Records each day section's bounds (this div does not
+                        // scroll — its offset stays zero) for the windowing above.
+                        .id("feed-days")
+                        .track_scroll(&app.feed_items)
                         .children(sections)
                         .child(load_older(cx)),
                 ),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -22,15 +22,22 @@ pub mod tab_bar;
 pub mod table_picker;
 
 use gpui::{
-    AnyElement, Context, Div, InteractiveElement, IntoElement, MouseButton, SharedString, Stateful,
+    AnyElement, Context, Div, InteractiveElement, IntoElement, MouseButton, ParentElement as _,
+    SharedString, Stateful, Styled as _, div,
 };
 use gpui_component::menu::ContextMenuExt;
+use gpui_component::{ActiveTheme as _, Icon, IconName};
 
 use crate::actions::{
     CopyPageContents, CopyPageContentsMarkdown, CopyPageLink, DeletePage, ExportPdf, NewSubPage,
     OpenInNewTab, OpenInNewWindow, RenamePage, ToggleFavorite,
 };
 use crate::app::AppView;
+
+/// A bundled Lucide face (served by the app's `Assets`) as a menu-row icon.
+pub(crate) fn menu_icon(name: &str) -> Icon {
+    Icon::empty().path(SharedString::from(format!("icons/{name}.svg")))
+}
 
 /// Attach THE page context menu to a row — one menu for every page-like
 /// surface (sidebar rows, All Pages, search results, backlinks), so the same
@@ -54,24 +61,52 @@ pub(crate) fn with_page_menu(
             this.set_context_page(id, title.clone());
         }),
     )
-    .context_menu(move |menu, _window, _cx| {
-        menu.menu(fav_label, Box::new(ToggleFavorite))
+    .context_menu(move |menu, _window, cx| {
+        let danger = cx.theme().danger;
+        let fav_icon = if is_fav {
+            Icon::from(IconName::StarOff)
+        } else {
+            Icon::from(IconName::Star)
+        };
+        menu.menu_with_icon(fav_label, fav_icon, Box::new(ToggleFavorite))
             .separator()
-            .menu("Open in new tab", Box::new(OpenInNewTab))
-            .menu("Open in new window", Box::new(OpenInNewWindow))
+            .menu_with_icon(
+                "Open in new tab",
+                menu_icon("arrow-up-right"),
+                Box::new(OpenInNewTab),
+            )
+            .menu_with_icon(
+                "Open in new window",
+                menu_icon("app-window"),
+                Box::new(OpenInNewWindow),
+            )
             .separator()
-            .menu("Copy link", Box::new(CopyPageLink))
-            .menu("Copy contents", Box::new(CopyPageContents))
-            .menu(
+            .menu_with_icon("Copy link", menu_icon("link"), Box::new(CopyPageLink))
+            .menu_with_icon("Copy contents", IconName::Copy, Box::new(CopyPageContents))
+            .menu_with_icon(
                 "Copy contents as Markdown",
+                menu_icon("file-text"),
                 Box::new(CopyPageContentsMarkdown),
             )
             .separator()
-            .menu("Export as PDF…", Box::new(ExportPdf))
+            .menu_with_icon(
+                "Export as PDF…",
+                menu_icon("file-down"),
+                Box::new(ExportPdf),
+            )
             .separator()
-            .menu("New sub-page", Box::new(NewSubPage))
-            .menu("Rename page", Box::new(RenamePage))
-            .menu("Delete page", Box::new(DeletePage))
+            .menu_with_icon(
+                "New sub-page",
+                menu_icon("sticky-note-plus"),
+                Box::new(NewSubPage),
+            )
+            .menu_with_icon("Rename page", menu_icon("pencil"), Box::new(RenamePage))
+            // Destructive: red label + red icon (Cditor-style).
+            .menu_element_with_icon(
+                menu_icon("trash-2").text_color(danger),
+                Box::new(DeletePage),
+                move |_, _| div().text_color(danger).child("Delete page"),
+            )
     })
     .into_any_element()
 }

--- a/src/ui/page_view.rs
+++ b/src/ui/page_view.rs
@@ -8,6 +8,7 @@ use gpui::{
 };
 use gpui_component::Sizable;
 use gpui_component::input::Input;
+use gpui_component::scroll::Scrollbar;
 
 use crate::app::{AppView, PageEditor, PageFind};
 use crate::hierarchy;
@@ -45,77 +46,97 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
         .children(app.page_find.as_ref().map(|pf| find_bar(pf, cx)))
         .child(
             div()
-                .id("page-scroll")
+                .relative()
                 .flex_1()
                 .min_h_0()
                 .w_full()
-                .overflow_y_scroll()
-                .track_scroll(&app.page_scroll)
-                // Drop image files onto the page to add them.
-                .on_drop(cx.listener(
-                    move |this: &mut AppView, paths: &ExternalPaths, window, cx| {
-                        this.insert_dropped_files(
-                            SlashTarget::Page(page_id),
-                            paths.paths(),
-                            false,
-                            window,
-                            cx,
-                        );
-                    },
-                ))
                 .child(
                     div()
-                        // Match the journal feed: uniform padding, left-aligned.
-                        .p(px(28.0))
-                        // The gutter rail lives inside the left padding.
-                        .when_some(gutter_w, |d, w| d.pl(w.max(px(28.0))))
-                        .flex()
-                        .flex_col()
-                        // Fill the viewport so the open area below the content
-                        // is clickable all the way down.
-                        .min_h(relative(1.0))
-                        .child(page_title(
-                            pe,
-                            parent_breadcrumb(&pe.title, cx).map(IntoElement::into_any_element),
+                        .id("page-scroll")
+                        .size_full()
+                        .overflow_y_scroll()
+                        .track_scroll(&app.page_scroll)
+                        // Drop image files onto the page to add them.
+                        .on_drop(cx.listener(
+                            move |this: &mut AppView, paths: &ExternalPaths, window, cx| {
+                                this.insert_dropped_files(
+                                    SlashTarget::Page(page_id),
+                                    paths.paths(),
+                                    false,
+                                    window,
+                                    cx,
+                                );
+                            },
                         ))
-                        // WYSIWYG on → the live editor is the only view; off → the
-                        // reader view, swapped for the editor while editing.
-                        .child(if app.wysiwyg() || app.is_page_editing() {
-                            // gpui-editor draws no chrome; the wrapper sets the
-                            // ambient text style it inherits when shaping lines.
-                            // The gutter — the page's margin rail (line numbers
-                            // today; room for more per-line UI later) — is an
-                            // absolute child hanging left into the padding, so
-                            // rows and rail share a coordinate origin.
-                            let editor = div()
-                                .relative()
-                                .text_size(app.text_size())
-                                .text_color(theme::text_primary())
-                                .child(pe.state.clone());
-                            match gutter_w {
-                                Some(w) => editor
-                                    .child(line_gutter(pe.state.clone(), app.text_size(), w))
-                                    .into_any_element(),
-                                None => editor.into_any_element(),
-                            }
-                        } else {
-                            page_rendered(app, pe, cx).into_any_element()
-                        })
-                        // A large editable surface right under the content (like the
-                        // journal's open day area), so the page stays easy to click
-                        // into even when a PDF chip fills the body and sub-page /
-                        // reference sections sit below. It grows to fill, pushing
-                        // those sections to the bottom.
-                        .child(page_open_area(page_id, cx))
-                        .when(!children.is_empty(), |this| {
-                            this.child(sub_pages_section(&pe.title, &children, cx))
-                        })
-                        .when(!pe.backlinks.is_empty(), |this| {
-                            this.child(backlinks_section(&pe.backlinks, app, cx))
-                        })
-                        .when(!pe.unlinked.is_empty(), |this| {
-                            this.child(unlinked_section(&pe.unlinked, cx))
-                        }),
+                        .child(
+                            div()
+                                // Match the journal feed: uniform padding, left-aligned.
+                                .p(px(28.0))
+                                // The gutter rail lives inside the left padding.
+                                .when_some(gutter_w, |d, w| d.pl(w.max(px(28.0))))
+                                .flex()
+                                .flex_col()
+                                // Fill the viewport so the open area below the content
+                                // is clickable all the way down.
+                                .min_h(relative(1.0))
+                                .child(page_title(
+                                    pe,
+                                    parent_breadcrumb(&pe.title, cx)
+                                        .map(IntoElement::into_any_element),
+                                ))
+                                // WYSIWYG on → the live editor is the only view; off → the
+                                // reader view, swapped for the editor while editing.
+                                .child(if app.wysiwyg() || app.is_page_editing() {
+                                    // gpui-editor draws no chrome; the wrapper sets the
+                                    // ambient text style it inherits when shaping lines.
+                                    // The gutter — the page's margin rail (line numbers
+                                    // today; room for more per-line UI later) — is an
+                                    // absolute child hanging left into the padding, so
+                                    // rows and rail share a coordinate origin.
+                                    let editor = div()
+                                        .relative()
+                                        .text_size(app.text_size())
+                                        .text_color(theme::text_primary())
+                                        .child(pe.state.clone());
+                                    match gutter_w {
+                                        Some(w) => editor
+                                            .child(line_gutter(
+                                                pe.state.clone(),
+                                                app.text_size(),
+                                                w,
+                                            ))
+                                            .into_any_element(),
+                                        None => editor.into_any_element(),
+                                    }
+                                } else {
+                                    page_rendered(app, pe, cx).into_any_element()
+                                })
+                                // A large editable surface right under the content (like the
+                                // journal's open day area), so the page stays easy to click
+                                // into even when a PDF chip fills the body and sub-page /
+                                // reference sections sit below. It grows to fill, pushing
+                                // those sections to the bottom.
+                                .child(page_open_area(page_id, cx))
+                                .when(!children.is_empty(), |this| {
+                                    this.child(sub_pages_section(&pe.title, &children, cx))
+                                })
+                                .when(!pe.backlinks.is_empty(), |this| {
+                                    this.child(backlinks_section(&pe.backlinks, app, cx))
+                                })
+                                .when(!pe.unlinked.is_empty(), |this| {
+                                    this.child(unlinked_section(&pe.unlinked, cx))
+                                }),
+                        ),
+                )
+                // A visible scrollbar over the page's right edge (Cditor-inspired).
+                .child(
+                    div()
+                        .absolute()
+                        .top_0()
+                        .left_0()
+                        .right_0()
+                        .bottom_0()
+                        .child(Scrollbar::vertical(&app.page_scroll).id("page-scrollbar")),
                 ),
         )
         .into_any_element()

--- a/src/ui/page_view.rs
+++ b/src/ui/page_view.rs
@@ -34,6 +34,9 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
     // sits exactly where it would without a gutter.
     let gutter_w: Option<Pixels> = (app.line_numbers() && (app.wysiwyg() || app.is_page_editing()))
         .then(|| gutter_width(pe.state.read(cx).value().as_ref(), app.text_size()));
+    pe.state.update(cx, |s, _| {
+        s.set_grip_inset(gutter_w.unwrap_or(gpui::px(0.)))
+    });
     div()
         .flex_1()
         .min_w_0()
@@ -73,7 +76,8 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
                                 // Match the journal feed: uniform padding, left-aligned.
                                 .p(px(28.0))
                                 // The gutter rail lives inside the left padding.
-                                .when_some(gutter_w, |d, w| d.pl(w.max(px(28.0))))
+                                // +24 leaves room for the drag grip left of the rail.
+                                .when_some(gutter_w, |d, w| d.pl(w.max(px(28.0)) + px(24.0)))
                                 .flex()
                                 .flex_col()
                                 // Fill the viewport so the open area below the content

--- a/src/ui/page_view.rs
+++ b/src/ui/page_view.rs
@@ -175,6 +175,12 @@ pub(crate) fn line_gutter(
             let font = window.text_style().font();
             let viewport_h = window.viewport_size().height;
             for (i, &(top, row_h)) in layout.iter().enumerate() {
+                // A collapsed row — a folded body line, or a hidden ``` fence
+                // (which still advances by the code card's pad) — gets no
+                // number; painting one would reveal the hidden line.
+                if row_h <= px(0.5) {
+                    continue;
+                }
                 // A fold collapsed this row (no vertical advance) — skip it.
                 if let Some(&(next_top, _)) = layout.get(i + 1)
                     && next_top - top <= px(0.5)

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -188,7 +188,11 @@ fn expanded(app: &AppView, window: &mut Window, cx: &mut Context<AppView>) -> im
                         .w(relative(1.0))
                         .min_h(px(48.0))
                         .context_menu(|menu, _window, _cx| {
-                            menu.menu("New page", Box::new(NewPage))
+                            menu.menu_with_icon(
+                                "New page",
+                                super::menu_icon("sticky-note-plus"),
+                                Box::new(NewPage),
+                            )
                         }),
                 ),
         )

--- a/src/ui/slash_menu.rs
+++ b/src/ui/slash_menu.rs
@@ -4,28 +4,103 @@
 
 use gpui::{
     Context, InteractiveElement, IntoElement, MouseButton, ParentElement,
-    StatefulInteractiveElement, Styled, div, prelude::FluentBuilder as _, px,
+    StatefulInteractiveElement, Styled, div, prelude::FluentBuilder as _, px, relative,
 };
 
 use crate::app::AppView;
-use crate::slash::{ItemKind, Slash, Trigger};
+use crate::slash::{ItemKind, PaletteItem, Slash, Trigger};
 use crate::theme;
 
-/// Fixed row height (px) — rows are exactly this tall (`.h(ITEM_H)`), so the
-/// keyboard scroll-into-view (`AppView::scroll_slash_into_view`) and the
+/// Fixed row heights (px) — rows are exactly this tall (`.h(item_h(..))`), so
+/// the keyboard scroll-into-view (`AppView::scroll_slash_into_view`) and the
 /// scrollbar thumb below always agree with the painted list. (They drifted
-/// ~4px/row when rows sized themselves from text + padding.)
-pub const ITEM_H: f32 = 28.0;
+/// ~4px/row when rows sized themselves from text + padding.) The `/` palette
+/// uses tall Notion-style rows (icon box + title + description,
+/// Cditor-inspired); the other triggers (`[[`, `#`, `\`, `{{`) are plain
+/// autocompletes and keep the compact row.
+const SLASH_ITEM_H: f32 = 44.0;
+const COMPACT_ITEM_H: f32 = 28.0;
 const PAD: f32 = 4.0;
+
+/// Row height for `trigger`'s menu.
+pub fn item_h(trigger: Trigger) -> f32 {
+    if trigger == Trigger::Slash {
+        SLASH_ITEM_H
+    } else {
+        COMPACT_ITEM_H
+    }
+}
+
 /// Height cap = an exact number of rows, so the bottom row is never
 /// half-clipped and arrow-key scrolling advances by whole rows.
-pub const MAX_H: f32 = 2.0 * PAD + 10.0 * ITEM_H;
+pub fn max_h(trigger: Trigger) -> f32 {
+    let rows = if trigger == Trigger::Slash { 7.0 } else { 10.0 };
+    2.0 * PAD + rows * item_h(trigger)
+}
+
 /// Scrollable viewport height (the cap minus top/bottom padding).
-pub const VIEW_H: f32 = MAX_H - 2.0 * PAD;
+pub fn view_h(trigger: Trigger) -> f32 {
+    max_h(trigger) - 2.0 * PAD
+}
+
+/// The category flyout panel's width.
+const FLYOUT_WIDTH: f32 = 240.0;
+
+/// The rendered height of a panel showing `n_items` (capped at the visible-row
+/// cap, plus padding). Used by the caller to place the main panel and to size
+/// the flyout for its overflow check.
+pub fn panel_height(trigger: Trigger, n_items: usize) -> f32 {
+    let rows = if trigger == Trigger::Slash { 7 } else { 10 };
+    let shown = n_items.clamp(1, rows) as f32;
+    2.0 * PAD + shown * item_h(trigger)
+}
+
+/// Icon-box glyph + one-line description for the `/` palette's known entries.
+/// Dynamic rows (dates, templates, pages) match on their label's stable
+/// prefix; anything unknown falls back to a bare "+" box, no description.
+fn meta(label: &str) -> (&'static str, Option<&'static str>) {
+    match label {
+        "Heading 1" => ("H1", Some("Big section heading.")),
+        "Heading 2" => ("H2", Some("Medium section heading.")),
+        "Heading 3" => ("H3", Some("Small section heading.")),
+        "Bullet list" => ("•", Some("A simple bulleted list.")),
+        "Numbered list" => ("1.", Some("A list with numbering.")),
+        "To-do" => ("☐", Some("Track a task with a checkbox.")),
+        "Quote" => ("❝", Some("Capture a quote.")),
+        "Note alert" => ("!", Some("Callout — something worth noting.")),
+        "Tip alert" => ("!", Some("Callout — a helpful tip.")),
+        "Important alert" => ("!", Some("Callout — key information.")),
+        "Warning alert" => ("!", Some("Callout — needs attention.")),
+        "Caution alert" => ("!", Some("Callout — risky consequences.")),
+        "Code block" => ("</>", Some("Capture a code snippet.")),
+        "Mermaid diagram" => ("◇", Some("Draw a diagram from text.")),
+        "Math" => ("Σ", Some("Typeset a display formula.")),
+        "Table" => ("⊞", Some("Pick a rows × columns size.")),
+        "Divider" => ("—", Some("Visually divide the page.")),
+        "Bold" => ("B", Some("Bold text.")),
+        "Italic" => ("I", Some("Italic text.")),
+        "Strikethrough" => ("S", Some("Struck-through text.")),
+        "Inline code" => ("<>", Some("Code within a sentence.")),
+        "Inline math" => ("$", Some("A formula within a sentence.")),
+        "Highlight" => ("==", Some("Highlighted text.")),
+        "Link" => ("↗", Some("A web link.")),
+        "Property" => ("::", Some("Add a key:: value property.")),
+        "Markdown" => ("≡", Some("All markdown blocks.")),
+        "Templates" => ("⧉", Some("Insert one of your templates.")),
+        _ if label.starts_with("Date (") => ("@", Some("Insert today's date.")),
+        _ if label.starts_with("Time (") => ("@", Some("Insert the current time.")),
+        _ => ("+", None),
+    }
+}
 
 pub fn render(
     slash: &Slash,
     scroll: &gpui::ScrollHandle,
+    flyout: (&[PaletteItem], &gpui::ScrollHandle),
+    // `flyout_top_offset`: vertical offset for the flyout from the main panel's
+    // top (0 = aligned; negative shifts it up so it clears the window bottom).
+    // The caller sizes this since only it knows the menu's final window position.
+    flyout_top_offset: f32,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
     let items = &slash.items;
@@ -40,9 +115,11 @@ pub fn render(
 
     // Inner scroll viewport: caps the height + scrolls the overflow. The chrome (bg/border)
     // lives on the outer `relative` box below so the scrollbar thumb can position against it.
+    let rich = slash.trigger == Trigger::Slash;
+    let row_h = item_h(slash.trigger);
     let mut col = div()
         .id("completion-menu")
-        .max_h(px(MAX_H))
+        .max_h(px(max_h(slash.trigger)))
         .overflow_y_scroll()
         .track_scroll(scroll)
         .flex()
@@ -62,52 +139,90 @@ pub fn render(
         for (i, item) in items.iter().enumerate() {
             let selected = i == slash.selected;
             let is_category = matches!(item.kind, ItemKind::Category(_));
-            col = col.child(
-                div()
-                    .px_3()
-                    .h(px(ITEM_H))
-                    .flex_none()
-                    .text_size(px(13.0))
-                    .flex()
-                    .flex_row()
-                    .items_center()
-                    .justify_between()
-                    .gap_4()
-                    .cursor_pointer()
-                    .when(selected, |d| {
-                        d.bg(theme::accent_tint()).text_color(theme::text_primary())
-                    })
-                    .when(!selected, |d| d.text_color(theme::text_secondary()))
-                    // Hover moves the keyboard selection to this row, so the one
-                    // highlight is what both a click and Enter accept.
-                    .on_mouse_move(cx.listener(move |this, _, _window, cx| {
-                        this.slash_hover(i, cx);
-                    }))
-                    // Mouse-DOWN (not click) + stop_propagation: accept before the press
-                    // can blur the editor, so the insertion lands and focus stays put.
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(move |this, _, window, cx| {
-                            cx.stop_propagation();
-                            this.click_slash(i, window, cx);
-                        }),
-                    )
+            let row = div()
+                .px_3()
+                .h(px(row_h))
+                .flex_none()
+                .text_size(px(13.0))
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_4()
+                .cursor_pointer()
+                .when(selected, |d| {
+                    d.bg(theme::accent_tint()).text_color(theme::text_primary())
+                })
+                .when(!selected, |d| d.text_color(theme::text_secondary()))
+                // Hover moves the keyboard selection to this row, so the one
+                // highlight is what both a click and Enter accept.
+                .on_mouse_move(cx.listener(move |this, _, _window, cx| {
+                    this.slash_hover(i, cx);
+                }))
+                // Mouse-DOWN (not click) + stop_propagation: accept before the press
+                // can blur the editor, so the insertion lands and focus stays put.
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, window, cx| {
+                        cx.stop_propagation();
+                        this.click_slash(i, window, cx);
+                    }),
+                );
+            col = col.child(if rich {
+                // Notion-style row (Cditor-inspired): a boxed glyph, the title,
+                // and a muted one-line description under it.
+                let (icon, desc) = meta(&item.label);
+                row.child(
+                    div()
+                        .flex_none()
+                        .w(px(30.0))
+                        .h(px(30.0))
+                        .rounded(px(6.0))
+                        .border_1()
+                        .border_color(theme::border_subtle())
+                        .bg(theme::bg_content())
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .text_size(px(12.0))
+                        .text_color(theme::text_secondary())
+                        .child(icon),
+                )
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .flex()
+                        .flex_col()
+                        .child(div().child(item.label.clone()))
+                        .children(desc.map(|d| {
+                            div()
+                                .text_size(px(11.0))
+                                .text_color(theme::text_tertiary())
+                                .child(d)
+                        })),
+                )
+                .when(is_category, |d| {
+                    d.child(div().text_color(theme::text_tertiary()).child("›"))
+                })
+            } else {
+                row.justify_between()
                     .child(item.label.clone())
                     .when(is_category, |d| {
                         d.child(div().text_color(theme::text_tertiary()).child("›"))
-                    }),
-            );
+                    })
+            });
         }
     }
 
     // Scrollbar thumb — only when the rows overflow the cap; sized from the content height
     // and positioned from the live scroll offset (mirrors the gpui-editor table/suggestion
     // menus). Wheel + keyboard scroll both re-render, so the offset read here stays fresh.
-    let rows_h = items.len().max(1) as f32 * ITEM_H;
-    let thumb = (rows_h > VIEW_H).then(|| {
-        let scrolled = (-f32::from(scroll.offset().y)).clamp(0.0, rows_h - VIEW_H);
-        let thumb_h = (VIEW_H * VIEW_H / rows_h).max(24.0);
-        let thumb_top = PAD + scrolled / (rows_h - VIEW_H) * (VIEW_H - thumb_h);
+    let vh = view_h(slash.trigger);
+    let rows_h = items.len().max(1) as f32 * row_h;
+    let thumb = (rows_h > vh).then(|| {
+        let scrolled = (-f32::from(scroll.offset().y)).clamp(0.0, rows_h - vh);
+        let thumb_h = (vh * vh / rows_h).max(24.0);
+        let thumb_top = PAD + scrolled / (rows_h - vh) * (vh - thumb_h);
         let mut thumb_c = theme::text_tertiary();
         thumb_c.a = 0.5;
         div()
@@ -122,9 +237,12 @@ pub fn render(
 
     // Outer chrome: `relative` so the absolute thumb anchors to it, `occlude` so the wheel
     // scrolls the menu rather than bleeding through to the page beneath.
-    div()
+    let main_panel = div()
         .relative()
         .occlude()
+        // Swallow clicks on panel dead-space so they don't bubble to the
+        // backdrop and close the menu (row clicks already stop_propagation).
+        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
         .min_w(px(min_w))
         .bg(theme::bg_sidebar())
         .border_1()
@@ -132,6 +250,126 @@ pub fn render(
         .rounded(px(8.0))
         .overflow_hidden()
         .child(col)
-        .children(thumb)
+        .children(thumb);
+
+    // A selected category's submenu flies out beside the main panel
+    // (Cditor-style) instead of replacing the list. The caller passes its rows
+    // (empty = no category selected → no flyout).
+    let (fly_items, fly_scroll) = flyout;
+    let fly_panel = (!fly_items.is_empty()).then(|| {
+        let mut fcol = div()
+            .id("completion-flyout")
+            .max_h(px(max_h(Trigger::Slash)))
+            .overflow_y_scroll()
+            .track_scroll(fly_scroll)
+            .flex()
+            .flex_col()
+            .py(px(PAD));
+        for (i, item) in fly_items.iter().enumerate() {
+            let selected = slash.flyout == Some(i);
+            let (icon, desc) = meta(&item.label);
+            fcol = fcol.child(
+                div()
+                    .px_3()
+                    .h(px(SLASH_ITEM_H))
+                    .flex_none()
+                    .text_size(px(13.0))
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_4()
+                    .cursor_pointer()
+                    .when(selected, |d| {
+                        d.bg(theme::accent_tint()).text_color(theme::text_primary())
+                    })
+                    .when(!selected, |d| d.text_color(theme::text_secondary()))
+                    .on_mouse_move(cx.listener(move |this, _, _window, cx| {
+                        this.slash_flyout_hover(i, cx);
+                    }))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _, window, cx| {
+                            cx.stop_propagation();
+                            this.click_slash_flyout(i, window, cx);
+                        }),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .w(px(30.0))
+                            .h(px(30.0))
+                            .rounded(px(6.0))
+                            .border_1()
+                            .border_color(theme::border_subtle())
+                            .bg(theme::bg_content())
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .text_size(px(12.0))
+                            .text_color(theme::text_secondary())
+                            .child(icon),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .flex()
+                            .flex_col()
+                            .child(div().child(item.label.clone()))
+                            .children(desc.map(|d| {
+                                div()
+                                    .text_size(px(11.0))
+                                    .text_color(theme::text_tertiary())
+                                    .child(d)
+                            })),
+                    ),
+            );
+        }
+        // Its own thumb, against its own scroll offset.
+        let fly_view_h = view_h(Trigger::Slash);
+        let fly_rows_h = fly_items.len() as f32 * SLASH_ITEM_H;
+        let fthumb = (fly_rows_h > fly_view_h).then(|| {
+            let scrolled = (-f32::from(fly_scroll.offset().y)).clamp(0.0, fly_rows_h - fly_view_h);
+            let thumb_h = (fly_view_h * fly_view_h / fly_rows_h).max(24.0);
+            let thumb_top = PAD + scrolled / (fly_rows_h - fly_view_h) * (fly_view_h - thumb_h);
+            let mut thumb_c = theme::text_tertiary();
+            thumb_c.a = 0.5;
+            div()
+                .absolute()
+                .top(px(thumb_top))
+                .right(px(2.0))
+                .w(px(6.0))
+                .h(px(thumb_h))
+                .rounded(px(3.0))
+                .bg(thumb_c)
+        });
+        div()
+            // Absolutely positioned beside the main panel — so it floats out
+            // and does NOT enlarge the anchored element's bounding box (which
+            // would make gpui snap the whole menu up near the window bottom).
+            // Anchored to the main panel's right edge (`left: 100%`) + a gap.
+            .absolute()
+            .top(px(flyout_top_offset))
+            .left(relative(1.0))
+            .ml(px(4.0))
+            .occlude()
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .w(px(FLYOUT_WIDTH))
+            .bg(theme::bg_sidebar())
+            .border_1()
+            .border_color(theme::border_subtle())
+            .rounded(px(8.0))
+            .overflow_hidden()
+            .child(fcol)
+            .children(fthumb)
+    });
+
+    div()
+        .id("slash-menu")
+        // `relative` so the flyout positions against this box; the main panel
+        // is the only in-flow child, so this box's size = the main panel's.
+        .relative()
+        .child(main_panel)
+        .children(fly_panel)
         .into_any_element()
 }

--- a/src/ui/slash_menu.rs
+++ b/src/ui/slash_menu.rs
@@ -83,6 +83,7 @@ fn meta(label: &str) -> (&'static str, Option<&'static str>) {
         "Inline code" => ("<>", Some("Code within a sentence.")),
         "Inline math" => ("$", Some("A formula within a sentence.")),
         "Highlight" => ("==", Some("Highlighted text.")),
+        "Underline" => ("U", Some("Underlined text.")),
         "Link" => ("↗", Some("A web link.")),
         "Property" => ("::", Some("Add a key:: value property.")),
         "Markdown" => ("≡", Some("All markdown blocks.")),
@@ -248,6 +249,7 @@ pub fn render(
         .border_1()
         .border_color(theme::border_subtle())
         .rounded(px(8.0))
+        .shadow_md()
         .overflow_hidden()
         .child(col)
         .children(thumb);
@@ -359,6 +361,7 @@ pub fn render(
             .border_1()
             .border_color(theme::border_subtle())
             .rounded(px(8.0))
+            .shadow_md()
             .overflow_hidden()
             .child(fcol)
             .children(fthumb)

--- a/src/ui/tab_bar.rs
+++ b/src/ui/tab_bar.rs
@@ -9,7 +9,9 @@ use gpui::{
 use gpui_component::menu::ContextMenuExt;
 use gpui_component::tab::{Tab, TabBar};
 use gpui_component::tooltip::Tooltip;
+use gpui_component::{ActiveTheme as _, Icon, IconName};
 
+use super::menu_icon;
 use crate::actions::{
     CopyPageContents, CopyPageContentsMarkdown, CopyPageLink, DeletePage, NewSubPage,
     OpenInNewWindow, RenamePage, ToggleFavorite,
@@ -36,9 +38,11 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
         let title = tab.title.clone();
         let menu_title = title.clone();
         let is_page = matches!(tab.kind, TabKind::Page(_));
-        let fav_label = match &tab.kind {
-            TabKind::Page(pid) if app.is_favorite(*pid) => "Remove from favorites",
-            _ => "Add to favorites",
+        let is_fav = matches!(&tab.kind, TabKind::Page(pid) if app.is_favorite(*pid));
+        let fav_label = if is_fav {
+            "Remove from favorites"
+        } else {
+            "Add to favorites"
         };
         // Cap the label: a long name (e.g. a PDF filename) is ellipsized, with the
         // full title in a tooltip. A "(highlights)" tab keeps that suffix visible.
@@ -73,28 +77,52 @@ pub fn render(app: &AppView, cx: &mut Context<AppView>) -> impl IntoElement {
             overlay =
                 overlay.tooltip(move |window, cx| Tooltip::new(full.clone()).build(window, cx));
         }
-        let overlay = overlay.context_menu(move |menu, _window, _cx| {
+        let overlay = overlay.context_menu(move |menu, _window, cx| {
+            let danger = cx.theme().danger;
             let menu = menu
-                .menu("Open in new window", Box::new(OpenInNewWindow))
-                .menu("Export as PDF…", Box::new(crate::actions::ExportPdf));
+                .menu_with_icon(
+                    "Open in new window",
+                    menu_icon("app-window"),
+                    Box::new(OpenInNewWindow),
+                )
+                .menu_with_icon(
+                    "Export as PDF…",
+                    menu_icon("file-down"),
+                    Box::new(crate::actions::ExportPdf),
+                );
             // Page tabs grow the shared page verbs; the pinned Journal and
             // PDF tabs keep the slim menu.
             if !is_page {
                 return menu;
             }
+            let fav_icon = if is_fav {
+                Icon::from(IconName::StarOff)
+            } else {
+                Icon::from(IconName::Star)
+            };
             menu.separator()
-                .menu("Copy link", Box::new(CopyPageLink))
-                .menu("Copy contents", Box::new(CopyPageContents))
-                .menu(
+                .menu_with_icon("Copy link", menu_icon("link"), Box::new(CopyPageLink))
+                .menu_with_icon("Copy contents", IconName::Copy, Box::new(CopyPageContents))
+                .menu_with_icon(
                     "Copy contents as Markdown",
+                    menu_icon("file-text"),
                     Box::new(CopyPageContentsMarkdown),
                 )
                 .separator()
-                .menu(fav_label, Box::new(ToggleFavorite))
+                .menu_with_icon(fav_label, fav_icon, Box::new(ToggleFavorite))
                 .separator()
-                .menu("New sub-page", Box::new(NewSubPage))
-                .menu("Rename page", Box::new(RenamePage))
-                .menu("Delete page", Box::new(DeletePage))
+                .menu_with_icon(
+                    "New sub-page",
+                    menu_icon("sticky-note-plus"),
+                    Box::new(NewSubPage),
+                )
+                .menu_with_icon("Rename page", menu_icon("pencil"), Box::new(RenamePage))
+                // Destructive: red label + red icon (Cditor-style).
+                .menu_element_with_icon(
+                    menu_icon("trash-2").text_color(danger),
+                    Box::new(DeletePage),
+                    move |_, _| div().text_color(danger).child("Delete page"),
+                )
         });
         let mut t = Tab::new()
             .label(display)


### PR DESCRIPTION
The full port of what we liked from JYChen-8866's Cditor (issue #16) into zorite's flat-markdown engines, plus the follow-on audit fixes. 41 commits:

## Features
- **Notion-style checkboxes, visible scrollbars, code-card chrome** (Copy + language picker), **slash palette with category flyout**, context-menu restyle with a selection format bar (B/I/U/S/`<>`)
- **Tables**: Cditor-style menu, hover outlines + split-pill add/remove affordances, drag-to-resize columns persisted as `<!-- table:STYLE cols=… -->`, and **wide tables scroll horizontally in place** (natural column widths, masked paint, slim thumb) instead of scaling down
- **Full inline-marker hiding**: formatting markers never reveal (caret moves by visible position; Cditor-style delete collapses emptied pairs)
- **"Turn into" block conversion flyout** in the right-click menu
- **Block drag-reorder** via a hover gutter grip (whole regions move as units; window-level mouse pipeline since the grip lives outside the element)
- **Whiteboard**: adopted the ding-board fork wholesale (mindmaps, flowcharts, bound connectors, alignment guides, culling)

## Performance (from the Cditor audit)
- Measure→prepaint shape memo, content-generation scan cache, cross-frame line-run cache, table column/wrap-row caches, resumable IME UTF-16 mapping
- **Windowed rendering**: offscreen plain lines skip shaping (exact cached heights, no estimates), paint culls offscreen lines
- Scroll anchoring for async raster loads — compensator gated to the real final width (intrinsic-width measures used to yank the feed offset) with a once-per-paint latch
- Reader-mode journal: offscreen days render as fixed-height spacers

## Fixes
- Escaped `\|` handling through cell split/rewrite, CRLF paste normalization, double-backtick spans, nested inline emphasis, ragged-table grid widening with row spans, selection-highlight bands (full-height rows, no phantom stripes), table style-marker reveal leaks, unwrapped hidden sources for table/widget rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Credits

Huge thanks to **[@JYChen-8866](https://github.com/JYChen-8866)** (jychen), who wrote [Cditor](https://github.com/JYChen-8866/Cditor) specifically to contribute its editor to Zorite (#16). This PR ports its best ideas into Zorite's flat-markdown engines — the table interactions, marker-hiding behavior, menus, code cards, and drag-reorder are all his designs — and the whiteboard improvements are his ding-board fork adopted wholesale. The multi-window virtual-rendering architecture in Cditor also directly informed the windowed-rendering work here.
