### PR TITLE
Logseq affinity: ((id)) block refs, block backlinks, property parity, list-heading folds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 
 # Obsidian test vault for importer development (not shipped)
 zorite_migration/
+Logseq/

--- a/crates/gpui-editor/API.md
+++ b/crates/gpui-editor/API.md
@@ -83,7 +83,7 @@ crate root; nothing from `gpui-markdown` is re-exported.)
 | [`EditorState::copy_table`](#copy_table) | method | `fn copy_table(&mut self, cx: &mut Context<Self>)` | Whole table to the clipboard (markdown) |
 | [`EditorState::set_table_style`](#set_table_style) | method | `fn set_table_style(&mut self, name: Option<&'static str>, cx: &mut Context<Self>)` | Rewrite the table's style marker |
 | [`EditorEvent`](#enum-editorevent) | enum | 8 variants | Everything the editor asks the host to do |
-| [`SyntaxStyle`](#struct-syntaxstyle) | struct | 22 public fields | Colors + fonts + icon hooks for WYSIWYG |
+| [`SyntaxStyle`](#struct-syntaxstyle) | struct | 25 public fields | Colors + fonts + icon hooks for WYSIWYG — incl. `block_label: Option<Rc<dyn Fn(&str, &str) -> Option<String>>>` (block-link display resolver) + `block_label_gen: u64` (bumped when labels change, re-keys the line cache) + `block_ref_count: Option<BlockRefCountFn>` (id → referencing-page count; >0 paints a superscript badge over the hidden ` ^id` anchor whose click emits `OpenWikiLink("refs:^id")`) |
 | [`AlertIcons`](#struct-alerticons) | struct | 5 public fields | SVG asset paths for alert title icons |
 | [`Diagnostic`](#struct-diagnostic) | struct | `pub range: Range<usize>` | A flagged (underlined) span |
 | [`CellAlign`](#enum-cellalign) | enum | `Left · Center · Right` | A table column's alignment |

--- a/crates/gpui-editor/examples/demo.rs
+++ b/crates/gpui-editor/examples/demo.rs
@@ -58,12 +58,15 @@ impl Render for Demo {
 /// A dark-theme palette for the live-preview markdown styling.
 fn demo_markdown_style() -> SyntaxStyle {
     SyntaxStyle {
-        marker: hsla(0., 0., 0.5, 0.55),       // dimmed gray syntax markers
-        code: hsla(0.09, 0.6, 0.72, 1.),       // warm inline code text
-        code_bg: hsla(0., 0., 1., 0.06),       // faint code chip background
-        link: hsla(0.58, 0.75, 0.66, 1.),      // blue links / wiki-links
-        tag: hsla(0.33, 0.45, 0.62, 1.),       // green tags
-        quote: hsla(0., 0., 0.6, 1.),          // muted blockquote text/border
+        block_label: None,
+        block_label_gen: 0,
+        block_ref_count: None,
+        marker: hsla(0., 0., 0.5, 0.55), // dimmed gray syntax markers
+        code: hsla(0.09, 0.6, 0.72, 1.), // warm inline code text
+        code_bg: hsla(0., 0., 1., 0.06), // faint code chip background
+        link: hsla(0.58, 0.75, 0.66, 1.), // blue links / wiki-links
+        tag: hsla(0.33, 0.45, 0.62, 1.), // green tags
+        quote: hsla(0., 0., 0.6, 1.),    // muted blockquote text/border
         alert_note: hsla(0.58, 0.9, 0.62, 1.), // GitHub alert blues/greens…
         alert_tip: hsla(0.36, 0.5, 0.48, 1.),
         alert_important: hsla(0.74, 0.85, 0.73, 1.),

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -2736,6 +2736,9 @@ impl EditorState {
                 gpui_markdown::syntax::LinkHit::Page(t) => {
                     cx.emit(EditorEvent::OpenWikiLink(t.clone().into()))
                 }
+                gpui_markdown::syntax::LinkHit::BlockRef(id) => {
+                    cx.emit(EditorEvent::OpenWikiLink(format!("#^{id}").into()))
+                }
                 gpui_markdown::syntax::LinkHit::Url(u) => {
                     cx.emit(EditorEvent::OpenLink(u.clone().into()))
                 }
@@ -2791,11 +2794,32 @@ impl EditorState {
                     cx.emit(EditorEvent::OpenWikiLink(title.into()));
                     return;
                 }
+                Some(markdown_syntax::LinkHit::BlockRef(id)) => {
+                    cx.emit(EditorEvent::OpenWikiLink(format!("#^{id}").into()));
+                    return;
+                }
                 Some(markdown_syntax::LinkHit::Url(url)) => {
                     cx.emit(EditorEvent::OpenLink(url.into()));
                     return;
                 }
                 None => {}
+            }
+            // The reference-count badge painted over a hidden ` ^id` anchor:
+            // a click on its (replaced) range lists the referencers. Only when
+            // the anchor is hidden — with the caret on the line the raw text
+            // is revealed for editing and clicks place the caret as usual.
+            if self.row_col(self.selected_range.start).0 != row
+                && let Some((at, id)) = gpui_markdown::syntax::block_id(line)
+                && offset - start >= at
+                && self
+                    .markdown_style
+                    .as_ref()
+                    .and_then(|st| st.block_ref_count.as_ref().map(|f| f(id)))
+                    .unwrap_or(0)
+                    > 0
+            {
+                cx.emit(EditorEvent::OpenWikiLink(format!("refs:^{id}").into()));
+                return;
             }
         }
         // A press on a table's hover "+" strip adds a row (below) or column (right).
@@ -9151,6 +9175,7 @@ fn line_run_epoch(font: &Font, st: Option<&SyntaxStyle>) -> u64 {
             hash_hsla(c, &mut h);
         }
         st.mono.family.hash(&mut h);
+        st.block_label_gen.hash(&mut h);
     }
     h.finish()
 }
@@ -9889,7 +9914,24 @@ impl Element for EditorElement {
                     backgrounds.get(i).copied().flatten(),
                     marks.get(i).copied().flatten(),
                 );
-                for (range, _) in markdown_syntax::links(line) {
+                // The reference-count badge over a hidden ` ^id` anchor is
+                // clickable too (skipped on the caret's line, where the raw
+                // anchor is revealed for editing).
+                let badge = editor
+                    .markdown_style
+                    .as_ref()
+                    .and_then(|st| st.block_ref_count.as_ref())
+                    .filter(|_| editor.row_col(editor.selected_range.start).0 != i)
+                    .and_then(|f| {
+                        gpui_markdown::syntax::block_id(line)
+                            .filter(|(_, id)| f(id) > 0)
+                            .map(|(at, _)| at..line.len())
+                    });
+                for range in markdown_syntax::links(line)
+                    .into_iter()
+                    .map(|(r, _)| r)
+                    .chain(badge)
+                {
                     let map = maps.get(i).and_then(Option::as_ref);
                     let d1 = display_col_in(map, range.start);
                     let d2 = display_col_in(map, range.end);

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -9859,7 +9859,7 @@ impl Element for EditorElement {
                     continue;
                 };
                 let line = &editor.content[start..editor.line_end(i)];
-                if markdown_syntax::heading_level(line).is_none() || lh == px(0.) {
+                if markdown_syntax::line_heading_level(line).is_none() || lh == px(0.) {
                     continue;
                 }
                 let top = bounds.origin.y + line_tops[i];

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -8238,7 +8238,7 @@ fn build_prop_panel(
     let mut key_w = px(0.);
     let mut val_w = px(0.);
     for &line in &lines[range.start..range.end] {
-        let Some((k, v)) = gpui_markdown::syntax::property(line) else {
+        let Some((_, k, v)) = gpui_markdown::syntax::prefixed_property(line) else {
             continue;
         };
         key_w = key_w.max(measure_width(window, k, font, font_size));

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -2096,9 +2096,11 @@ pub(crate) fn is_table_row(line: &str) -> bool {
 /// Contiguous runs of `key:: value` property lines (Obsidian/Logseq-style
 /// metadata) — each renders as a two-column panel, the WYSIWYG twin of the
 /// reader's `render_property_table`. A run is one or more adjacent property
-/// lines; any non-property line ends it. Fenced code is skipped so a
-/// `Type::method()` code line isn't mistaken for a property. Returns line-index
-/// ranges in order.
+/// lines; any non-property line ends it. A leading list marker is tolerated
+/// (`- key:: value`, the Logseq props-only-block shape — the reader's parser
+/// consumes the marker and panels it, so the editor matches). Fenced code is
+/// skipped so a `Type::method()` code line isn't mistaken for a property.
+/// Returns line-index ranges in order.
 pub(crate) fn property_regions(content: &str) -> Vec<Range<usize>> {
     let lines: Vec<&str> = content.split('\n').collect();
     let mut out = Vec::new();
@@ -2110,12 +2112,12 @@ pub(crate) fn property_regions(content: &str) -> Vec<Range<usize>> {
             i += 1;
             continue;
         }
-        if !in_fence && gpui_markdown::syntax::property(lines[i]).is_some() {
+        if !in_fence && gpui_markdown::syntax::prefixed_property(lines[i]).is_some() {
             let start = i;
             i += 1;
             while i < lines.len()
                 && !lines[i].trim_start().starts_with("```")
-                && gpui_markdown::syntax::property(lines[i]).is_some()
+                && gpui_markdown::syntax::prefixed_property(lines[i]).is_some()
             {
                 i += 1;
             }
@@ -3162,5 +3164,9 @@ mod tests {
         // A `Type::method()` line inside a code fence isn't a property.
         let r2 = property_regions("```rust\nFoo::bar()\n```\nkey:: v");
         assert_eq!(r2, vec![3..4]);
+        // A list-marker property line (Logseq props-only block) counts too;
+        // an ordinary bullet doesn't.
+        let r3 = property_regions("- status:: open\n  time:: 3pm\n- plain bullet");
+        assert_eq!(r3, vec![0..2]);
     }
 }

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -1232,12 +1232,28 @@ pub(crate) fn heading_level(line: &str) -> Option<u8> {
     ((1..=6).contains(&n) && (n == b.len() || b[n] == b' ')).then_some(n as u8)
 }
 
+/// [`heading_level`], also matching a heading behind a list marker
+/// (`- ### Notes`, the outliner shape). Returns the depth plus the line's
+/// indent when it's a LIST heading (`None` = a top-level heading) — list
+/// headings fold by indent, not by heading boundaries.
+pub(crate) fn line_heading_level(line: &str) -> Option<(u8, Option<usize>)> {
+    if let Some(l) = heading_level(line) {
+        return Some((l, None));
+    }
+    let p = list_prefix(line).map(|(p, ..)| p)?;
+    let l = heading_level(&line[p..])?;
+    Some((l, Some(line.len() - line.trim_start().len())))
+}
+
 /// Line ranges (heading line through section end) of collapsed heading
 /// sections: `folded` holds the trimmed source lines of folded headings
-/// (`## Goals`). A section runs from its heading to the next heading of the
-/// same or a higher level, fence-aware — mirrors
-/// [`gpui_markdown::syntax::extract_section`]. Every line matching a folded
-/// key folds (duplicate headings fold together; the key is the line text).
+/// (`## Goals`). A top-level section runs from its heading to the next
+/// heading of the same or a higher level, fence-aware — mirrors
+/// [`gpui_markdown::syntax::extract_section`]. A LIST heading's section
+/// (`- ### Notes`) is its indented children: it runs while lines sit deeper
+/// than the heading's own indent (blank lines included). Every line matching
+/// a folded key folds (duplicate headings fold together; the key is the line
+/// text).
 pub(crate) fn heading_fold_regions(
     content: &str,
     folded: &std::collections::HashSet<String>,
@@ -1246,6 +1262,7 @@ pub(crate) fn heading_fold_regions(
         return Vec::new();
     }
     let lines: Vec<&str> = content.split('\n').collect();
+    let indent = |l: &str| l.len() - l.trim_start().len();
     let mut out = Vec::new();
     let mut in_fence = false;
     let mut i = 0;
@@ -1258,17 +1275,23 @@ pub(crate) fn heading_fold_regions(
         let level = if in_fence {
             None
         } else {
-            heading_level(lines[i])
+            line_heading_level(lines[i])
         };
         match level {
-            Some(l) if folded.contains(lines[i].trim()) => {
+            Some((l, list_indent)) if folded.contains(lines[i].trim()) => {
                 let start = i;
                 i += 1;
                 while i < lines.len() {
                     if lines[i].trim_start().starts_with("```") {
                         in_fence = !in_fence;
-                    } else if !in_fence && heading_level(lines[i]).is_some_and(|n| n <= l) {
-                        break;
+                    } else if !in_fence {
+                        let stop = match list_indent {
+                            None => heading_level(lines[i]).is_some_and(|n| n <= l),
+                            Some(ind) => !lines[i].trim().is_empty() && indent(lines[i]) <= ind,
+                        };
+                        if stop {
+                            break;
+                        }
                     }
                     i += 1;
                 }
@@ -3154,6 +3177,11 @@ mod tests {
         let folded: std::collections::HashSet<String> = ["# Top".to_string()].into();
         assert_eq!(heading_fold_regions(src, &folded), vec![0..9]);
         assert!(heading_fold_regions(src, &Default::default()).is_empty());
+        // A LIST heading folds its indented children (blanks included) and
+        // stops at the next sibling — not at unrelated later headings.
+        let src = "* ### Notes: ^abc\n  - one\n\n  - two\n* sibling\n# After";
+        let folded: std::collections::HashSet<String> = ["* ### Notes: ^abc".to_string()].into();
+        assert_eq!(heading_fold_regions(src, &folded), vec![0..4]);
     }
 
     #[test]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -52,6 +52,19 @@ pub struct SyntaxStyle {
     pub rule: Hsla,
     /// `<mark>` highlight background.
     pub mark_bg: Hsla,
+    /// Resolves a block link's display text: `(page, id)` → the target
+    /// block's text, host-supplied. `None` (or a `None` return) keeps the
+    /// `Page → id` form.
+    #[allow(clippy::type_complexity)]
+    pub block_label: Option<std::rc::Rc<dyn Fn(&str, &str) -> Option<String>>>,
+    /// Bumped by the host when resolved labels change — part of the line-run
+    /// cache epoch, so cached lines re-key when a target block edits.
+    pub block_label_gen: u64,
+    /// How many pages reference a block id — a non-zero count paints a small
+    /// badge in place of the hidden ` ^id` anchor (Logseq-style; clicking it
+    /// emits `OpenWikiLink("refs:^id")` for the host to list the referencers).
+    /// Count changes ride `block_label_gen` for cache re-keying.
+    pub block_ref_count: Option<BlockRefCountFn>,
     /// Popover/menu surface background (e.g. the right-click table menu).
     pub popover_bg: Hsla,
     /// Popover/menu border.
@@ -96,6 +109,9 @@ impl Style {
 /// icon. Host-provided so the crate makes no assumption about which assets exist.
 pub type PropertyIconFn = std::rc::Rc<dyn Fn(&str) -> Option<gpui::SharedString>>;
 
+/// Maps a block id to how many pages reference it (0 = no badge).
+pub type BlockRefCountFn = std::rc::Rc<dyn Fn(&str) -> usize>;
+
 /// Styling a scanned span adds on top of the editor's base run.
 #[derive(Clone, Default)]
 struct Style {
@@ -122,7 +138,7 @@ struct Style {
     /// What a hidden marker paints in its place (e.g. a block link's `#^`
     /// shows ` → `): every replacement byte maps back to the span's start, so
     /// the display↔source maps stay consistent. `None` = plain removal.
-    replace: Option<&'static str>,
+    replace: Option<SharedString>,
 }
 
 struct Span {
@@ -317,7 +333,7 @@ pub(crate) fn hidden_runs(
     // place). A visible segment is copied verbatim, so source↔display is 1:1
     // within it — which lets a diagnostic (source coords) map straight onto
     // the display.
-    let mut segs: Vec<(Range<usize>, Option<&Style>, Option<&'static str>)> = Vec::new();
+    let mut segs: Vec<(Range<usize>, Option<&Style>, Option<SharedString>)> = Vec::new();
     let mut pos = 0;
     for span in &spans {
         if span.range.start > pos {
@@ -333,7 +349,7 @@ pub(crate) fn hidden_runs(
             && (span.style.always_hide || force || (!reveal_inline && !in_construct && !in_prefix));
         if !hidden {
             segs.push((span.range.clone(), Some(&span.style), None));
-        } else if let Some(rep) = span.style.replace {
+        } else if let Some(rep) = span.style.replace.clone() {
             segs.push((span.range.clone(), Some(&span.style), Some(rep)));
         }
         pos = span.range.end;
@@ -355,7 +371,7 @@ pub(crate) fn hidden_runs(
         // back to the span's start (so caret/click math lands on the marker),
         // and it takes one run in the marker's own style.
         if let Some(rep) = replace {
-            display.push_str(rep);
+            display.push_str(rep.as_ref());
             map.extend(std::iter::repeat_n(src.start, rep.len()));
             runs.push(run_for(
                 rep.len(),
@@ -553,13 +569,35 @@ fn apply_heading(
 /// UTF-8-safe (an ASCII byte never appears inside a multi-byte char).
 fn scan_line(text: &str, start: usize, end: usize, st: &SyntaxStyle, out: &mut Vec<Span>) {
     let b = text.as_bytes();
-    if apply_heading(text, start, end, st, out) {
-        return;
-    }
     // An Obsidian block-id anchor at the line's end (` ^some-id`) is addressing,
     // not content: a marker span dims it and W6 hides it (reveal-on-caret).
-    if let Some((at, _)) = gpui_markdown::syntax::block_id(&text[start..end]) {
-        marker(out, start + at..end, st.marker);
+    // A referenced block instead paints a small count badge in the anchor's
+    // place (Logseq-style; the anchor hitbox/click emit `refs:^id`).
+    // Hidden BEFORE the heading fast-path — heading lines carry anchors too
+    // (`### Notes ^id` used to show the raw tail).
+    let end = match gpui_markdown::syntax::block_id(&text[start..end]) {
+        Some((at, id)) => {
+            let refs = st.block_ref_count.as_ref().map_or(0, |f| f(id));
+            if refs > 0 {
+                let badge = format!(" {}", gpui_markdown::syntax::superscript(refs));
+                out.push(Span {
+                    range: start + at..end,
+                    style: Style {
+                        color: Some(st.tag),
+                        hide: true,
+                        replace: Some(SharedString::from(badge)),
+                        ..Default::default()
+                    },
+                });
+            } else {
+                marker(out, start + at..end, st.marker);
+            }
+            start + at
+        }
+        None => end,
+    };
+    if apply_heading(text, start, end, st, out) {
+        return;
     }
     // Blockquote: leading `>` (GFM nesting) + optional spaces. Hide the markers;
     // the body keeps inline styling over a muted base color (set by the caller).
@@ -859,6 +897,36 @@ fn scan_inline(
             i = rb + 1;
             continue;
         }
+        // Block ref, frontend form: `((id))` — a construct ONLY when the
+        // host's resolver knows the id (so prose parens stay prose). Renders
+        // as the target block's text, link-colored; raw on caret.
+        if c == b'('
+            && !is_backslash_escaped(b, i)
+            && i + 1 < end
+            && b[i + 1] == b'('
+            && let Some(close) = find2(b, i + 2, end, b')', b')')
+        {
+            let id = &text[i + 2..close];
+            let label = (!id.is_empty()
+                && id
+                    .bytes()
+                    .all(|c| c.is_ascii_alphanumeric() || c == b'-' || c == b'_'))
+            .then(|| st.block_label.as_ref().and_then(|f| f("", id)))
+            .flatten();
+            if let Some(label) = label {
+                out.push(Span {
+                    range: i..close + 2,
+                    style: Style {
+                        color: Some(st.link),
+                        hide: true,
+                        replace: Some(SharedString::from(label)),
+                        ..Default::default()
+                    },
+                });
+                i = close + 2;
+                continue;
+            }
+        }
         // Wiki-link: [[Page]] (check before single-[ link).
         if c == b'['
             && !is_backslash_escaped(b, i)
@@ -891,15 +959,38 @@ fn scan_inline(
                 }
                 _ => None,
             };
-            match anchor {
-                Some((a, alen)) if a > 0 && a + alen < target_end => {
+            // (See also the `((id))` frontend form handled below.)
+            // A resolvable `[[Page#^id]]` (no alias) displays the TARGET
+            // BLOCK'S TEXT instead of `Page → id` — the whole inner span
+            // swaps for the resolved label (reveal-on-caret shows the raw
+            // form for editing, like any hidden construct).
+            let resolved = match anchor {
+                Some((a, 2)) if a > 0 && a + 2 < target_end && target_end == inner.len() => st
+                    .block_label
+                    .as_ref()
+                    .and_then(|f| f(&inner[..a], &inner[a + 2..target_end])),
+                _ => None,
+            };
+            match (resolved, anchor) {
+                (Some(label), _) => {
+                    out.push(Span {
+                        range: i + 2..close,
+                        style: Style {
+                            color: Some(st.link),
+                            hide: true,
+                            replace: Some(SharedString::from(label)),
+                            ..Default::default()
+                        },
+                    });
+                }
+                (None, Some((a, alen))) if a > 0 && a + alen < target_end => {
                     push(out, i + 2..i + 2 + a, link.clone());
                     out.push(Span {
                         range: i + 2 + a..i + 2 + a + alen,
                         style: Style {
                             color: Some(st.marker),
                             hide: true,
-                            replace: Some(" → "),
+                            replace: Some(" → ".into()),
                             ..Default::default()
                         },
                     });
@@ -2597,6 +2688,9 @@ mod tests {
     fn test_style() -> SyntaxStyle {
         let c = hsla(0., 0., 0.5, 1.);
         SyntaxStyle {
+            block_label: None,
+            block_label_gen: 0,
+            block_ref_count: None,
             marker: c,
             code: c,
             code_bg: c,

--- a/crates/gpui-markdown/API.md
+++ b/crates/gpui-markdown/API.md
@@ -44,6 +44,7 @@ isn't public. Feature `—` = always compiled (`gpui_markdown::syntax`);
 | [`link_at`](#link_at) | fn | `fn link_at(line: &str, col: usize) -> Option<LinkHit>` | The link under a byte column | — |
 | [`block_id`](#block_id) | fn | `fn block_id(line: &str) -> Option<(usize, &str)>` | Trailing ` ^block-id` anchor on a line | — |
 | [`split_block_anchor`](#split_block_anchor) | fn | `fn split_block_anchor(target: &str) -> (&str, Option<&str>)` | Split `Note#^id` into `(page, block id)` | — |
+| [`superscript`](#superscript) | fn | `fn superscript(n: usize) -> String` | `n` as superscript digits (`¹²`) — the ref-count badge text | — |
 | [`split_heading_anchor`](#split_heading_anchor) | fn | `fn split_heading_anchor(target: &str) -> (&str, Option<&str>)` | Split `Note#Heading` into `(page, heading)` | — |
 | [`find_heading_line`](#find_heading_line) | fn | `fn find_heading_line(content: &str, heading: &str) -> Option<usize>` | Byte offset of a matching ATX heading's line | — |
 | [`find_block_line`](#find_block_line) | fn | `fn find_block_line(content: &str, id: &str) -> Option<usize>` | Byte offset of the line carrying `^id` | — |
@@ -74,7 +75,7 @@ isn't public. Feature `—` = always compiled (`gpui_markdown::syntax`);
 | [`MarkdownView::on_embed_image`](#markdownviewon_embed_image) | builder | `fn on_embed_image(self, renderer: ImageRenderer) -> Self` | Image renderer used *inside* embeds | `view` |
 | [`MarkdownView::folded_headings`](#markdownviewfolded_headings) | builder | `fn folded_headings(self, folded: HashSet<String>) -> Self` | The host-owned set of collapsed headings | `view` |
 | [`MarkdownView::on_heading_toggle`](#markdownviewon_heading_toggle) | builder | `fn on_heading_toggle(self, handler: HeadingToggleHandler) -> Self` | Handle heading fold-chevron clicks | `view` |
-| [`MarkdownStyle`](#struct-markdownstyle) | struct | 19 pub fields | Visual configuration (host maps its theme on) | `view` |
+| [`MarkdownStyle`](#struct-markdownstyle) | struct | 21 pub fields | Visual configuration (host maps its theme on) — incl. `block_label: Option<Rc<dyn Fn(&str, &str) -> Option<String>>>` (block-link display resolver) + `block_ref_count: Option<BlockRefCountFn>` (id → referencing-page count; >0 renders a superscript badge linking to `refs:^id` in place of the hidden ` ^id` anchor) | `view` |
 | `impl Default for MarkdownStyle` | trait impl | `fn default() -> Self` | Neutral dark palette | `view` |
 | [`AlertColors`](#struct-alertcolors) | struct | 5 pub fields | Alert border/title colors, one per kind | `view` |
 | `impl Default for AlertColors` | trait impl | `fn default() -> Self` | GitHub's dark palette | `view` |
@@ -549,6 +550,17 @@ space** starts (so renderers can hide the whole tail) and the id itself
 **Guarantees & edge cases** — the id must be non-empty, made of word chars /
 `-`, and sit at the line's **end** (trailing whitespace tolerated; a mid-line
 `^id` doesn't count).
+
+---
+
+## `superscript`
+
+```rust
+pub fn superscript(n: usize) -> String
+```
+
+`n` rendered as Unicode superscript digits (`12` → `¹²`) — the block
+reference-count badge text, small at any font size. Infallible.
 
 ---
 

--- a/crates/gpui-markdown/src/syntax.rs
+++ b/crates/gpui-markdown/src/syntax.rs
@@ -290,6 +290,9 @@ fn roman(mut n: u32) -> String {
 pub enum LinkHit {
     Page(String),
     Url(String),
+    /// A `((id))` block reference (Logseq-style frontend form) — the host
+    /// resolves the id to its page + anchor.
+    BlockRef(String),
 }
 
 /// Split a wiki-link's inner text into `(target, display)`:
@@ -369,6 +372,23 @@ pub fn links(line: &str) -> Vec<(std::ops::Range<usize>, LinkHit)> {
             }
             i = close + 2;
             continue;
+        }
+        // Block ref: `((id))` — an anchor-shaped id (word chars / `-`).
+        if c == b'('
+            && i + 1 < end
+            && b[i + 1] == b'('
+            && let Some(close) = find2(b, i + 2, end, b')', b')')
+        {
+            let id = &line[i + 2..close];
+            if !id.is_empty()
+                && id
+                    .bytes()
+                    .all(|c| c.is_ascii_alphanumeric() || c == b'-' || c == b'_')
+            {
+                out.push((i..close + 2, LinkHit::BlockRef(id.to_string())));
+                i = close + 2;
+                continue;
+            }
         }
         // Footnote reference [^label]: styled like a link but not one.
         if c == b'['
@@ -451,6 +471,16 @@ pub fn block_id(line: &str) -> Option<(usize, &str)> {
 /// block carrying `^id` on the page `Note`; anything else is a plain page
 /// target. Only the `#^` form is an anchor — a bare `#` stays part of the
 /// title (page names may contain it, and `file.pdf#p3` has its own meaning).
+/// Superscript digits (`¹²…`) for the block reference-count badge — reads
+/// small at any text size, so the badge doesn't shout on heading lines.
+pub fn superscript(n: usize) -> String {
+    const DIGITS: [char; 10] = ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹'];
+    n.to_string()
+        .bytes()
+        .map(|b| DIGITS[(b - b'0') as usize])
+        .collect()
+}
+
 pub fn split_block_anchor(target: &str) -> (&str, Option<&str>) {
     match target.split_once("#^") {
         Some((page, id)) if !page.is_empty() && !id.is_empty() => (page, Some(id)),

--- a/crates/gpui-markdown/src/syntax.rs
+++ b/crates/gpui-markdown/src/syntax.rs
@@ -627,6 +627,31 @@ pub fn property(line: &str) -> Option<(&str, &str)> {
     Some((key, rest[idx + 2..].trim()))
 }
 
+/// [`property`], tolerating a leading list marker — the Logseq shape for a
+/// props-only block (`- key:: value`, also `* ` / `+ ` / `1. ` / `1) `).
+/// Returns `(prefix, key, value)`; `prefix` is everything before the key
+/// (indent + marker), so editors can write the line back unchanged.
+pub fn prefixed_property(line: &str) -> Option<(&str, &str, &str)> {
+    let ws = line.len() - line.trim_start().len();
+    if let Some((k, v)) = property(line) {
+        return Some((&line[..ws], k, v));
+    }
+    let rest = &line[ws..];
+    let body = if let Some(r) = ["- ", "* ", "+ "].iter().find_map(|m| rest.strip_prefix(m)) {
+        r
+    } else {
+        let d = rest.bytes().take_while(u8::is_ascii_digit).count();
+        let b = rest.as_bytes();
+        if d > 0 && rest.len() > d + 1 && matches!(b[d], b'.' | b')') && b[d + 1] == b' ' {
+            &rest[d + 2..]
+        } else {
+            return None;
+        }
+    };
+    let (k, v) = property(body)?;
+    Some((&line[..line.len() - body.len()], k, v))
+}
+
 /// A rendered piece of a property value: literal text, or a link "pill" (a
 /// wiki-link, `#tag`, or URL shown as a rounded chip). Both panels render values
 /// through this so they pill-ify identically.
@@ -973,6 +998,21 @@ mod tests {
         assert_eq!(property("just prose"), None);
         assert_eq!(property(":: value"), None);
         assert_eq!(property("1key:: v"), None);
+    }
+
+    #[test]
+    fn prefixed_property_tolerates_list_markers() {
+        // Plain / indented lines: prefix is the indent.
+        assert_eq!(prefixed_property("k:: v"), Some(("", "k", "v")));
+        assert_eq!(prefixed_property("  k:: v"), Some(("  ", "k", "v")));
+        // List markers (Logseq props-only block), bullets and numbers.
+        assert_eq!(prefixed_property("- k:: v"), Some(("- ", "k", "v")));
+        assert_eq!(prefixed_property("  * k:: v"), Some(("  * ", "k", "v")));
+        assert_eq!(prefixed_property("2. k:: v"), Some(("2. ", "k", "v")));
+        // Not properties: a plain bullet, a task, a numberless dot.
+        assert_eq!(prefixed_property("- plain bullet"), None);
+        assert_eq!(prefixed_property("- [ ] k:: v"), None);
+        assert_eq!(prefixed_property(". k:: v"), None);
     }
 
     #[test]

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -27,6 +27,16 @@ use crate::syntax::{
 /// own theme; defaults are a neutral dark palette.
 #[derive(Clone)]
 pub struct MarkdownStyle {
+    /// Resolves a block link's display text: `(page, id)` → the target
+    /// block's text, host-supplied. `None` (or a `None` return) keeps the
+    /// `Page → id` form.
+    #[allow(clippy::type_complexity)]
+    pub block_label: Option<Rc<dyn Fn(&str, &str) -> Option<String>>>,
+    /// How many pages reference a block id — a non-zero count renders a small
+    /// clickable badge in place of the hidden ` ^id` anchor (Logseq-style),
+    /// linked through the `refs:^id` target the host resolves. `None` (or 0)
+    /// keeps the anchor invisible.
+    pub block_ref_count: Option<BlockRefCountFn>,
     pub text_color: Hsla,
     pub text_size: Pixels,
     /// Body line height as a multiple of `text_size`. Hosts with an editor
@@ -74,6 +84,9 @@ pub struct MarkdownStyle {
 /// icon. Host-provided so the crate makes no assumption about which assets exist.
 pub type PropertyIconFn = Rc<dyn Fn(&str) -> Option<SharedString>>;
 
+/// Maps a block id to how many pages reference it (0 = no badge).
+pub type BlockRefCountFn = Rc<dyn Fn(&str) -> usize>;
+
 /// Per-kind SVG asset paths for the alert title icons.
 #[derive(Clone)]
 pub struct AlertIcons {
@@ -87,6 +100,8 @@ pub struct AlertIcons {
 impl Default for MarkdownStyle {
     fn default() -> Self {
         Self {
+            block_label: None,
+            block_ref_count: None,
             text_color: rgb(0xE6E6E6).into(),
             text_size: px(15.0),
             line_height: 1.45,
@@ -1998,6 +2013,13 @@ fn push_text(
                     let anchored = (display == target).then(|| {
                         let (page, block) = crate::syntax::split_block_anchor(display);
                         if let Some(id) = block {
+                            // A resolvable block link shows the target
+                            // block's text (matching WYSIWYG).
+                            if let Some(label) =
+                                style.block_label.as_ref().and_then(|f| f(page, id))
+                            {
+                                return Some(label);
+                            }
                             return Some(format!("{page} → {id}"));
                         }
                         let (page, heading) = crate::syntax::split_heading_anchor(display);
@@ -2016,15 +2038,52 @@ fn push_text(
             i += 1; // not a valid link; the '[' stays plain
             continue;
         }
+        // A `((id))` frontend block ref (only a construct when the resolver
+        // knows the id — prose parens stay prose): the target block's text,
+        // linked through the anchor-only `#^id` target the host resolves.
+        if value[i..].starts_with("((")
+            && let Some(close) = value[i + 2..].find("))")
+        {
+            let id = &value[i + 2..i + 2 + close];
+            if !id.is_empty()
+                && id
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+                && let Some(label) = style.block_label.as_ref().and_then(|f| f("", id))
+            {
+                out.map(src_base + plain_start);
+                push_run(&value[plain_start..i], cur, out);
+                out.map(src_base + i);
+                push_link(&label, &format!("#^{id}"), style.link_color, cur, out);
+                i += 2 + close + 2;
+                plain_start = i;
+                continue;
+            }
+        }
         // An Obsidian block-id anchor (` ^some-id` at a line's end) is an
         // addressing artifact, not content — hide it (like Obsidian's preview).
+        // A referenced block instead shows a small count badge (Logseq-style),
+        // linked through `refs:^id` for the host to list the referencers.
         // Text nodes carry soft breaks, so a "line end" is a `\n` or the end of
         // the value.
         if bytes[i] == b' ' && value[i + 1..].starts_with('^') {
             let end = value[i..].find('\n').map_or(value.len(), |p| i + p);
-            if crate::syntax::block_id(&value[..end]).is_some_and(|(at, _)| at == i) {
+            if let Some((at, id)) = crate::syntax::block_id(&value[..end])
+                && at == i
+            {
                 out.map(src_base + plain_start);
                 push_run(&value[plain_start..i], cur, out);
+                let refs = style.block_ref_count.as_ref().map_or(0, |f| f(id));
+                if refs > 0 {
+                    out.map(src_base + i);
+                    push_link(
+                        &format!(" {}", crate::syntax::superscript(refs)),
+                        &format!("refs:^{id}"),
+                        style.tag_color,
+                        cur,
+                        out,
+                    );
+                }
                 i = end;
                 plain_start = i;
                 continue;
@@ -2341,6 +2400,11 @@ fn render_property_table(
                                         crate::syntax::LinkHit::Page(t) => {
                                             if let Some(h) = &on_wiki {
                                                 h(t.clone().into(), window, cx);
+                                            }
+                                        }
+                                        crate::syntax::LinkHit::BlockRef(id) => {
+                                            if let Some(h) = &on_wiki {
+                                                h(format!("#^{id}").into(), window, cx);
                                             }
                                         }
                                         crate::syntax::LinkHit::Url(u) => cx.open_url(u),

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -1519,6 +1519,15 @@ fn render_list(list: &mdast::List, ctx: &mut Ctx, depth: usize, window: &mut Win
                     ctx.strike_done = prev_strike;
                 }
             }
+            // A folded heading inside a list item hides the item's remaining
+            // children (its nested sub-list) — the outliner twin of the root
+            // walk's section skip. Siblings are separate topics and stay.
+            if let mdast::Node::Heading(h) = child
+                && heading_fold_key(h, &ctx.source)
+                    .is_some_and(|k| ctx.folded_headings.contains(&k))
+            {
+                break;
+            }
         }
 
         // If the item leads with a heading, nudge the bullet down to the

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -952,7 +952,14 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
             // A block of `key:: value` lines renders as a property panel.
             if let Some(rows) = property_rows(p, &ctx.source.clone()) {
                 ctx.counter += 1;
-                return Some(render_property_table(rows, ctx, ctx.counter));
+                return Some(render_property_table(rows, ctx, ctx.counter, window));
+            }
+            // A MIXED paragraph — prose lines with `key:: value` lines among
+            // them (the Logseq shape: props right under a block's first
+            // line) — renders each property run as a panel between the prose
+            // rows, matching WYSIWYG's line-based property regions.
+            if let Some(el) = render_mixed_properties(p, ctx, window) {
+                return Some(el);
             }
             // A paragraph that *starts* with `![alt](src)` (optionally
             // `{width=N}`) renders as a real image via the host. Any text that
@@ -2341,14 +2348,204 @@ fn property_rows(p: &mdast::Paragraph, source: &str) -> Option<Vec<(String, Stri
     (!rows.is_empty()).then_some(rows)
 }
 
+/// One piece of a mixed prose/property paragraph: clipped prose children, or
+/// a property run's rows (in [`property_rows`]' `(key, value, v_off)` form).
+enum MixedSeg {
+    Prose(Vec<mdast::Node>),
+    Props(Vec<(String, String, usize)>),
+}
+
+/// A paragraph mixing prose lines and `key:: value` lines (the Logseq shape:
+/// properties right under a block's first content line) renders as a column —
+/// prose rows with a property panel per property run. `None` when the
+/// paragraph isn't mixed (all-or-nothing paragraphs keep their fast paths) or
+/// a segment boundary can't be clipped cleanly (falls back to plain prose).
+fn render_mixed_properties(
+    p: &mdast::Paragraph,
+    ctx: &mut Ctx,
+    window: &mut Window,
+) -> Option<AnyElement> {
+    let source = ctx.source.clone();
+    let pos = p.position.as_ref()?;
+    let raw = source.get(pos.start.offset..pos.end.offset)?;
+    // The paragraph's lines with their SOURCE offsets (line-start byte).
+    let mut lines: Vec<(usize, &str)> = Vec::new();
+    let mut off = pos.start.offset;
+    for line in raw.split('\n') {
+        lines.push((off, line));
+        off += line.len() + 1;
+    }
+    let is_prop: Vec<bool> = lines
+        .iter()
+        .map(|(_, l)| crate::syntax::property(l).is_some())
+        .collect();
+    if is_prop.iter().all(|&b| b) || !is_prop.iter().any(|&b| b) {
+        return None; // pure paragraphs keep their existing paths
+    }
+    // Contiguous runs of same-kind lines → segments, clipped up front so any
+    // failure falls back to plain prose rendering before anything is built.
+    let mut segs: Vec<MixedSeg> = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let prop = is_prop[i];
+        let start = i;
+        while i < lines.len() && is_prop[i] == prop {
+            i += 1;
+        }
+        if prop {
+            let rows = lines[start..i]
+                .iter()
+                .map(|(off, line)| {
+                    let (key, value) = crate::syntax::property(line).expect("classified above");
+                    // Value offset: past `key::` + leading whitespace, so
+                    // click-to-edit lands on the value (same as property_rows).
+                    let idx = line.find("::").unwrap_or(0) + 2;
+                    let lead = line[idx..].len() - line[idx..].trim_start().len();
+                    (key.to_string(), value.to_string(), off + idx + lead)
+                })
+                .collect();
+            segs.push(MixedSeg::Props(rows));
+        } else {
+            let seg_start = lines[start].0;
+            let (last_off, last_line) = lines[i - 1];
+            let children =
+                clip_children(&p.children, seg_start..last_off + last_line.len(), &source)?;
+            if !children.is_empty() {
+                segs.push(MixedSeg::Prose(children));
+            }
+        }
+    }
+    let mut column = div().flex().flex_col().gap(px(6.0));
+    for seg in segs {
+        match seg {
+            MixedSeg::Prose(children) => column = column.child(inline_element(&children, ctx)),
+            MixedSeg::Props(rows) => {
+                ctx.counter += 1;
+                column = column.child(render_property_table(rows, ctx, ctx.counter, window));
+            }
+        }
+    }
+    Some(column.into_any_element())
+}
+
+/// The paragraph children falling inside the source range `seg` (a whole
+/// number of lines): wholly-contained children clone as-is; a text node
+/// straddling a boundary is split at its line boundaries (soft breaks live in
+/// text nodes). `None` when a non-text child straddles — the caller falls
+/// back rather than guessing.
+fn clip_children(
+    children: &[mdast::Node],
+    seg: Range<usize>,
+    source: &str,
+) -> Option<Vec<mdast::Node>> {
+    let mut out = Vec::new();
+    for ch in children {
+        let cpos = ch.position()?;
+        let (cs, ce) = (cpos.start.offset, cpos.end.offset);
+        if ce <= seg.start || cs >= seg.end {
+            continue;
+        }
+        if cs >= seg.start && ce <= seg.end {
+            out.push(ch.clone());
+            continue;
+        }
+        // A hard break (two trailing spaces) straddling a segment boundary is
+        // meaningless once the lines split — drop it.
+        if matches!(ch, mdast::Node::Break(_)) {
+            continue;
+        }
+        let mdast::Node::Text(t) = ch else {
+            return None;
+        };
+        out.push(clip_text(t, &seg, source)?);
+    }
+    Some(out)
+}
+
+/// Slice a soft-wrapped text node to the lines intersecting `seg`. Value
+/// lines map 1:1 to the node's source lines, with continuation indent the
+/// parser stripped re-derived per line (`source_line.ends_with(value_line)`),
+/// so the clipped node's position offsets stay exact in source coordinates.
+fn clip_text(t: &mdast::Text, seg: &Range<usize>, source: &str) -> Option<mdast::Node> {
+    let pos = t.position.as_ref()?;
+    let (ns, ne) = (pos.start.offset, pos.end.offset);
+    let src_lines: Vec<&str> = source.get(ns..ne)?.split('\n').collect();
+    let val_lines: Vec<&str> = t.value.split('\n').collect();
+    if src_lines.len() != val_lines.len() {
+        return None;
+    }
+    let mut kept: Vec<&str> = Vec::new();
+    let mut span: Option<(usize, usize)> = None;
+    let mut soff = ns;
+    for (sl, vl) in src_lines.iter().zip(&val_lines) {
+        // The parser strips trailing whitespace (soft breaks, `\r` of CRLF
+        // endings) and leading continuation indent from value lines — compare
+        // against the trimmed source line and re-derive the indent.
+        let st = sl.trim_end();
+        if !st.ends_with(vl) {
+            return None;
+        }
+        let vstart = soff + (st.len() - vl.len());
+        let vend = vstart + vl.len();
+        if vstart < seg.end && vend > seg.start {
+            // Kept lines are consecutive by construction: `seg` is a
+            // contiguous line range, and node lines are walked in order.
+            kept.push(vl);
+            span = Some((span.map_or(vstart, |(s, _)| s), vend));
+        }
+        soff += sl.len() + 1;
+    }
+    let (start, end) = span?;
+    let mut position = pos.clone();
+    position.start.offset = start;
+    position.end.offset = end;
+    Some(mdast::Node::Text(mdast::Text {
+        value: kept.join("\n"),
+        position: Some(position),
+    }))
+}
+
 /// Renders a run of `key:: value` properties as a two-column panel: a muted key
 /// column and the value rendered inline (wiki-links/tags stay live), each row
-/// highlighting on hover.
+/// highlighting on hover. The key column is measured to the widest key (plus
+/// icon room), matching WYSIWYG's panel instead of a fixed width.
 fn render_property_table(
     rows: Vec<(String, String, usize)>,
     ctx: &mut Ctx,
     id: usize,
+    window: &mut Window,
 ) -> AnyElement {
+    let mut key_font = window.text_style().font();
+    key_font.weight = FontWeight::MEDIUM;
+    let key_w = rows.iter().fold(px(0.0), |acc, (k, ..)| {
+        let run = TextRun {
+            len: k.len(),
+            font: key_font.clone(),
+            color: ctx.style.text_color,
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+        };
+        acc.max(
+            window
+                .text_system()
+                .shape_line(
+                    SharedString::from(k.clone()),
+                    ctx.style.text_size,
+                    &[run],
+                    None,
+                )
+                .width(),
+        )
+    });
+    // Icon room (icon + its gap) when the host resolves icons, then the same
+    // 20px of breathing room WYSIWYG's panel gives past the widest key.
+    let icon_indent = if ctx.style.property_icon.is_some() {
+        f32::from(ctx.style.text_size) + 6.0
+    } else {
+        0.0
+    };
+    let key_cell_w = key_w + px(icon_indent + 20.0);
     let key_col = ctx.style.muted_color;
     let tag_c = ctx.style.tag_color;
     let link_c = ctx.style.link_color;
@@ -2418,7 +2615,7 @@ fn render_property_table(
         // Key cell: an optional host-resolved icon, then the muted key name.
         let icon_path = ctx.style.property_icon.as_ref().and_then(|f| f(&key));
         let mut key_cell = div()
-            .w(px(140.0))
+            .w(key_cell_w)
             .flex_shrink_0()
             .flex()
             .items_center()
@@ -3185,6 +3382,37 @@ mod tests {
             panic!("paragraph");
         };
         assert!(property_rows(p2, "k:: v\njust prose").is_none());
+    }
+
+    #[test]
+    fn mixed_property_clipping_survives_real_world_line_endings() {
+        // The Logseq shape: a prose first line, then property lines — with
+        // CRLF endings, a trailing space, and a two-space hard break (a
+        // `Break` child), all of which real vaults carry.
+        let src =
+            "#meeting with [[IPC]] ^abc  \r\ntime:: 14:01 \r\nsubject:: EMS comms\r\nattendees::";
+        let mdast::Node::Root(r) = parse_cached(src).unwrap().as_ref().clone() else {
+            panic!("root");
+        };
+        let mdast::Node::Paragraph(p) = &r.children[0] else {
+            panic!("paragraph");
+        };
+        // Prose segment = line 1 (source byte range).
+        let line1_end = src.find('\n').unwrap(); // includes the \r — a whole line
+        let kids = clip_children(&p.children, 0..line1_end, src)
+            .expect("clip must survive CRLF + trailing spaces + hard breaks");
+        assert_eq!(kids.len(), 1);
+        let mdast::Node::Text(t) = &kids[0] else {
+            panic!("text");
+        };
+        assert_eq!(t.value, "#meeting with [[IPC]] ^abc");
+        let pos = t.position.as_ref().unwrap();
+        assert_eq!(
+            &src[pos.start.offset..pos.end.offset],
+            "#meeting with [[IPC]] ^abc"
+        );
+        // And the property lines still classify (\r-tolerant).
+        assert!(crate::syntax::property("time:: 14:01 \r").is_some());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -414,6 +414,10 @@ struct PdfFieldEdit {
     _sub: gpui::Subscription,
 }
 
+/// `(page, ^id)` → the target block's text — the shape both engines'
+/// styles carry for block-link labels.
+type BlockLabelFn = std::rc::Rc<dyn Fn(&str, &str) -> Option<String>>;
+
 /// (level, page title, rows) — the slash flyout's cached item list.
 type FlyoutCache = (
     slash::SlashLevel,
@@ -500,6 +504,22 @@ pub struct AppView {
     pub slash_flyout_scroll: ScrollHandle,
     /// Flyout rows cache — see [`Self::slash_flyout_items`].
     slash_flyout_cache: std::cell::RefCell<Option<FlyoutCache>>,
+    /// Resolved block-link labels: `^id` → (page title lowercased, the
+    /// target block's text). Filled by `ensure_content_block_labels`; read
+    /// by the resolver both engines' styles carry (`((id))` lookups pass an
+    /// empty page).
+    block_label_store: Rc<std::cell::RefCell<HashMap<String, (String, String)>>>,
+    /// Bumped when the store changes — re-keys the editor's line-run cache
+    /// (threaded through `SyntaxStyle::block_label_gen`).
+    block_label_gen: u64,
+    /// `^id` → page title, for the `((id))` FRONTEND form: editors show/edit
+    /// `((id))`; the DB stores Obsidian `[[Page#^id]]`. Filled at load
+    /// translation, palette picks, and the label-ensure pass.
+    block_ref_index: Rc<std::cell::RefCell<HashMap<String, String>>>,
+    /// `^id` → how many pages reference it, for the count badge painted on a
+    /// referenced block (both views). Cold ids fill in the label-ensure pass;
+    /// the debounced doc-changed refresh re-queries the known set.
+    block_ref_counts: Rc<std::cell::RefCell<HashMap<String, usize>>>,
 
     /// The Windows/Linux in-titlebar menu bar (File/Edit/View). macOS shows the
     /// native menu bar instead; this gives the other OSes visual parity.
@@ -912,6 +932,10 @@ impl AppView {
             slash_scroll: ScrollHandle::new(),
             slash_flyout_scroll: ScrollHandle::new(),
             slash_flyout_cache: std::cell::RefCell::new(None),
+            block_label_store: Rc::new(std::cell::RefCell::new(HashMap::new())),
+            block_label_gen: 0,
+            block_ref_index: Rc::new(std::cell::RefCell::new(HashMap::new())),
+            block_ref_counts: Rc::new(std::cell::RefCell::new(HashMap::new())),
             app_menu_bar: gpui_component::menu::AppMenuBar::new(cx),
             page_editor: None,
             pages: Vec::new(),
@@ -1074,9 +1098,11 @@ impl AppView {
             .flatten()
             .map(|p| p.content)
             .unwrap_or_default();
+        let content = self.to_frontend_refs(&content);
         let state = make_editor(
             &content,
             self.wysiwyg,
+            self.editor_style(),
             self.list_indent,
             self.image_store(),
             self.mermaid_store(),
@@ -1249,6 +1275,9 @@ impl AppView {
                 .flatten()
                 .map(|p| p.content)
                 .unwrap_or_default();
+            // Compare + load in FRONTEND form ((id)) — the DB form would
+            // never match the editor and churn set_text every signal.
+            let content = self.to_frontend_refs(&content);
             if let Some(de) = self.day_editors.get(&date)
                 && de.state.read(cx).value() != content
             {
@@ -1269,6 +1298,8 @@ impl AppView {
     /// Save a page's content to the DB and signal other windows to refresh. The
     /// single choke point for content writes, so every save reaches other windows.
     pub(crate) fn save_page_content(&mut self, id: i64, content: &str, cx: &mut Context<Self>) {
+        // The frontend edits `((id))`; the DB stores Obsidian `[[Page#^id]]`.
+        let content = &self.to_db_refs(content);
         if let Err(e) = self.db.set_page_content(id, content) {
             log::error!("save page {id}: {e}");
         }
@@ -1347,12 +1378,18 @@ impl AppView {
         // created / renamed / deleted elsewhere).
         if let Some(id) = self.page_editor.as_ref().map(|pe| pe.id)
             && let Ok(bl) = self.db.backlinks(id)
-            && let Some(pe) = self.page_editor.as_mut()
-            && pe.id == id
         {
-            pe.backlinks = bl;
-            pe.unlinked = self.db.unlinked_mentions(id).unwrap_or_default();
+            self.warm_backlink_labels(&bl, cx);
+            if let Some(pe) = self.page_editor.as_mut()
+                && pe.id == id
+            {
+                pe.backlinks = bl;
+                pe.unlinked = self.db.unlinked_mentions(id).unwrap_or_default();
+            }
         }
+        // A save anywhere may have added/removed block references — re-check
+        // the badge counts (debounced with the rest of this refresh).
+        self.refresh_block_ref_counts(cx);
         self.refresh_sidebar();
         cx.notify();
     }
@@ -1427,6 +1464,41 @@ impl AppView {
     }
 
     pub fn open_page_title(&mut self, title: &str, window: &mut Window, cx: &mut Context<Self>) {
+        // A block's reference-count badge targets `refs:^id`: list the pages
+        // referencing that block instead of navigating.
+        if let Some(id) = title.strip_prefix("refs:^") {
+            self.show_block_refs_dialog(id.to_string(), window, cx);
+            return;
+        }
+        // A `((id))` frontend ref arrives as a bare `#^id`: resolve its page
+        // through the index, falling back to a content search (ids saved as
+        // literal `((id))` before the index warmed). NEVER get_or_create from
+        // an anchor-only target — that would mint a junk `#^id` page.
+        if let Some(id) = title.strip_prefix("#^") {
+            // Read borrow ends before the fallback's write borrow.
+            let hit = self.block_ref_index.borrow().get(id).cloned();
+            let page = hit.or_else(|| {
+                let hit = self
+                    .db
+                    .page_referencing(&format!(" ^{id}"))
+                    .ok()
+                    .flatten()?;
+                let p = self.db.get_page(hit).ok().flatten()?;
+                let title = p.journal_date.clone().unwrap_or(p.title);
+                self.block_ref_index
+                    .borrow_mut()
+                    .insert(id.to_string(), title.clone());
+                Some(title)
+            });
+            match page {
+                Some(p) => {
+                    let full = format!("{p}#^{id}");
+                    self.open_page_title(&full, window, cx);
+                }
+                None => log::warn!("block ref ^{id}: no page carries the anchor"),
+            }
+            return;
+        }
         // A `[[Note#^block-id]]` link targets a block: open the note, then seat
         // the caret at (and scroll to) the line carrying the `^block-id` anchor.
         // Only the `#^` form is an anchor — a bare `#` stays part of the title.
@@ -2419,9 +2491,11 @@ impl AppView {
             }
         };
         let pid = page.id;
+        let page_content = self.to_frontend_refs(&page.content);
         let state = make_editor(
-            &page.content,
+            &page_content,
             self.wysiwyg,
+            self.editor_style(),
             self.list_indent,
             self.image_store(),
             self.mermaid_store(),
@@ -2559,6 +2633,7 @@ impl AppView {
         });
         let backlinks = self.db.backlinks(pid).unwrap_or_default();
         let unlinked = self.db.unlinked_mentions(pid).unwrap_or_default();
+        self.warm_backlink_labels(&backlinks, cx);
 
         // Inline-editable title: renames the page on Enter or blur.
         let title_state =
@@ -2642,8 +2717,10 @@ impl AppView {
             log::error!("rebuild links for page {source_id}: {e}");
         }
         self.signal_doc_changed(cx);
+        let bl = self.db.backlinks(page_id).unwrap_or_default();
+        self.warm_backlink_labels(&bl, cx);
         if let Some(pe) = self.page_editor.as_mut() {
-            pe.backlinks = self.db.backlinks(page_id).unwrap_or_default();
+            pe.backlinks = bl;
             pe.unlinked = self.db.unlinked_mentions(page_id).unwrap_or_default();
         }
         cx.notify();
@@ -3081,7 +3158,11 @@ impl AppView {
                             // " ^" + 8 hex chars.
                             s.start += id.len() + 2;
                         }
-                        format!("[[{title}#^{id}]]")
+                        // The FRONTEND form; expands to [[title#^id]] at save.
+                        self.block_ref_index
+                            .borrow_mut()
+                            .insert(id.clone(), title.clone());
+                        format!("(({id}))")
                     }
                     None => format!("[[{title}]]"),
                 };
@@ -4304,7 +4385,306 @@ impl AppView {
         }
     }
 
+    /// DB → frontend: unaliased `[[Page#^id]]` block links become `((id))`
+    /// (recording id → page in the index for the reverse trip). Idempotent.
+    fn to_frontend_refs(&self, content: &str) -> String {
+        if !content.contains("#^") {
+            return content.to_string();
+        }
+        let mut out = String::with_capacity(content.len());
+        let mut rest = content;
+        while let Some(open) = rest.find("[[") {
+            let Some(close) = rest[open..].find("]]") else {
+                break;
+            };
+            let inner = &rest[open + 2..open + close];
+            out.push_str(&rest[..open]);
+            match inner.split_once("#^") {
+                Some((page, id))
+                    if !page.is_empty()
+                        && !id.is_empty()
+                        && !id.contains('|')
+                        && id
+                            .bytes()
+                            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_') =>
+                {
+                    self.block_ref_index
+                        .borrow_mut()
+                        .insert(id.to_string(), page.to_string());
+                    out.push_str(&format!("(({id}))"));
+                }
+                _ => out.push_str(&rest[open..open + close + 2]),
+            }
+            rest = &rest[open + close + 2..];
+        }
+        out.push_str(rest);
+        out
+    }
+
+    /// Frontend → DB: `((id))` expands to `[[Page#^id]]` via the index; ids
+    /// the index doesn't know stay literal. Idempotent.
+    fn to_db_refs(&self, content: &str) -> String {
+        if !content.contains("((") {
+            return content.to_string();
+        }
+        let mut out = String::with_capacity(content.len());
+        let mut rest = content;
+        while let Some(open) = rest.find("((") {
+            let Some(close) = rest[open..].find("))") else {
+                break;
+            };
+            let id = &rest[open + 2..open + close];
+            out.push_str(&rest[..open]);
+            match self.block_ref_index.borrow().get(id) {
+                Some(page)
+                    if !id.is_empty()
+                        && id
+                            .bytes()
+                            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_') =>
+                {
+                    out.push_str(&format!("[[{page}#^{id}]]"));
+                }
+                _ => out.push_str(&rest[open..open + close + 2]),
+            }
+            rest = &rest[open + close + 2..];
+        }
+        out.push_str(rest);
+        out
+    }
+
+    /// The block-label resolver both engines' styles carry: a pure store
+    /// lookup (never the DB — this runs during render).
+    pub(crate) fn block_label_resolver(&self) -> BlockLabelFn {
+        let store = self.block_label_store.clone();
+        std::rc::Rc::new(move |page, id| {
+            store.borrow().get(id).and_then(|(p, label)| {
+                (page.is_empty() || *p == page.to_lowercase()).then(|| label.clone())
+            })
+        })
+    }
+
+    /// The block reference-count resolver both engines' styles carry: a pure
+    /// store lookup (never the DB — this runs during render); 0 = no badge.
+    pub(crate) fn block_ref_count_resolver(&self) -> Rc<dyn Fn(&str) -> usize> {
+        let counts = self.block_ref_counts.clone();
+        Rc::new(move |id| counts.borrow().get(id).copied().unwrap_or(0))
+    }
+
+    /// The editor syntax style with the block-label resolver + generation
+    /// installed — every `set_markdown_style` call routes through here.
+    fn editor_style(&self) -> gpui_editor::SyntaxStyle {
+        let mut st = theme::editor_syntax_style();
+        st.block_label = Some(self.block_label_resolver());
+        st.block_label_gen = self.block_label_gen;
+        st.block_ref_count = Some(self.block_ref_count_resolver());
+        st
+    }
+
+    /// Resolve every `[[Page#^id]]` in `content` into the label store (the
+    /// target block's text, prefix-stripped + truncated). A change bumps the
+    /// generation and re-pushes editor styles so cached lines re-key.
+    fn ensure_content_block_labels(&mut self, content: &str, cx: &mut Context<Self>) {
+        let mut changed = false;
+        let rest = content;
+        // Both ref forms: `[[Page#^id]]` (DB/reader form — also warms the
+        // id→page index) and `((id))` (frontend form — page via the index).
+        let mut refs: Vec<(String, String)> = Vec::new();
+        {
+            let mut r = rest;
+            while let Some(open) = r.find("[[") {
+                r = &r[open + 2..];
+                let Some(close) = r.find("]]") else { break };
+                let inner = &r[..close];
+                r = &r[close + 2..];
+                if let Some((page, id)) = inner.split_once("#^")
+                    && !page.is_empty()
+                    && !id.is_empty()
+                    && !id.contains('|')
+                {
+                    self.block_ref_index
+                        .borrow_mut()
+                        .insert(id.to_string(), page.to_string());
+                    refs.push((page.to_string(), id.to_string()));
+                }
+            }
+            let mut r = rest;
+            while let Some(open) = r.find("((") {
+                r = &r[open + 2..];
+                let Some(close) = r.find("))") else { break };
+                let id = &r[..close];
+                r = &r[close + 2..];
+                if id.is_empty()
+                    || !id
+                        .bytes()
+                        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+                {
+                    continue;
+                }
+                // Index first; else find the page CARRYING the anchor (ids
+                // saved as literal `((id))` before the index warmed) and
+                // record it — self-healing for pre-index content. Two
+                // statements: the read borrow must END before the fallback
+                // takes the write borrow.
+                let hit = self.block_ref_index.borrow().get(id).cloned();
+                let page = hit.or_else(|| {
+                    let hit = self
+                        .db
+                        .page_referencing(&format!(" ^{id}"))
+                        .ok()
+                        .flatten()?;
+                    let p = self.db.get_page(hit).ok().flatten()?;
+                    let title = p.journal_date.clone().unwrap_or(p.title);
+                    self.block_ref_index
+                        .borrow_mut()
+                        .insert(id.to_string(), title.clone());
+                    Some(title)
+                });
+                if let Some(page) = page {
+                    refs.push((page, id.to_string()));
+                }
+            }
+        }
+        for (page, id) in refs {
+            let Ok(Some(p)) = self.db.get_page_by_title(&page) else {
+                continue;
+            };
+            let lines: Vec<&str> = p.content.split('\n').collect();
+            let label = lines.iter().enumerate().find_map(|(li, line)| {
+                let (cut, lid) = gpui_markdown::syntax::block_id(line)?;
+                (lid == id).then(|| {
+                    let mut t = line[..cut].trim();
+                    // Strip list/task/heading dressing for a clean label.
+                    for p in ["- [ ] ", "- [x] ", "- [X] ", "- ", "* ", "+ "] {
+                        if let Some(r) = t.strip_prefix(p) {
+                            t = r.trim_start();
+                            break;
+                        }
+                    }
+                    t = t.trim_start_matches('#').trim_start();
+                    let indent = |l: &str| l.len() - l.trim_start().len();
+                    let base = indent(line);
+                    let has_children = lines
+                        .get(li + 1)
+                        .is_some_and(|n| !n.trim().is_empty() && indent(n) > base);
+                    let mut label: String = t.chars().take(60).collect();
+                    if t.chars().count() > 60 || has_children {
+                        label.push('…');
+                    }
+                    label
+                })
+            });
+            if let Some(label) = label {
+                let entry = (page.to_lowercase(), label);
+                if self.block_label_store.borrow().get(&id) != Some(&entry) {
+                    self.block_label_store.borrow_mut().insert(id, entry);
+                    changed = true;
+                }
+            }
+        }
+        // The other side: `^id` anchors this content CARRIES — referenced
+        // ones get a count badge. Only cold ids query the DB; the debounced
+        // doc-changed refresh keeps the known set current.
+        for line in content.split('\n') {
+            if let Some((_, id)) = gpui_markdown::syntax::block_id(line)
+                && !self.block_ref_counts.borrow().contains_key(id)
+            {
+                let n = self.db.count_block_refs(id).unwrap_or(0);
+                self.block_ref_counts.borrow_mut().insert(id.to_string(), n);
+                changed |= n > 0;
+            }
+        }
+        if changed {
+            self.bump_block_meta(cx);
+        }
+    }
+
+    /// Bump the block-metadata generation (labels / ref counts changed) and
+    /// re-push editor styles so cached lines re-key.
+    fn bump_block_meta(&mut self, cx: &mut Context<Self>) {
+        self.block_label_gen += 1;
+        let states: Vec<Entity<EditorState>> = self
+            .day_editors
+            .values()
+            .map(|de| de.state.clone())
+            .chain(self.page_editor.as_ref().map(|pe| pe.state.clone()))
+            .collect();
+        let style = self.editor_style();
+        for state in states {
+            state.update(cx, |editor, cx| {
+                editor.set_markdown_style(style.clone(), cx)
+            });
+        }
+    }
+
+    /// Re-query every known block-ref count (a save may have added or removed
+    /// references anywhere); runs on the debounced doc-changed refresh.
+    fn refresh_block_ref_counts(&mut self, cx: &mut Context<Self>) {
+        let ids: Vec<String> = self.block_ref_counts.borrow().keys().cloned().collect();
+        let mut changed = false;
+        for id in ids {
+            let n = self.db.count_block_refs(&id).unwrap_or(0);
+            changed |= self.block_ref_counts.borrow_mut().insert(id, n) != Some(n);
+        }
+        if changed {
+            self.bump_block_meta(cx);
+        }
+    }
+
+    /// Resolve the block labels referenced inside backlink snippets, so the
+    /// linked-reference cards render `[[Page#^id]]` refs as the block's text.
+    fn warm_backlink_labels(&mut self, links: &[Backlink], cx: &mut Context<Self>) {
+        let snippets: Vec<String> = links
+            .iter()
+            .filter(|b| b.snippet.contains("#^") || b.snippet.contains("(("))
+            .map(|b| b.snippet.clone())
+            .collect();
+        for s in snippets {
+            self.ensure_content_block_labels(&s, cx);
+        }
+    }
+
+    /// Open a linked-reference card's source page and seat the caret at the
+    /// referencing line (Logseq-style jump-to-block). `line` is the 0-based
+    /// line index from [`Backlink`]; the byte offset is recomputed against the
+    /// editor's (frontend-form) content once the page is up.
+    pub fn open_backlink(
+        &mut self,
+        page_id: i64,
+        line: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.db.is_whiteboard(page_id) {
+            self.open_whiteboard(page_id, window, cx);
+            return;
+        }
+        match self.db.get_page(page_id) {
+            Ok(Some(page)) => {
+                self.open_page_foreground(page, window, cx);
+                let weak = cx.entity().downgrade();
+                window.defer(cx, move |window, cx| {
+                    let _ = weak.update(cx, |this, cx| {
+                        let Some(pe) = this.page_editor.as_ref().filter(|pe| pe.id == page_id)
+                        else {
+                            return;
+                        };
+                        let source = pe.state.read(cx).value().to_string();
+                        let offset = source
+                            .split_inclusive('\n')
+                            .take(line)
+                            .map(str::len)
+                            .sum::<usize>();
+                        this.edit_page_at_offset(offset, px(160.0), window, cx);
+                    });
+                });
+            }
+            Ok(None) => log::warn!("page {page_id} not found"),
+            Err(e) => log::error!("open page {page_id}: {e}"),
+        }
+    }
+
     fn ensure_content_math(&mut self, content: &str, cx: &mut Context<Self>) {
+        self.ensure_content_block_labels(content, cx);
         for source in gpui_editor::math_sources(content) {
             self.ensure_math_loaded(source, cx);
         }
@@ -5745,6 +6125,71 @@ impl AppView {
         }
     }
 
+    /// The count badge on a referenced block was clicked: a dialog listing
+    /// every page referencing the block, each row jumping to its reference.
+    fn show_block_refs_dialog(&mut self, id: String, window: &mut Window, cx: &mut Context<Self>) {
+        let refs = self.db.block_referencers(&id).unwrap_or_default();
+        if refs.is_empty() {
+            return;
+        }
+        self.warm_backlink_labels(&refs, cx);
+        let mut style = theme::markdown_style(self.list_indent(), px(13.0));
+        style.block_label = Some(self.block_label_resolver());
+        let weak = cx.entity().downgrade();
+        window.open_dialog(cx, move |dialog, window, _cx| {
+            let mut list = div().flex().flex_col().gap_2();
+            for (i, bl) in refs.iter().enumerate() {
+                let weak_row = weak.clone();
+                let page_id = bl.source_page_id;
+                let line = bl.line;
+                list = list.child(
+                    div()
+                        .id(("block-ref-row", i))
+                        .px_3()
+                        .py_2()
+                        .rounded(px(6.0))
+                        .bg(theme::glass())
+                        .cursor_pointer()
+                        .hover(|h| h.bg(theme::glass_strong()))
+                        .flex()
+                        .flex_col()
+                        .gap_1()
+                        .child(
+                            div()
+                                .text_size(px(11.0))
+                                .text_color(theme::accent())
+                                .child(bl.source_page_title.clone()),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(13.0))
+                                .text_color(theme::text_secondary())
+                                .child(
+                                    gpui_markdown::MarkdownView::new(
+                                        format!("block-ref-md-{i}"),
+                                        bl.snippet.clone(),
+                                    )
+                                    .style(style.clone()),
+                                ),
+                        )
+                        .on_click(move |_, window, cx| {
+                            window.close_dialog(cx);
+                            let _ = weak_row.update(cx, |this, cx| {
+                                this.open_backlink(page_id, line, window, cx)
+                            });
+                        }),
+                );
+            }
+            dialog
+                .title(format!("Linked references ({})", refs.len()))
+                .w(px(480.0))
+                // The default dialog seat (10% down) reads awkwardly for a
+                // click-through list — drop it toward the window's middle.
+                .margin_top(window.viewport_size().height * 0.3)
+                .child(list)
+        });
+    }
+
     /// Open the "insert page card" dialog, then place the chosen page as a card
     /// at world `(x, y)` on board `board_id`.
     fn place_embed_dialog(
@@ -6736,9 +7181,10 @@ impl AppView {
                 .map(|de| de.state.clone())
                 .chain(self.page_editor.as_ref().map(|pe| pe.state.clone()))
                 .collect();
+            let style = self.editor_style();
             for state in states {
                 state.update(cx, |editor, cx| {
-                    editor.set_markdown_style(theme::editor_syntax_style(), cx)
+                    editor.set_markdown_style(style.clone(), cx)
                 });
             }
         }
@@ -7110,10 +7556,11 @@ impl AppView {
             .map(|de| de.state.clone())
             .chain(self.page_editor.as_ref().map(|pe| pe.state.clone()))
             .collect();
+        let style = self.editor_style();
         for state in states {
             state.update(cx, |editor, cx| {
                 if on {
-                    editor.set_markdown_style(theme::editor_syntax_style(), cx);
+                    editor.set_markdown_style(style.clone(), cx);
                 } else {
                     editor.clear_markdown_style(cx);
                 }
@@ -8817,6 +9264,7 @@ impl AppView {
                 // Backlink snippets now show the rewritten `[[new]]` text.
                 let backlinks = self.db.backlinks(id).unwrap_or_default();
                 let unlinked = self.db.unlinked_mentions(id).unwrap_or_default();
+                self.warm_backlink_labels(&backlinks, cx);
                 if let Some(pe) = self.page_editor.as_mut() {
                     pe.title = new_title.clone();
                     pe.backlinks = backlinks;
@@ -9841,6 +10289,7 @@ fn align_caret_to_click(mut state: CaretAlign, window: &mut Window) {
 fn make_editor(
     content: &str,
     wysiwyg: bool,
+    style: gpui_editor::SyntaxStyle,
     list_indent: usize,
     image_store: Rc<RefCell<crate::images::ImageStore>>,
     mermaid_store: Rc<RefCell<crate::mermaid::MermaidStore>>,
@@ -9937,7 +10386,7 @@ fn make_editor(
     // you type (W1). Off = plain raw markdown ("editor mode").
     if wysiwyg {
         editor.update(cx, |editor, cx| {
-            editor.set_markdown_style(theme::editor_syntax_style(), cx)
+            editor.set_markdown_style(style.clone(), cx)
         });
     }
     editor

--- a/src/app.rs
+++ b/src/app.rs
@@ -2788,6 +2788,10 @@ impl AppView {
                 slash::build_link_items(&query, &linkable, &self.aliases)
             }
             Trigger::Tag => slash::build_tag_items(&query, &self.pages),
+            Trigger::BlockRef => {
+                let rows = self.db.search_rows(&query, 40).unwrap_or_default();
+                slash::build_block_ref_items(&query, &rows)
+            }
             Trigger::Placeholder => slash::build_placeholder_items(&query),
             Trigger::Math => slash::build_math_items(&query),
         };
@@ -2909,6 +2913,81 @@ impl AppView {
         }));
     }
 
+    /// The anchor id of `line` in page `page_id`, creating one when the line
+    /// has none: a ` ^id` (8 hex chars, hashed from the page + line) appends
+    /// to the line — through the OPEN editor when there is one (undo +
+    /// autosave), else straight to the DB. `None` when the line can't carry
+    /// an anchor (shifted content, fences, table rows).
+    fn ensure_block_anchor(
+        &mut self,
+        page_id: i64,
+        line_idx: usize,
+        cx: &mut Context<Self>,
+    ) -> Option<(String, usize)> {
+        let p = self.db.get_page(page_id).ok()??;
+        let lines: Vec<&str> = p.content.split('\n').collect();
+        let line = *lines.get(line_idx)?;
+        if let Some((_, id)) = gpui_markdown::syntax::block_id(line) {
+            return Some((id.to_string(), usize::MAX));
+        }
+        let t = line.trim_start();
+        if t.is_empty() || t.starts_with("```") || t.starts_with('|') {
+            return None;
+        }
+        let id = {
+            use std::hash::{Hash, Hasher};
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            page_id.hash(&mut h);
+            line_idx.hash(&mut h);
+            line.hash(&mut h);
+            format!("{:08x}", h.finish() as u32)
+        };
+        // Byte range of the line's trimmed end, so the anchor lands before
+        // any trailing whitespace is dropped.
+        let start: usize = lines[..line_idx].iter().map(|l| l.len() + 1).sum();
+        let end = start + line.trim_end().len();
+        let anchor = format!(" ^{id}");
+        // Route through the open editor (keeps its undo history; its Changed
+        // event autosaves) — the day's editor for journals, the open page's
+        // otherwise. Fall back to a direct DB save.
+        let open_editor = if p.is_journal {
+            p.journal_date
+                .as_deref()
+                .and_then(|d| self.day_editors.get(d))
+                .map(|de| de.state.clone())
+        } else {
+            self.page_editor
+                .as_ref()
+                .filter(|pe| pe.id == page_id)
+                .map(|pe| pe.state.clone())
+        };
+        match open_editor {
+            Some(state) => {
+                state.update(cx, |e, cx| {
+                    // The anchor edit must not move the USER'S caret — this
+                    // may be the very document the palette is open in.
+                    let old = e.cursor();
+                    e.replace_range(end..end, &anchor, cx);
+                    let restored = if old >= end { old + anchor.len() } else { old };
+                    e.set_cursor(restored.min(e.value().len()), cx);
+                    cx.emit(gpui_editor::EditorEvent::Changed);
+                });
+            }
+            None => {
+                let mut new = p.content.clone();
+                new.replace_range(end..end, &anchor);
+                match (p.is_journal, p.journal_date.as_deref()) {
+                    (true, Some(d)) => {
+                        let d = d.to_string();
+                        self.save_journal(&d, &new, cx);
+                    }
+                    _ => self.save_page_content(page_id, &new, cx),
+                }
+            }
+        }
+        Some((id, end))
+    }
+
     fn slash_title(&self, target: &SlashTarget) -> String {
         match target {
             SlashTarget::Day(d) => d.clone(),
@@ -2928,6 +3007,7 @@ impl AppView {
             OpenPicker(SlashTarget, usize, gpui::Bounds<gpui::Pixels>),
             Property(SlashTarget),
             Game,
+            BlockRef(i64, String, usize),
         }
         // With the flyout focused, Enter accepts ITS highlighted row.
         let flyout_item = self
@@ -2953,6 +3033,9 @@ impl AppView {
                 ItemKind::TablePicker => Act::OpenPicker(s.target.clone(), s.start, s.caret),
                 ItemKind::Property => Act::Property(s.target.clone()),
                 ItemKind::Game => Act::Game,
+                ItemKind::BlockRefPick { page, title, line } => {
+                    Act::BlockRef(*page, title.clone(), *line)
+                }
             }
         };
         match act {
@@ -2974,6 +3057,37 @@ impl AppView {
                 self.open_game(window, cx);
             }
             Act::Insert(snippet, caret) => self.insert_slash(snippet, caret, window, cx),
+            // A picked block: anchor its line (if it has no ` ^id` yet), then
+            // link to it. An unanchorable line degrades to a page link.
+            Act::BlockRef(page, title, line) => {
+                // A same-document ref: the anchor insertion shifts everything
+                // after it — including the palette's trigger offset.
+                let same_doc = self.slash.as_ref().is_some_and(|s| match &s.target {
+                    SlashTarget::Page(pid) => *pid == page,
+                    SlashTarget::Day(d) => self
+                        .db
+                        .get_page(page)
+                        .ok()
+                        .flatten()
+                        .is_some_and(|p| p.journal_date.as_deref() == Some(d.as_str())),
+                });
+                let snippet = match self.ensure_block_anchor(page, line, cx) {
+                    Some((id, at)) => {
+                        if same_doc
+                            && at != usize::MAX
+                            && let Some(s) = self.slash.as_mut()
+                            && at <= s.start
+                        {
+                            // " ^" + 8 hex chars.
+                            s.start += id.len() + 2;
+                        }
+                        format!("[[{title}#^{id}]]")
+                    }
+                    None => format!("[[{title}]]"),
+                };
+                let caret = snippet.len();
+                self.insert_slash(snippet, caret, window, cx);
+            }
             Act::Property(target) => {
                 // Insert a placeholder property line, then open the in-place
                 // form on it with the key field ready to type/pick.
@@ -3204,6 +3318,12 @@ impl AppView {
                 tail += closer.len();
                 break;
             }
+        }
+        // The block-ref palette opens on `((` but inserts a `[[…]]` link —
+        // a `))` sitting right after the caret is the trigger's own closer
+        // (typed Logseq-style), not content: absorb it too.
+        if s.trigger == Trigger::BlockRef && value[tail..].starts_with("))") {
+            tail += 2;
         }
         let new = format!("{}{}{}", &value[..start], snippet, &value[tail..]);
         let caret_off = start + caret;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1202,6 +1202,7 @@ impl Db {
                 source_page_id: id,
                 source_page_title: source_title,
                 snippet: clip_line(content[line_start..line_end].trim()),
+                line: content[..line_start].matches('\n').count(),
             });
         }
         Ok(out)
@@ -1226,14 +1227,15 @@ impl Db {
             .collect()
     }
 
-    /// Pages that link to `page_id`, each with the linking line as a
-    /// snippet — the "Linked References" list.
+    /// Pages that link to `page_id`, each with the referencing block (line +
+    /// indented children) as a markdown snippet — the "Linked References"
+    /// list. `line` locates the reference for jump-to-block.
     pub fn backlinks(&self, page_id: i64) -> rusqlite::Result<Vec<Backlink>> {
         let Some(target) = self.get_page(page_id)? else {
             return Ok(Vec::new());
         };
         let mut stmt = self.conn.prepare(
-            "SELECT p.id, p.title, p.content FROM page_links l \
+            "SELECT p.id, p.title, p.content, p.kind FROM page_links l \
              JOIN pages p ON p.id = l.source_page_id \
              WHERE l.target_page_id = ?1 AND p.id != ?1 \
              ORDER BY p.is_journal DESC, p.journal_date DESC, p.title COLLATE NOCASE",
@@ -1243,15 +1245,31 @@ impl Db {
                 row.get::<_, i64>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
             ))
         })?;
         let mut out = Vec::new();
         for r in rows {
-            let (id, title, content) = r?;
+            let (id, title, content, kind) = r?;
+            // A whiteboard's content is scene JSON, not prose.
+            if kind == "whiteboard" {
+                out.push(Backlink {
+                    source_page_id: id,
+                    source_page_title: title,
+                    snippet: "Whiteboard".into(),
+                    line: 0,
+                });
+                continue;
+            }
+            let (line, snippet) = match find_reference(&content, &target.title) {
+                Some((line, off)) => (line, reference_block(&content, off)),
+                None => (0, snippet(&content, &format!("[[{}]]", target.title))),
+            };
             out.push(Backlink {
                 source_page_id: id,
                 source_page_title: title,
-                snippet: snippet(&content, &format!("[[{}]]", target.title)),
+                snippet,
+                line,
             });
         }
         Ok(out)
@@ -1319,6 +1337,66 @@ impl Db {
         Ok(rows)
     }
 
+    /// How many pages reference block `id` — via the DB form `[[Page#^id]]`
+    /// or a literal `((id))` — for the block's reference-count badge.
+    /// Whiteboards are excluded (scene JSON, not prose).
+    pub fn count_block_refs(&self, id: &str) -> rusqlite::Result<usize> {
+        let db_form = format!("%#^{}]]%", escape_like(id));
+        let fe_form = format!("%(({}))%", escape_like(id));
+        self.conn
+            .query_row(
+                "SELECT COUNT(*) FROM pages \
+                 WHERE (content LIKE ?1 ESCAPE '\\' OR content LIKE ?2 ESCAPE '\\') \
+                 AND kind != 'whiteboard'",
+                params![db_form, fe_form],
+                |r| r.get::<_, i64>(0),
+            )
+            .map(|n| n as usize)
+    }
+
+    /// The pages behind [`Self::count_block_refs`], each with its referencing
+    /// block as a snippet — the badge's click-through list.
+    pub fn block_referencers(&self, id: &str) -> rusqlite::Result<Vec<Backlink>> {
+        let db_form = format!("%#^{}]]%", escape_like(id));
+        let fe_form = format!("%(({}))%", escape_like(id));
+        let mut stmt = self.conn.prepare(
+            "SELECT id, title, content FROM pages \
+             WHERE (content LIKE ?1 ESCAPE '\\' OR content LIKE ?2 ESCAPE '\\') \
+             AND kind != 'whiteboard' \
+             ORDER BY is_journal DESC, journal_date DESC, title COLLATE NOCASE",
+        )?;
+        let rows = stmt.query_map(params![db_form, fe_form], |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+            ))
+        })?;
+        let needles = [format!("#^{id}]]"), format!("(({id}))")];
+        let mut out = Vec::new();
+        for r in rows {
+            let (pid, title, content) = r?;
+            let mut line = 0;
+            let mut off = 0;
+            let mut scan = 0;
+            for (idx, l) in content.split('\n').enumerate() {
+                if needles.iter().any(|n| l.contains(n.as_str())) {
+                    line = idx;
+                    off = scan;
+                    break;
+                }
+                scan += l.len() + 1;
+            }
+            out.push(Backlink {
+                source_page_id: pid,
+                source_page_title: title,
+                snippet: reference_block(&content, off),
+                line,
+            });
+        }
+        Ok(out)
+    }
+
     /// The id of a page whose content references `needle` (e.g. an image path) —
     /// used to jump to the page that shows a file found in search. First match by
     /// the usual ordering (journals newest-first, then title).
@@ -1353,6 +1431,53 @@ pub(crate) fn snippet(content: &str, needle: &str) -> String {
         .unwrap_or("")
         .trim();
     clip_line(line)
+}
+
+/// The first line whose links target `title` (a `[[wiki]]`, anchored
+/// `[[title#…]]`, or `#tag` form, case-insensitive), as
+/// `(line index, byte offset of the line start)`.
+fn find_reference(content: &str, title: &str) -> Option<(usize, usize)> {
+    use gpui_markdown::syntax::{LinkHit, links, split_block_anchor, split_heading_anchor};
+    let mut off = 0;
+    for (idx, line) in content.split('\n').enumerate() {
+        for (_, hit) in links(line) {
+            if let LinkHit::Page(t) = hit {
+                let base = split_heading_anchor(split_block_anchor(&t).0).0;
+                if t.eq_ignore_ascii_case(title) || base.eq_ignore_ascii_case(title) {
+                    return Some((idx, off));
+                }
+            }
+        }
+        off += line.len() + 1;
+    }
+    None
+}
+
+/// The referencing block, Logseq-style: the line at `line_start` plus its
+/// more-indented children, dedented to the line's own indent and capped.
+fn reference_block(content: &str, line_start: usize) -> String {
+    const MAX_LINES: usize = 8;
+    fn indent(l: &str) -> usize {
+        l.len() - l.trim_start().len()
+    }
+    fn dedent(l: &str, base: usize) -> &str {
+        &l[indent(l).min(base)..]
+    }
+    let mut it = content[line_start..].split('\n');
+    let first = it.next().unwrap_or("");
+    let base = indent(first);
+    let mut out = vec![dedent(first, base).to_string()];
+    for line in it {
+        if line.trim().is_empty() || indent(line) <= base {
+            break;
+        }
+        if out.len() == MAX_LINES {
+            out.push("…".into());
+            break;
+        }
+        out.push(dedent(line, base).to_string());
+    }
+    out.join("\n")
 }
 
 /// Truncate a snippet line to a readable length.

--- a/src/import/logseq.rs
+++ b/src/import/logseq.rs
@@ -717,10 +717,24 @@ fn is_internal_prop(key: &str) -> bool {
 
 use gpui_markdown::syntax::property as parse_prop;
 
+/// The import-side identity of a block carrying an `id::` property.
+struct BlockRef {
+    /// The page title / journal date the block lands in — the `[[target#^id]]`
+    /// link target. Empty when unknown (highlights pages): refs fall back to
+    /// the inlined text.
+    target: String,
+    /// The block's first content line — the inline fallback.
+    text: String,
+}
+
 /// Per-import conversion state: the block-ref map and pending asset copies.
 struct Converter {
-    /// `id:: <uuid>` → that block's first content line, for `((ref))`s.
-    id_map: HashMap<String, String>,
+    /// `id:: <uuid>` → its block's identity, for `((ref))`s (issue #53:
+    /// refs become real block LINKS, not inlined text).
+    id_map: HashMap<String, BlockRef>,
+    /// Ids some `((…))` references anywhere in the vault — their blocks get
+    /// a ` ^short` anchor on import so the links have a destination.
+    referenced: std::collections::HashSet<String>,
     /// Asset files to copy: (source path, managed ref like `images/x.png`).
     copies: Vec<(PathBuf, String)>,
     assets_dir: PathBuf,
@@ -738,6 +752,7 @@ impl Converter {
     fn new(root: &Path) -> Self {
         Self {
             id_map: HashMap::new(),
+            referenced: std::collections::HashSet::new(),
             copies: Vec::new(),
             assets_dir: root.join("assets"),
             warnings: Vec::new(),
@@ -745,7 +760,8 @@ impl Converter {
     }
 
     /// Pass 1: collect `id::` properties so `((block-ref))`s can resolve.
-    fn collect_ids(&mut self, blocks: &[Block]) {
+    /// `target` is the page title / journal date the block will land in.
+    fn collect_ids(&mut self, blocks: &[Block], target: Option<&str>) {
         for b in blocks {
             let Some(id) = b
                 .lines
@@ -760,7 +776,25 @@ impl Converter {
                 .find(|l| !l.trim().is_empty() && parse_prop(l).is_none())
                 .map(|l| l.trim().to_string())
                 .unwrap_or_default();
-            self.id_map.insert(id, text);
+            self.id_map.insert(
+                id,
+                BlockRef {
+                    target: target.unwrap_or_default().to_string(),
+                    text,
+                },
+            );
+        }
+    }
+
+    /// Pass 1: every `((id))` the raw text references, so pass 2 can anchor
+    /// exactly the blocks that need it.
+    fn collect_refs(&mut self, text: &str) {
+        let mut rest = text;
+        while let Some(p) = rest.find("((") {
+            rest = &rest[p + 2..];
+            if let Some(end) = rest.find("))") {
+                self.referenced.insert(rest[..end].trim().to_string());
+            }
         }
     }
 
@@ -863,6 +897,26 @@ impl Converter {
         }
         if lines.is_empty() {
             return None;
+        }
+        // A block whose `id::` some `((ref))` targets gets a ` ^short` anchor
+        // on its first plain content line, so the imported `[[page#^short]]`
+        // links land (issue #53). Fence/table lines can't carry anchors — if
+        // the block has no plain line, the link degrades to page navigation.
+        if let Some(id) = block.lines.iter().find_map(|l| {
+            parse_prop(l).and_then(|(k, v)| (k == "id").then(|| v.trim().to_string()))
+        }) && self.referenced.contains(&id)
+            && let Some(first) = lines.iter_mut().find(|l| {
+                let t = l.trim_start();
+                !t.is_empty()
+                    && parse_prop(l).is_none()
+                    && !t.starts_with('|')
+                    && !t.starts_with("```")
+            })
+        {
+            let anchor = format!(" ^{}", short_block_id(&id));
+            if !first.ends_with(&anchor) {
+                first.push_str(&anchor);
+            }
         }
         let task = convert_task(&mut lines[0]);
         Some(ConvBlock {
@@ -987,7 +1041,7 @@ fn strip_priority(text: &str) -> &str {
 /// `{{video url}}` → url, `{{embed [[X]]}}` → `[[X]]`, `{{embed ((id))}}` →
 /// the block's text; queries and anything unrecognized stay visible as
 /// inline code so nothing is silently lost.
-fn convert_macros(line: &str, id_map: &HashMap<String, String>) -> String {
+fn convert_macros(line: &str, id_map: &HashMap<String, BlockRef>) -> String {
     let mut out = String::new();
     let mut rest = line;
     while let Some(start) = rest.find("{{") {
@@ -1002,7 +1056,7 @@ fn convert_macros(line: &str, id_map: &HashMap<String, String>) -> String {
             let target = target.trim();
             if let Some(id) = target.strip_prefix("((").and_then(|t| t.strip_suffix("))")) {
                 match id_map.get(id.trim()) {
-                    Some(text) => out.push_str(text),
+                    Some(r) => out.push_str(&r.text),
                     None => out.push_str(target),
                 }
             } else {
@@ -1018,7 +1072,7 @@ fn convert_macros(line: &str, id_map: &HashMap<String, String>) -> String {
 }
 
 /// `((uuid))` → the referenced block's text (left as-is when unknown).
-fn convert_block_refs(line: &str, id_map: &HashMap<String, String>) -> String {
+fn convert_block_refs(line: &str, id_map: &HashMap<String, BlockRef>) -> String {
     let mut out = String::new();
     let mut rest = line;
     while let Some(start) = rest.find("((") {
@@ -1028,13 +1082,25 @@ fn convert_block_refs(line: &str, id_map: &HashMap<String, String>) -> String {
         let inner = rest[start + 2..start + end].trim();
         out.push_str(&rest[..start]);
         match id_map.get(inner) {
-            Some(text) => out.push_str(text),
+            // A known block on a known page: a real block link (issue #53) —
+            // the target block gets a matching ` ^short` anchor on import.
+            Some(r) if !r.target.is_empty() => {
+                out.push_str(&format!("[[{}#^{}]]", r.target, short_block_id(inner)));
+            }
+            // Known block, unknown page (highlights): the old inline text.
+            Some(r) => out.push_str(&r.text),
             None => out.push_str(&rest[start..start + end + 2]),
         }
         rest = &rest[start + end + 2..];
     }
     out.push_str(rest);
     out
+}
+
+/// The imported anchor id for a Logseq block uuid: its first 8 hex chars —
+/// short enough to live in the source, unique enough for a vault.
+fn short_block_id(uuid: &str) -> &str {
+    &uuid[..8.min(uuid.len())]
 }
 
 /// `[[A/B]]` → `[[A::B]]` (segments trimmed) and `#[[multi word]]` →
@@ -1341,7 +1407,27 @@ pub fn read_graph(root: &Path, opts: &Options) -> Result<ImportBundle, String> {
             }
         };
         let blocks = parse_outline(&text);
-        conv.collect_ids(&blocks);
+        // The link target a block on this file resolves to: the page's final
+        // title (a first-block `title::` overrides the filename) or the
+        // journal date. Highlights pages derive titles later — their ids fall
+        // back to inlined text.
+        let target = match &file.kind {
+            Kind::Journal(date) => Some(date.clone()),
+            Kind::Page(title_guess) => Some(
+                blocks
+                    .first()
+                    .and_then(|b| {
+                        b.lines.iter().find_map(|l| {
+                            parse_prop(l)
+                                .and_then(|(k, v)| (k == "title").then(|| name_to_title(v)))
+                        })
+                    })
+                    .unwrap_or_else(|| title_guess.clone()),
+            ),
+            Kind::Highlights => None,
+        };
+        conv.collect_ids(&blocks, target.as_deref());
+        conv.collect_refs(&text);
         parsed.push((file.kind, blocks));
     }
 
@@ -1416,6 +1502,65 @@ pub fn read_graph(root: &Path, opts: &Options) -> Result<ImportBundle, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn block_refs_import_as_links_with_anchors() {
+        // A synthetic vault: a target block with an id, a ref to it, a
+        // title::-renamed page, a journal block, and an unresolvable ref.
+        let root = std::env::temp_dir().join(format!("zorite-logseq-refs-{}", std::process::id()));
+        let pages = root.join("pages");
+        let journals = root.join("journals");
+        std::fs::create_dir_all(&pages).unwrap();
+        std::fs::create_dir_all(&journals).unwrap();
+        std::fs::write(
+            pages.join("Target.md"),
+            "- first line\n  id:: 638b7565-ac9b-4d71-ac77-758bc6ceec42\n- other\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pages.join("Renamed.md"),
+            "- title:: Actual Name\n- kept\n  id:: 12345678-aaaa-bbbb-cccc-ddddeeee0000\n",
+        )
+        .unwrap();
+        std::fs::write(
+            journals.join("2024_02_07.md"),
+            "- day block\n  id:: aaaabbbb-cccc-dddd-eeee-ffff00001111\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pages.join("Source.md"),
+            "- see ((638b7565-ac9b-4d71-ac77-758bc6ceec42)) here\n\
+             - renamed ((12345678-aaaa-bbbb-cccc-ddddeeee0000))\n\
+             - day ((aaaabbbb-cccc-dddd-eeee-ffff00001111))\n\
+             - broken ((00000000-0000-0000-0000-000000000000))\n",
+        )
+        .unwrap();
+
+        let bundle = read_graph(&root, &Options { flatten: true }).unwrap();
+        std::fs::remove_dir_all(&root).ok();
+
+        let page = |t: &str| {
+            bundle
+                .pages
+                .iter()
+                .find(|p| p.title == t)
+                .unwrap_or_else(|| panic!("page {t} missing"))
+        };
+        // Referenced blocks grew anchors on their first content line.
+        assert!(page("Target").content.contains("first line ^638b7565"));
+        assert!(page("Actual Name").content.contains("kept ^12345678"));
+        assert!(bundle.days[0].content.contains("day block ^aaaabbbb"));
+        // Refs became block links — to the FINAL titles.
+        let src = &page("Source").content;
+        assert!(src.contains("see [[Target#^638b7565]] here"), "{src}");
+        assert!(src.contains("renamed [[Actual Name#^12345678]]"), "{src}");
+        assert!(src.contains("day [[2024-02-07#^aaaabbbb]]"), "{src}");
+        // An id nothing declares stays literal.
+        assert!(
+            src.contains("((00000000-0000-0000-0000-000000000000))"),
+            "{src}"
+        );
+    }
 
     // -- filenames --
 
@@ -1644,13 +1789,32 @@ mod tests {
             "`{{query (task TODO)}}`"
         );
         let mut ids = HashMap::new();
-        ids.insert("abc".to_string(), "the block text".to_string());
+        ids.insert(
+            "abc".to_string(),
+            BlockRef {
+                target: String::new(),
+                text: "the block text".to_string(),
+            },
+        );
+        // No known target page: embeds and refs fall back to inlined text.
         assert_eq!(convert_macros("{{embed ((abc))}}", &ids), "the block text");
         assert_eq!(
             convert_block_refs("see ((abc)) here", &ids),
             "see the block text here"
         );
         assert_eq!(convert_block_refs("((missing))", &ids), "((missing))");
+        // A known target: a block link with the shortened anchor id.
+        ids.insert(
+            "638b7565-ac9b-4d71-ac77-758bc6ceec42".to_string(),
+            BlockRef {
+                target: "Target".to_string(),
+                text: "first line".to_string(),
+            },
+        );
+        assert_eq!(
+            convert_block_refs("((638b7565-ac9b-4d71-ac77-758bc6ceec42))", &ids),
+            "[[Target#^638b7565]]"
+        );
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -24,11 +24,15 @@ pub struct Page {
 }
 
 /// One row of a page's "Linked References" panel: another page whose
-/// text links to the page being viewed, with the linking line as a
-/// snippet.
+/// text links to the page being viewed, with the linking block as a
+/// markdown snippet.
 #[derive(Clone, Debug)]
 pub struct Backlink {
     pub source_page_id: i64,
     pub source_page_title: String,
     pub snippet: String,
+    /// 0-based line index of the referencing line in the source content —
+    /// stable across the DB↔frontend `[[Page#^id]]`↔`((id))` rewrite (which
+    /// never adds or removes newlines). 0 when the line couldn't be located.
+    pub line: usize,
 }

--- a/src/slash.rs
+++ b/src/slash.rs
@@ -32,6 +32,9 @@ pub enum Trigger {
     Tag,
     /// `{{` — template placeholder.
     Placeholder,
+    /// `((` — Logseq-style block reference: search blocks by content, pick
+    /// one, and a `[[Page#^id]]` link lands (anchoring the target if needed).
+    BlockRef,
     /// `\` inside a `$$…$$` block — a LaTeX command.
     Math,
 }
@@ -49,6 +52,13 @@ pub enum ItemKind {
     Property,
     /// The hidden `/play` easter egg — only offered on that exact query.
     Game,
+    /// Link the picked block: page row id + final title + the block's line
+    /// index — accept anchors the line (if needed) and inserts the link.
+    BlockRefPick {
+        page: i64,
+        title: String,
+        line: usize,
+    },
 }
 
 /// One entry in the open palette.
@@ -111,6 +121,15 @@ pub fn detect(value: &str, cursor: usize) -> Option<(Trigger, usize, String)> {
     }
     if let Some((start, q)) = detect_bracket(value, cursor, "{{", "}}") {
         return Some((Trigger::Placeholder, start, q));
+    }
+    // Block ref: `((` — but never inside math (block, inline, or a same-line
+    // `$$…$$` being typed), where parens are just parens.
+    if !in_math_block(value, cursor)
+        && !in_inline_math(value, cursor)
+        && !in_inline_display_math(value, cursor)
+        && let Some((start, q)) = detect_bracket(value, cursor, "((", "))")
+    {
+        return Some((Trigger::BlockRef, start, q));
     }
     // Tag: `#` at a boundary with at least one tag char after it, so a lone
     // `#` and markdown headings (`# `) don't trigger.
@@ -175,6 +194,18 @@ fn in_math_block(value: &str, cursor: usize) -> bool {
 /// inline math, the way [`in_math_block`] does for `$$` blocks. A text line carrying inline math
 /// has single `$`; `\$` (escaped) doesn't count.
 fn in_inline_math(value: &str, cursor: usize) -> bool {
+    dollars_before(value, cursor) % 2 == 1
+}
+
+/// Whether `cursor` sits inside a same-line `$$…$$` display span being typed:
+/// an even `$` count forming an odd number of `$$` pairs precedes it.
+fn in_inline_display_math(value: &str, cursor: usize) -> bool {
+    let n = dollars_before(value, cursor);
+    n.is_multiple_of(2) && (n / 2) % 2 == 1
+}
+
+/// Unescaped `$`s on the caret's line before `cursor` (`\$` doesn't count).
+fn dollars_before(value: &str, cursor: usize) -> usize {
     let cursor = cursor.min(value.len());
     let line_start = value[..cursor].rfind('\n').map_or(0, |i| i + 1);
     let bytes = value.as_bytes();
@@ -191,7 +222,7 @@ fn in_inline_math(value: &str, cursor: usize) -> bool {
             count += 1;
         }
     }
-    count % 2 == 1
+    count
 }
 
 /// A `\name` LaTeX command ending at the caret (an alphabetic run back to a `\`). Unlike
@@ -449,6 +480,51 @@ pub fn build_math_items(query: &str) -> Vec<PaletteItem> {
 }
 
 /// An `Insert` palette item that drops the caret at the end of `snippet`.
+/// Block-reference completion: each row is a page's content; every line
+/// containing the query becomes a pickable block (its text as the label).
+/// Skips lines that can't carry a ` ^id` anchor (fences + their bodies,
+/// table rows, properties, markers) — and asks for 2+ chars first.
+pub fn build_block_ref_items(query: &str, rows: &[(i64, String, String)]) -> Vec<PaletteItem> {
+    let q = query.trim().to_lowercase();
+    if q.chars().count() < 2 {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    'rows: for (id, title, content) in rows {
+        let mut in_fence = false;
+        for (li, line) in content.split('\n').enumerate() {
+            let t = line.trim_start();
+            if t.starts_with("```") {
+                in_fence = !in_fence;
+                continue;
+            }
+            if in_fence
+                || t.is_empty()
+                || t.starts_with('|')
+                || t.starts_with("<!--")
+                || t.starts_with("$$")
+                || gpui_markdown::syntax::property(line).is_some()
+                || !line.to_lowercase().contains(&q)
+            {
+                continue;
+            }
+            let snippet: String = t.chars().take(64).collect();
+            out.push(PaletteItem {
+                label: format!("{snippet} — {title}"),
+                kind: ItemKind::BlockRefPick {
+                    page: *id,
+                    title: title.clone(),
+                    line: li,
+                },
+            });
+            if out.len() >= MAX_COMPLETION_ITEMS {
+                break 'rows;
+            }
+        }
+    }
+    out
+}
+
 fn insert_item(label: String, snippet: String) -> PaletteItem {
     let caret = snippet.len();
     PaletteItem {
@@ -686,6 +762,35 @@ fn is_boundary(b: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn block_ref_trigger_and_items() {
+        // `((` opens the block palette; `))` closes it; math parens don't.
+        assert_eq!(
+            detect("see ((wa", 8),
+            Some((Trigger::BlockRef, 4, "wa".to_string()))
+        );
+        assert_eq!(detect("see ((done))", 12), None);
+        assert_ne!(detect("$$f((x)", 7).map(|t| t.0), Some(Trigger::BlockRef));
+        // Items: matching lines become picks; fences/tables/properties and
+        // sub-2-char queries don't.
+        let rows = vec![(
+            7i64,
+            "WAF".to_string(),
+            "intro\n- Imperva waf rules\n| waf | t |\nkey:: waf\n```\nwaf code\n```".to_string(),
+        )];
+        let items = build_block_ref_items("waf", &rows);
+        assert_eq!(items.len(), 1);
+        assert!(items[0].label.contains("Imperva waf rules"));
+        assert!(items[0].label.contains("WAF"));
+        match &items[0].kind {
+            ItemKind::BlockRefPick { page, line, .. } => {
+                assert_eq!((*page, *line), (7, 1));
+            }
+            _ => panic!("wrong kind"),
+        }
+        assert!(build_block_ref_items("w", &rows).is_empty());
+    }
 
     #[test]
     fn slash_alone_triggers_empty_query() {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -282,6 +282,10 @@ fn mono_font() -> &'static str {
 pub fn markdown_style(indent_spaces: usize, text_size: Pixels) -> gpui_markdown::MarkdownStyle {
     let p = get();
     gpui_markdown::MarkdownStyle {
+        // The host injects the block-label and ref-count resolvers after
+        // construction (they need AppView state); the theme stays data-only.
+        block_label: None,
+        block_ref_count: None,
         text_color: p.text_primary,
         text_size,
         line_height: gpui_editor::LINE_HEIGHT_RATIO,
@@ -326,6 +330,9 @@ pub fn markdown_style(indent_spaces: usize, text_size: Pixels) -> gpui_markdown:
 pub fn editor_syntax_style() -> gpui_editor::SyntaxStyle {
     let p = get();
     gpui_editor::SyntaxStyle {
+        block_label: None,
+        block_label_gen: 0,
+        block_ref_count: None,
         marker: p.text_tertiary,
         code: p.code,
         code_bg: p.glass,

--- a/src/ui/journal.rs
+++ b/src/ui/journal.rs
@@ -354,7 +354,12 @@ fn rendered_day(
         let embeds = app.build_embed_map(&content);
         let fold_date = d.clone();
         let mut md = gpui_markdown::MarkdownView::new(format!("day-md-{i}"), content)
-            .style(theme::markdown_style(app.list_indent(), app.text_size()))
+            .style({
+                let mut st = theme::markdown_style(app.list_indent(), app.text_size());
+                st.block_label = Some(app.block_label_resolver());
+                st.block_ref_count = Some(app.block_ref_count_resolver());
+                st
+            })
             // Feed find (⌘F): paint this day's matches. The active index is
             // best-effort — block matching (rendered text) can count slightly
             // differently than the bar's source scan; the day + soft

--- a/src/ui/page_view.rs
+++ b/src/ui/page_view.rs
@@ -353,7 +353,12 @@ fn page_rendered(app: &AppView, pe: &PageEditor, cx: &mut Context<AppView>) -> i
         let embeds = app.build_embed_map(&content);
         let fold_page_id = pe.id;
         let mut md = gpui_markdown::MarkdownView::new("page-md", content)
-            .style(theme::markdown_style(app.list_indent(), app.text_size()))
+            .style({
+                let mut st = theme::markdown_style(app.list_indent(), app.text_size());
+                st.block_label = Some(app.block_label_resolver());
+                st.block_ref_count = Some(app.block_ref_count_resolver());
+                st
+            })
             // Track block bounds so find can scroll the active match into view.
             .track_blocks(app.md_block_scroll.clone())
             .on_image(crate::ui::image::renderer(
@@ -751,6 +756,21 @@ fn backlink_row(
     cx: &mut Context<AppView>,
 ) -> gpui::AnyElement {
     let page_id = bl.source_page_id;
+    let line = bl.line;
+    // The referencing block rendered as real markdown (block-ref labels
+    // resolve via the shared store); clicking anywhere on the card jumps to
+    // the referencing line on the source page.
+    let snippet = {
+        let mut st = theme::markdown_style(app.list_indent(), px(13.0));
+        st.block_label = Some(app.block_label_resolver());
+        div()
+            .text_size(px(13.0))
+            .text_color(theme::text_secondary())
+            .child(
+                gpui_markdown::MarkdownView::new(format!("bl-md-{i}"), bl.snippet.clone())
+                    .style(st),
+            )
+    };
     let row = div()
         .id(("bl", i))
         .px_3()
@@ -768,15 +788,10 @@ fn backlink_row(
                 .text_color(theme::accent())
                 .child(bl.source_page_title.clone()),
         )
-        .child(
-            div()
-                .text_size(px(13.0))
-                .text_color(theme::text_secondary())
-                .child(bl.snippet.clone()),
-        )
+        .child(snippet)
         .on_click(
             cx.listener(move |this: &mut AppView, _: &ClickEvent, window, cx| {
-                this.open_page_id(page_id, window, cx);
+                this.open_backlink(page_id, line, window, cx);
             }),
         );
     // The linked-reference rows carry the shared page menu too.

--- a/src/ui/property_editor.rs
+++ b/src/ui/property_editor.rs
@@ -48,6 +48,10 @@ pub struct PropertyEditor {
 impl gpui::EventEmitter<PropExit> for PropertyEditor {}
 
 struct Row {
+    /// Everything before the key on the source line (indent + an optional
+    /// list marker, e.g. `  ` or `- `) — written back verbatim so an
+    /// indented / bulleted property keeps its place in the outline.
+    prefix: String,
     key: Field,
     value: Field,
 }
@@ -119,7 +123,8 @@ impl PropertyEditor {
     ) -> Self {
         let rows = parse(source)
             .into_iter()
-            .map(|(k, v)| Row {
+            .map(|(p, k, v)| Row {
+                prefix: p,
                 key: Field::new(&k),
                 value: Field::new(&v),
             })
@@ -185,7 +190,8 @@ impl PropertyEditor {
     }
 
     /// The current fields serialized back to `key:: value` lines (empty-key rows
-    /// dropped). This is what the host writes over the source block on commit.
+    /// dropped), each behind its original prefix (indent / list marker). This is
+    /// what the host writes over the source block on commit.
     pub fn to_source(&self, _cx: &App) -> String {
         self.rows
             .iter()
@@ -194,7 +200,7 @@ impl PropertyEditor {
                 if k.is_empty() {
                     return None;
                 }
-                Some(format!("{k}:: {}", r.value.text.trim()))
+                Some(format!("{}{k}:: {}", r.prefix, r.value.text.trim()))
             })
             .collect::<Vec<_>>()
             .join("\n")
@@ -275,7 +281,19 @@ impl PropertyEditor {
     }
 
     fn add_row(&mut self, cx: &mut Context<Self>) {
+        // A new row sits at the same outline position as the one above it.
+        let prefix = self.rows.last().map_or(String::new(), |r| {
+            // Under a `- key:: value` first row, siblings indent under the
+            // marker rather than repeating the bullet.
+            let ws = r.prefix.len() - r.prefix.trim_start().len();
+            if r.prefix[ws..].is_empty() {
+                r.prefix.clone()
+            } else {
+                " ".repeat(r.prefix.len())
+            }
+        });
         self.rows.push(Row {
+            prefix,
             key: Field::default(),
             value: Field::default(),
         });
@@ -854,13 +872,15 @@ fn next_boundary(s: &str, i: usize) -> usize {
     s[i..].chars().next().map_or(i, |c| i + c.len_utf8())
 }
 
-/// Split a property block into `(key, value)` pairs, ignoring lines that aren't
-/// properties (via the shared grammar).
-fn parse(source: &str) -> Vec<(String, String)> {
+/// Split a property block into `(prefix, key, value)` triples — prefix is the
+/// line's indent + optional list marker, kept for writeback — ignoring lines
+/// that aren't properties (via the shared grammar).
+fn parse(source: &str) -> Vec<(String, String, String)> {
     source
         .lines()
         .filter_map(|l| {
-            gpui_markdown::syntax::property(l).map(|(k, v)| (k.to_string(), v.to_string()))
+            gpui_markdown::syntax::prefixed_property(l)
+                .map(|(p, k, v)| (p.to_string(), k.to_string(), v.to_string()))
         })
         .collect()
 }
@@ -871,12 +891,13 @@ mod tests {
 
     #[test]
     fn parse_reads_property_lines_only() {
-        let rows = parse("attendees:: Bob, Sue\ntime:: 3:00pm\njust prose");
+        let rows = parse("attendees:: Bob, Sue\n  time:: 3:00pm\n- status:: open\njust prose");
         assert_eq!(
             rows,
             vec![
-                ("attendees".to_string(), "Bob, Sue".to_string()),
-                ("time".to_string(), "3:00pm".to_string()),
+                (String::new(), "attendees".into(), "Bob, Sue".into()),
+                ("  ".into(), "time".into(), "3:00pm".into()),
+                ("- ".into(), "status".into(), "open".into()),
             ]
         );
     }


### PR DESCRIPTION
Four features tightening Zorite's Logseq alignment, driven by live-testing an imported Logseq work vault:

## `((id))` block references, 100% frontend
- `((` opens a block-reference palette (type 2+ chars, pick a block; an `^id` anchor is minted on the target if needed).
- The DB keeps Obsidian `[[Page#^id]]` links for portability; editors show and edit the Logseq `((id))` form everywhere (`to_frontend_refs` at load, `to_db_refs` at the save chokepoint). Refs render as the target block's text in both views and navigate to the block.

## Logseq-style block backlinks (both views)
- Linked References cards render the referencing block (line + indented children) as real markdown; clicking a card jumps to the referencing line on the source page.
- A referenced block shows a superscript reference-count badge in place of its hidden `^id` anchor; clicking it lists every referencer with jump-through rows.

## Property render parity for Logseq shapes
- Reader now panels property runs inside mixed paragraphs (props under a block's first line) — tolerant of CRLF, trailing spaces, and hard breaks found in real vaults.
- WYSIWYG now panels `- key:: value` props-only blocks (shared `prefixed_property` grammar).
- The property editor preserves each line's indent/list marker on writeback.
- Reader panel key column is measured like WYSIWYG's instead of fixed-width.

## Collapsible list headings
- `- ### Heading` inside a bullet/numbered list gets a fold chevron in both views; folding hides the heading's indented children, stopping at the next sibling (outliner semantics).

All commits pass the full gate (fmt, clippy `-D warnings`, workspace tests); tested live against a real Logseq vault import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)