### PR TITLE
feat: right-to-left text in both views (#66)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,17 +7,20 @@ already here — match the surrounding code, and prefer deleting over adding.
 
 Zorite — a cross-platform (macOS / Windows / Linux) Markdown daily-journal desktop app.
 Rust + [GPUI](https://www.gpui.rs) + gpui-component + SQLite. The repo is a Cargo
-workspace (edition 2024): the app at the root, plus six reusable crates under `crates/`.
+workspace (edition 2024): the app at the root, plus eight reusable crates under `crates/`.
 
 ## Layout
 
 - `src/` — the app: window, journal feed, editor wiring, SQLite (`db.rs`), import,
   settings, and the host-side renderers (`ui/`).
+- `crates/gpui-bidi` — bidirectional text for GPUI: index↔x over reordered glyphs,
+  logical-order row layout, and the row painter both renderers use (#66).
 - `crates/gpui-editor` — from-scratch text editor for GPUI (the WYSIWYG markdown surface).
 - `crates/gpui-markdown` — Markdown reading-view renderer.
 - `crates/gpui-pdf` — page-virtualized PDF viewer (pure-Rust `hayro`, no native libs).
 - `crates/gpui-whiteboard` — infinite pan/zoom whiteboard canvas.
 - `crates/ratex-gpui` — LaTeX math renderer + structural editor (RaTeX engine).
+- `crates/os-cursors` — custom mouse cursors (no gpui fork; Linux XCursor / macOS / Windows).
 - `crates/os-spellcheck` — native OS spell-check (no deps; macOS/Windows, Linux no-op).
 - `docs/` — Astro Starlight docs site (auto-deploys on push to `main`).
 
@@ -82,12 +85,20 @@ change must stay cross-platform.
   reformat or "improve" adjacent code. It's a `-D warnings` repo — leave no orphaned
   `dead_code`/`unused` behind your edit.
 - **Crates stay host-agnostic.** `crates/*` depend on `gpui` only — not `gpui-component`,
-  not the app — and run on all three platforms with no native libraries. One
-  sanctioned sibling dependency: `gpui-editor` → `gpui-markdown`, for the shared
-  construct **recognition** in `gpui_markdown::syntax` (alert kinds, table
-  styles, heading scales) — never for rendering. Keep the
-  editor/rendering cores GUI-free where a crate already splits them (e.g. ratex-gpui's
-  `editor::{model,cursor,geometry,input,latex}` are GUI-free; only `view` is gpui glue).
+  not the app — and run on all three platforms with no native libraries. Sibling
+  dependencies are sanctioned one at a time, and there are two:
+  - `gpui-editor` → `gpui-markdown`, for the shared construct **recognition** in
+    `gpui_markdown::syntax` (alert kinds, table styles, heading scales, writing
+    direction) — never for rendering.
+  - both renderers → `gpui-bidi`, the bidi layer (#66). It is a leaf: the
+    index↔x map, logical-order row layout, and the row painter that works
+    around gpui collapsing a bidi row to one colour. Shared because the two
+    engines have the same problem and must not solve it twice — when they did,
+    they disagreed about which side a table's first column sits on.
+
+  Keep the editor/rendering cores GUI-free where a crate already splits them
+  (e.g. ratex-gpui's `editor::{model,cursor,geometry,input,latex}` are GUI-free;
+  only `view` is gpui glue).
 - **The app owns rendering.** Renderers in the crates are host-agnostic; the app supplies
   the concrete one (see the `MarkdownView::on_math` / `on_inline_math` wiring in `ui/`).
 - **Cross-platform IO.** No `$HOME` or Unix-only assumptions — use `paths::*`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,6 +2776,7 @@ name = "gpui-bidi"
 version = "0.1.0"
 dependencies = [
  "gpui",
+ "unicode-bidi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -272,7 +272,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1789,7 +1789,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2021,7 +2021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3156,9 +3156,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4759,7 +4759,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5343,7 +5343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6680,7 +6680,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7279,7 +7279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7337,7 +7337,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7705,7 +7705,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8449,7 +8449,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9331,7 +9331,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,6 +2878,7 @@ name = "gpui-editor"
 version = "0.1.0"
 dependencies = [
  "gpui",
+ "gpui-bidi",
  "gpui-markdown",
  "gpui_platform",
  "os-spellcheck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,6 +2772,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpui-bidi"
+version = "0.1.0"
+dependencies = [
+ "gpui",
+]
+
+[[package]]
 name = "gpui-component"
 version = "0.5.2"
 source = "git+https://github.com/longbridge/gpui-component?rev=1505b1487131adbb443f6c69e87847db35bfa2d1#1505b1487131adbb443f6c69e87847db35bfa2d1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,7 @@ name = "gpui-markdown"
 version = "0.1.0"
 dependencies = [
  "gpui",
+ "gpui-bidi",
  "markdown",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "zorite"
 path = "src/main.rs"
 
 [workspace]
-members = ["crates/gpui-editor", "crates/gpui-markdown", "crates/gpui-pdf", "crates/gpui-whiteboard", "crates/os-cursors", "crates/os-spellcheck", "crates/ratex-gpui"]
+members = ["crates/gpui-bidi", "crates/gpui-editor", "crates/gpui-markdown", "crates/gpui-pdf", "crates/gpui-whiteboard", "crates/os-cursors", "crates/os-spellcheck", "crates/ratex-gpui"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/crates/gpui-bidi/API.md
+++ b/crates/gpui-bidi/API.md
@@ -1,0 +1,407 @@
+# gpui-bidi API
+
+The complete public API of [`gpui-bidi`](README.md) — every exported item, with
+its signature, contract, edge cases, and cost. For the what-and-why (which gpui
+lookups are wrong and why), see the [README](README.md).
+
+## Public API at a glance
+
+Three layers. The root works on plain numbers and is testable without a window;
+`shaped` reads a gpui line into it; `paragraph` lays out and paints whole
+paragraphs.
+
+| Item | Kind | Signature | Purpose |
+| --- | --- | --- | --- |
+| [`Glyph`](#struct-glyph) | struct | `{ index: usize, x: f32 }` | One glyph: where it came from, where it landed |
+| [`VisualMap`](#struct-visualmap) | struct | — | A shaped line's glyphs, readable in both directions |
+| [`VisualMap::from_glyphs`](#visualmapfrom_glyphs) | constructor | `fn(impl IntoIterator<Item = Glyph>, f32, usize) -> Self` | Build from glyphs, line width, text length |
+| [`VisualMap::with_levels`](#visualmapwith_levels) | builder | `fn(self, &str) -> Self` | Attach the text, for UAX #9 embedding levels |
+| [`VisualMap::is_bidi`](#visualmapis_bidi) | method | `fn(&self) -> bool` | Does any glyph sit out of logical order? |
+| [`VisualMap::width`](#visualmapwidth) | method | `fn(&self) -> f32` | Total advance width |
+| [`VisualMap::is_empty`](#visualmapis_empty) | method | `fn(&self) -> bool` | No glyphs at all |
+| [`VisualMap::x_for_index`](#visualmapx_for_index) | method | `fn(&self, usize) -> f32` | Where a caret before a byte belongs |
+| [`VisualMap::index_for_x`](#visualmapindex_for_x) | method | `fn(&self, f32) -> usize` | Which byte a click at an x names |
+| [`VisualMap::rects_for_range`](#visualmaprects_for_range) | method | `fn(&self, Range<usize>) -> Vec<(f32, f32)>` | The (possibly split) spans a range covers |
+| [`VisualMap::step_visual`](#visualmapstep_visual) | method | `fn(&self, usize, bool) -> Option<usize>` | One caret step left/right, visually |
+| [`VisualMap::is_rtl_range`](#visualmapis_rtl_range) | method | `fn(&self, Range<usize>) -> bool` | Does a byte range read right-to-left? |
+| [`shaped::map_of`](#shapedmap_of) | fn | `fn(&ShapedLine, usize) -> VisualMap` | Read a map out of a shaped line |
+| [`shaped::map_of_wrapped`](#shapedmap_of_wrapped) | fn | `fn(&WrappedLine, usize) -> VisualMap` | Same, over a wrapped line's pre-wrap layout |
+| [`paragraph::Row`](#struct-row) | struct | — | One laid-out row: span, width, map, runs, shaped line |
+| [`paragraph::layout_rows`](#layout_rows) | fn | `fn(&str, &[TextRun], Option<Pixels>, Pixels, &Window) -> Vec<Row>` | Break in logical order, shape each row |
+| [`paragraph::paint_row`](#paint_row) | fn | `fn(&Row, Point<Pixels>, Pixels, &mut Window, &mut App)` | Paint one row, styles intact |
+| [`paragraph::insert_breaks`](#insert_breaks) | fn | `fn(&str, &[TextRun], &[usize]) -> (SharedString, Vec<TextRun>)` | Inject `\n` at offsets, widening runs |
+| [`paragraph::RtlText`](#struct-rtltext) | struct | — | A right-to-left paragraph element |
+| [`paragraph::RtlLayout`](#struct-rtllayout) | struct | — | Handle onto the last layout, for hit-testing |
+
+---
+
+## `struct Glyph`
+
+```rust
+pub struct Glyph {
+    pub index: usize, // byte offset into the shaped text — LOGICAL order
+    pub x: f32,       // laid-out leading edge, line-relative — VISUAL order
+}
+```
+
+The two facts this crate needs about a glyph. Everything else about it — font,
+id, size — belongs to the shaper.
+
+---
+
+## `struct VisualMap`
+
+```rust
+pub struct VisualMap { /* private */ }
+```
+
+A shaped line's glyphs, indexed so logical offsets and visual positions convert
+both ways regardless of writing direction. Glyphs are stored in visual
+(x-ascending) order with a parallel logical-order table, so neither direction
+of the mapping has to scan.
+
+### `VisualMap::from_glyphs`
+
+```rust
+pub fn from_glyphs(glyphs: impl IntoIterator<Item = Glyph>, width: f32, len: usize) -> Self
+```
+
+`width` is the line's total advance; `len` the byte length of the shaped text
+(the caret can sit one past the last glyph, and only the caller knows where
+that is).
+
+**Guarantees & edge cases** — `glyphs` may arrive in any order; they are sorted
+by x here, so a shaper's runs can be handed over concatenated. Without
+[`with_levels`](#visualmapwith_levels), glyph direction is inferred from the
+neighbouring indices, which is exact in the middle of a run and **wrong at its
+edges** — prefer attaching the text.
+
+**Cost** — two sorts, O(n log n); no allocation beyond the two tables.
+
+### `VisualMap::with_levels`
+
+```rust
+pub fn with_levels(mut self, text: &str) -> Self
+```
+
+Attach the text the glyphs were shaped from, so direction comes from the UAX #9
+embedding levels rather than being inferred.
+
+**Why it matters** — at the edge of an embedded run the glyph visually beside it
+belongs to the *other* run and carries a misleading index, so inference reads
+"descending, therefore RTL" for the last letter of a Latin word inside Persian.
+The caret then sits on that letter's far edge — one glyph out, which a reader
+sees as the caret skipping a character.
+
+**Cost** — one `unicode-bidi` pass over the text, plus a `Vec<u8>` per byte.
+
+### `VisualMap::is_bidi`
+
+```rust
+pub fn is_bidi(&self) -> bool
+```
+
+Whether any glyph sits out of logical order. A pure left-to-right line answers
+`false`, and callers can use that to skip to gpui's own (cheaper) lookups.
+
+### `VisualMap::width`
+
+```rust
+pub fn width(&self) -> f32
+```
+
+The line's total advance width, as handed to the constructor.
+
+### `VisualMap::is_empty`
+
+```rust
+pub fn is_empty(&self) -> bool
+```
+
+No glyphs — an empty line. Every lookup below is still safe to call.
+
+### `VisualMap::x_for_index`
+
+```rust
+pub fn x_for_index(&self, offset: usize) -> f32
+```
+
+The x where a caret sitting *before* byte `offset` belongs.
+
+**Guarantees & edge cases** — "before" is in reading order, so for a glyph in an
+RTL run that is its **right** edge, not its left. An offset past the end
+resolves to the line's trailing edge: the right edge for LTR, x = 0 for a line
+ending in RTL. An offset before the first logical glyph gives the leading edge.
+Several glyphs can share an index (a ligature, a combining sequence); the first
+owns the caret. Empty map → `0.0`.
+
+**Cost** — one binary search.
+
+### `VisualMap::index_for_x`
+
+```rust
+pub fn index_for_x(&self, x: f32) -> usize
+```
+
+The byte offset a click at `x` should place the caret at.
+
+**Guarantees & edge cases** — picks the nearer edge of whichever glyph `x` lands
+on, so clicking a glyph's trailing half puts the caret after it in *reading*
+order — past it on the left for RTL, on the right for LTR. Left of every glyph
+gives the visually-first glyph's leading edge. Empty map → `0`.
+
+### `VisualMap::rects_for_range`
+
+```rust
+pub fn rects_for_range(&self, range: Range<usize>) -> Vec<(f32, f32)>
+```
+
+The visual spans covering logical `range`, as `(start x, end x)` pairs.
+
+**Guarantees & edge cases** — a logically contiguous selection can be **visually
+split**: selecting across a direction change in `"hello سلام world"` covers two
+or three separate stretches, so this returns however many it takes. Adjacent
+runs are merged and the result is sorted left to right. Empty range or empty
+map → empty vec.
+
+**Cost** — one pass over the glyphs plus a sort of the matches.
+
+### `VisualMap::step_visual`
+
+```rust
+pub fn step_visual(&self, offset: usize, right: bool) -> Option<usize>
+```
+
+The logical offset one caret step to the visual left or right of `offset`.
+`None` when there is no stop that way — the caret is leaving the line, and the
+caller should move it to the neighbouring row.
+
+**Why it isn't a byte step** — arrow keys move visually, and inside a line that
+is not "this line is RTL, so flip left and right". A Latin word or a URL
+embedded in Persian runs the other way, and the caret has to flow *through* it
+in its own direction rather than jump to its far end.
+
+**Guarantees & edge cases** — caret stops are ordered by x, ties broken by
+offset. The tie-break matters: at a direction change two different offsets sit
+at the same x, and ordering by x alone makes one of them unreachable — which
+shows up as the caret skipping a character at the edge of an embedded word. An
+`offset` that is not itself a caret stop returns `None`.
+
+**Cost** — builds the stop list per call, O(n log n) in the line's glyphs.
+
+### `VisualMap::is_rtl_range`
+
+```rust
+pub fn is_rtl_range(&self, range: Range<usize>) -> bool
+```
+
+Does the byte range read right-to-left? From the embedding levels when
+[`with_levels`](#visualmapwith_levels) supplied them, otherwise from glyph
+order (unreliable at run edges — see there).
+
+Used when a slice has to be re-shaped or re-styled on its own and needs its
+direction re-asserted; a run of pure neutrals (`[[`, `](`) has no direction of
+its own and takes the paragraph's.
+
+---
+
+## `shaped::map_of`
+
+```rust
+pub fn map_of(line: &ShapedLine, len: usize) -> VisualMap
+```
+
+Build a map from a gpui shaped line, levels attached from the line's own text.
+`len` is the byte length of the text that was shaped.
+
+**Note** — `ShapedLine` derefs to `LineLayout`, so `runs` is reachable even
+though the `layout` field is `pub(crate)`. That is what lets this work without
+forking gpui; worth re-checking whenever the gpui pin moves.
+
+## `shaped::map_of_wrapped`
+
+```rust
+pub fn map_of_wrapped(line: &WrappedLine, len: usize) -> VisualMap
+```
+
+[`map_of`](#shapedmap_of) over a wrapped line's **pre-wrap** layout.
+
+**Guarantees & edge cases** — a `WrappedLine` keeps one unwrapped glyph list
+plus the boundaries it was wrapped at, so the x values run along the single
+long line, not within a visual row. That is the right input for a caller that
+resolves a row's glyph span itself; a caller wanting per-row coordinates must
+subtract the row's start x — or use [`layout_rows`](#layout_rows), which gives
+one map per row.
+
+---
+
+## `struct Row`
+
+```rust
+pub struct Row {
+    pub start: usize,                          // byte offset in the ORIGINAL text
+    pub len: usize,                            // byte length of this row's text
+    pub width: Pixels,
+    pub map: VisualMap,
+    pub runs: Vec<(Range<usize>, TextRun)>,    // row-local ranges
+    pub line: WrappedLine,                     // shaped, ready to paint
+    pub font_size: Pixels,                     // what it was shaped at
+}
+```
+
+One laid-out row. `start` indexes the **original** text — the row breaks
+injected during layout do not exist there — so a caret offset maps straight
+through. `font_size` is carried so painting can re-shape without the caller
+supplying a size that might not be this row's (a heading is not the body size).
+
+## `layout_rows`
+
+```rust
+pub fn layout_rows(
+    text: &str,
+    runs: &[TextRun],
+    wrap_width: Option<Pixels>,
+    font_size: Pixels,
+    window: &Window,
+) -> Vec<Row>
+```
+
+Lay `text` out as rows: break it in **logical** order at word boundaries, then
+shape each row on its own so the shaper reorders each independently.
+
+`runs` must cover every byte of `text`. `wrap_width` of `None` produces a
+single row.
+
+**Guarantees & edge cases** — rows come back in reading order, so row 0 is the
+paragraph's first line whichever way the script runs. Word breaking is
+space-based (not gpui's `LineWrapper`, whose `is_word_char` does not know
+Arabic and so treats every character as a break candidate, splitting words
+mid-word); the zero-width non-joiner U+200C is **not** a break, since it sits
+inside Persian words. A single word wider than `wrap_width` overflows rather
+than being chopped. A line mixing RTL with unspaced CJK wraps poorly — see the
+README's Scope.
+
+**Cost** — one `shape_line` per word to measure, then one `shape_text` over the
+whole paragraph. gpui's line-layout cache absorbs the repeats across frames.
+
+## `paint_row`
+
+```rust
+pub fn paint_row(
+    row: &Row,
+    origin: Point<Pixels>,
+    line_height: Pixels,
+    window: &mut Window,
+    cx: &mut App,
+)
+```
+
+Paint one row at `origin`, whose x is the row's **left** edge (right-align by
+passing `bounds.right() - row.width`).
+
+**Guarantees & edge cases** — a single-style row goes through gpui's painter
+directly. A row with more than one style cannot: `paint_line` walks glyphs in
+visual order but pulls decorations from a forward-only iterator keyed on
+`glyph.index >= run_end`, and in an RTL row the first glyph carries the highest
+index, so the iterator jumps to the last run and never advances — the whole row
+paints in the colour of whichever run covers the logically-last character. Such
+a row is instead painted once per style, uniformly coloured for that style
+(making the collapse harmless) and clipped to the boxes that style occupies.
+Only the decoration varies between passes, so every pass lays out exactly as
+the row did, and cursive joining survives a style boundary inside a word. Run
+backgrounds (an inline-code tint) are painted too.
+
+**Cost** — one paint per distinct style, each over the whole row; the shaping is
+cached by gpui.
+
+## `insert_breaks`
+
+```rust
+pub fn insert_breaks(
+    text: &str,
+    runs: &[TextRun],
+    breaks: &[usize],
+) -> (SharedString, Vec<TextRun>)
+```
+
+Split `text` at `breaks` (logical byte offsets) by injecting `\n`, widening
+`runs` to cover the injected bytes. Exposed because it is the whole trick
+behind [`layout_rows`](#layout_rows): `shape_text` splits on `\n` and shapes
+each line separately, in order, so injecting a break at each logical boundary
+buys the per-line reordering.
+
+**Guarantees & edge cases** — `shape_text` requires runs to span every byte
+including the `\n`s, so a break inside a run lengthens that run rather than
+splitting it (the newline inherits the style it interrupts, which paints
+nothing either way). Offsets at 0, at `text.len()`, repeated, or mid-codepoint
+are ignored — each would produce an empty row or panic the shaper.
+
+---
+
+## `struct RtlText`
+
+```rust
+pub struct RtlText { /* private */ }
+
+impl RtlText {
+    pub fn new(text: impl Into<SharedString>) -> Self;
+    pub fn with_base_rtl(self, rtl: bool) -> Self;
+    pub fn with_highlights(self, impl IntoIterator<Item = (Range<usize>, HighlightStyle)>) -> Self;
+    pub fn with_pointer_ranges(self, ranges: Vec<Range<usize>>) -> Self;
+    pub fn layout(&self) -> &RtlLayout;
+}
+```
+
+A paragraph element that lays itself out in logical order and paints its rows
+right-aligned. Implements `Element`, so it drops into a gpui tree like
+`StyledText`.
+
+- **`with_base_rtl`** — defaults `true`. Pass `false` for a left-to-right
+  paragraph that merely *contains* right-to-left text: it still needs the
+  mapping (or the caret misplaces inside that phrase) but must stay
+  left-aligned.
+- **`with_highlights`** — styled ranges, exactly as `StyledText` takes them:
+  sorted, non-overlapping, on char boundaries.
+- **`with_pointer_ranges`** — ranges that show the pointing-hand cursor on
+  hover, i.e. links. One hitbox is inserted per visual box, so the hand appears
+  over the link's glyphs and nowhere else, and it does not depend on a repaint
+  happening as the mouse moves.
+- **`layout`** — clone this before the element is consumed by the tree; it is
+  how the host hit-tests (see [`RtlLayout`](#struct-rtllayout)).
+
+## `struct RtlLayout`
+
+```rust
+pub struct RtlLayout(/* private */);
+
+impl RtlLayout {
+    pub fn line_height(&self) -> Pixels;
+    pub fn index_for_position(&self, position: Point<Pixels>) -> Result<usize, usize>;
+    pub fn position_for_index(&self, offset: usize) -> Option<Point<Pixels>>;
+    pub fn rects_for_range(&self, range: Range<usize>) -> Vec<Bounds<Pixels>>;
+    pub fn left_edge_of(&self, range: Range<usize>) -> Option<Point<Pixels>>;
+}
+```
+
+A handle onto the last layout, for mapping between a point on screen and an
+offset in the text. Cheap to clone; **empty until the element has been painted
+once**, since hit-testing is in window space.
+
+- **`index_for_position`** — `Ok` inside the painted text, `Err` with the
+  nearest offset outside, the same contract as gpui's
+  `TextLayout::index_for_position`.
+- **`rects_for_range`** — one box per visual run per row: a link wrapped across
+  two rows gives two, and a range split by a direction change gives one per
+  piece.
+- **`left_edge_of`** — the top-left of a range's visual box, for seating an
+  inline raster (a formula, an image) over the spacer it reserved. Anchoring to
+  `range.start` instead would be the **right** edge in an RTL line, painting
+  the raster over the neighbouring words.
+
+---
+
+## Threading
+
+`VisualMap` and its lookups are plain data — any thread. `shaped::*`,
+`layout_rows`, `paint_row` and the elements need a gpui `Window` and belong on
+the UI thread.

--- a/crates/gpui-bidi/Cargo.toml
+++ b/crates/gpui-bidi/Cargo.toml
@@ -15,3 +15,9 @@ categories = ["text-processing", "gui"]
 # reads those pairs out of a `ShapedLine`.
 [dependencies]
 gpui.workspace = true
+# The UAX #9 algorithm itself, for the one thing the shaper's output does not
+# reveal: a glyph's embedding LEVEL. Direction cannot be inferred from
+# (index, x) pairs at the EDGE of an embedded run — the glyph beside it belongs
+# to the other run and carries a misleading index — so the levels come from the
+# text. Already in the tree (via lopdf/usvg), so this adds nothing to the build.
+unicode-bidi = { version = "0.3", default-features = false, features = ["hardcoded-data"] }

--- a/crates/gpui-bidi/Cargo.toml
+++ b/crates/gpui-bidi/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gpui-bidi"
+version = "0.1.0"
+edition = "2024"
+description = "Bidirectional-text index↔x mapping for gpui shaped lines. The platform shapers already reorder RTL glyphs correctly; gpui's own LineLayout lookups assume byte index and x rise together, which is false for RTL. This reads the reordered glyph table properly so a caret, a selection, and a click land where the reader expects."
+license = "GPL-3.0-or-later"
+repository = "https://github.com/packetThrower/zorite"
+homepage = "https://packetthrower.github.io/zorite/reference/crates/gpui-bidi/"
+keywords = ["bidi", "rtl", "gpui", "text", "unicode"]
+categories = ["text-processing", "gui"]
+
+# The core (`VisualMap`) is deliberately gpui-free: it works on plain
+# `(logical byte index, x)` glyph pairs, so every rule is unit-testable
+# without a window or a GPU. gpui is needed only for the thin adapter that
+# reads those pairs out of a `ShapedLine`.
+[dependencies]
+gpui.workspace = true

--- a/crates/gpui-bidi/README.md
+++ b/crates/gpui-bidi/README.md
@@ -1,0 +1,107 @@
+# gpui-bidi
+
+Bidirectional text for [GPUI](https://www.gpui.rs): read a shaped line's
+already-reordered glyphs correctly, break a paragraph into rows in reading
+order, and paint a styled row without the colours collapsing.
+
+Built for [Zorite](https://github.com/packetThrower/zorite), but it depends on
+`gpui` alone and knows nothing about the app.
+
+## Why it exists
+
+The platform shapers already do bidi properly. Shape `"سلام دنیا"` and the
+glyphs come back in **visual** order carrying **logical** byte indices — for
+that string, indices `15, 13, 11, 9, 8, 6, 2, 0` as x ascends. That is exactly
+what UAX #9 asks for, and it means right-to-left text *renders* correctly
+today.
+
+What is missing is everything that reads those glyphs back. gpui's lookups
+assume byte index and x rise together, which is false the moment a line
+contains RTL:
+
+- **`x_for_index`** returns the first glyph whose `index >= target`. The first
+  glyph of an RTL line carries the *highest* index, so every offset in the line
+  resolves to the same glyph — a caret that will not move, and selection
+  rectangles with no width. `index_for_x` and `closest_index_for_x` fail the
+  same way.
+- **Wrapping** shapes the paragraph as one long line and then slices it into
+  rows by ascending x. Glyph order is visual, so the first row gets the
+  paragraph's *last* words: a wrapped Persian note reads bottom-to-top. Its
+  break candidates come from an `is_word_char` that does not know Arabic, so
+  words also split down the middle.
+- **Painting** walks glyphs in visual order but pulls decorations from a
+  forward-only iterator keyed on `glyph.index >= run_end`. In an RTL row that
+  iterator jumps to the last run and never advances, so the whole row paints in
+  one colour — a link inside Persian text comes out the colour of the body.
+
+Upstream gpui is not currently taking changes for this, so the fixes live here.
+
+## What it does
+
+- [`VisualMap`](API.md#struct-visualmap) — index↔x in both directions over a
+  reordered glyph table, plus visual caret stepping and the rectangles a
+  selection needs (a logically contiguous range can be *visually split*).
+- [`paragraph::layout_rows`](API.md#layout_rows) — break a paragraph in
+  **logical** order at word boundaries, then shape each row on its own, so the
+  shaper reorders each independently and the rows come back in reading order.
+- [`paragraph::paint_row`](API.md#paint_row) — paint one row, working around
+  the decoration collapse without re-shaping (which would lose cursive joining
+  across a style boundary).
+- [`paragraph::RtlText`](API.md#struct-rtltext) — a ready-made element for
+  hosts that just want a right-to-left paragraph, with hit-testing and
+  hover-cursor support.
+
+Direction comes from the real UAX #9 embedding levels via `unicode-bidi`, not
+from the glyph geometry: at the *edge* of an embedded run the glyph beside it
+belongs to the other run and carries a misleading index, so geometry is exact
+in the middle of a run and wrong precisely where it matters.
+
+## Quick start
+
+```rust
+use gpui_bidi::shaped;
+
+// A shaped line from gpui, plus the text it came from (for the levels).
+let map = shaped::map_of(&line, text.len()).with_levels(text);
+
+// Where the caret before byte `offset` belongs — the glyph's RIGHT edge in an
+// RTL run, which is what gpui gets wrong.
+let x = map.x_for_index(offset);
+
+// And back, for a click.
+let offset = map.index_for_x(x);
+```
+
+Laying out and painting a paragraph yourself:
+
+```rust
+use gpui_bidi::paragraph::{layout_rows, paint_row};
+
+let rows = layout_rows(text, &runs, Some(wrap_width), font_size, window);
+for (i, row) in rows.iter().enumerate() {
+    let x = bounds.right() - row.width; // right-aligned; use bounds.left() for LTR
+    paint_row(row, point(x, bounds.top() + line_height * i), line_height, window, cx);
+}
+```
+
+## Scope
+
+Everything in the crate root works on plain `(logical byte index, x)` pairs, so
+it is unit-testable without a window, a GPU, or a font. Only the `shaped` and
+`paragraph` modules touch gpui.
+
+**Paragraph direction** — which side a line starts on — is the caller's, from
+the first strong character of its *content*. This crate maps within a line and
+lays out rows; it does not decide what a line is.
+
+The word breaking in `layout_rows` is space-based, which suits Arabic and
+Hebrew. A line mixing right-to-left text with unspaced CJK would wrap poorly;
+lines with no RTL should keep gpui's own wrapping.
+
+## API
+
+Complete reference: [API.md](API.md).
+
+## License
+
+GPL-3.0-or-later, same as Zorite.

--- a/crates/gpui-bidi/src/lib.rs
+++ b/crates/gpui-bidi/src/lib.rs
@@ -1,0 +1,451 @@
+//! Bidirectional-text index↔x mapping for gpui shaped lines.
+//!
+//! # Why this exists
+//!
+//! The platform shapers already do bidi correctly. Shape `"سلام دنیا"` and the
+//! glyphs come back in **visual** order carrying **logical** byte indices —
+//! for that string, indices `15, 13, 11, 9, 8, 6, 2, 0` as x ascends. That is
+//! exactly what UAX #9 asks for, and it means RTL text *renders* right today.
+//!
+//! What is wrong is how those glyphs get read back. gpui's
+//! `LineLayout::x_for_index` returns the first glyph whose `index >= target`,
+//! which assumes byte index and x rise together. In an RTL line the first
+//! glyph carries the *highest* index, so every offset in the line resolves to
+//! the same glyph and the caret collapses onto x = 0. `index_for_x` and
+//! `closest_index_for_x` fail the same way, and mixed content is worse: in
+//! `"hello سلام world"` the four offsets 6, 8, 10, 12 all map to one x.
+//!
+//! So this crate is **not** an implementation of the bidi algorithm — the
+//! shaper did that. It reads an already-reordered glyph table correctly.
+//!
+//! # Shape of the API
+//!
+//! [`VisualMap`] is built from plain `(logical byte index, x)` pairs, so every
+//! rule here is unit-testable without a window, a GPU, or a font. Hosts get
+//! those pairs from a shaped line — see [`VisualMap::from_glyphs`] and the
+//! `gpui` adapter in [`shaped`].
+//!
+//! # What a caller still owns
+//!
+//! - **Paragraph direction** (which side a line starts on) is the host's, from
+//!   the first strong character. This crate only maps within a shaped line.
+//! - **Logical caret movement.** Left/right arrows moving in *logical* order is
+//!   what most editors do, and it needs nothing from here.
+
+use std::ops::Range;
+
+/// One glyph as this crate needs it: where it came from in the source, and
+/// where it was laid out.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Glyph {
+    /// Byte offset into the shaped text — *logical* order.
+    pub index: usize,
+    /// Laid-out horizontal position of the glyph's leading edge, in the
+    /// line's own coordinate space (0 = line start) — *visual* order.
+    pub x: f32,
+}
+
+/// A shaped line's glyphs, indexed so logical offsets and visual positions can
+/// be converted in both directions regardless of writing direction.
+///
+/// Glyphs are stored in visual (x-ascending) order — the order a shaper
+/// returns them — and a parallel table gives their logical order, so neither
+/// direction of the mapping has to scan.
+#[derive(Clone, Debug)]
+pub struct VisualMap {
+    /// Visual order, x ascending. Always sorted by `x`.
+    glyphs: Vec<Glyph>,
+    /// Indices into `glyphs`, sorted by the glyph's logical `index`.
+    by_logical: Vec<usize>,
+    /// Total advance width of the line.
+    width: f32,
+    /// Byte length of the shaped text — the offset one past the last glyph.
+    len: usize,
+}
+
+impl VisualMap {
+    /// Build from a line's glyphs plus its total `width` and text byte length.
+    ///
+    /// `glyphs` may arrive in any order; it is sorted by `x` here, so callers
+    /// can hand over a shaper's runs concatenated without pre-sorting.
+    pub fn from_glyphs(glyphs: impl IntoIterator<Item = Glyph>, width: f32, len: usize) -> Self {
+        let mut glyphs: Vec<Glyph> = glyphs.into_iter().collect();
+        glyphs.sort_by(|a, b| a.x.total_cmp(&b.x));
+        let mut by_logical: Vec<usize> = (0..glyphs.len()).collect();
+        by_logical.sort_by_key(|&i| glyphs[i].index);
+        Self {
+            glyphs,
+            by_logical,
+            width,
+            len,
+        }
+    }
+
+    /// Whether any glyph sits out of logical order — i.e. the line contains
+    /// right-to-left text. A pure-LTR line answers `false`, and callers can
+    /// use that to skip straight to gpui's own (cheaper) lookups.
+    pub fn is_bidi(&self) -> bool {
+        self.glyphs.windows(2).any(|w| w[0].index > w[1].index)
+    }
+
+    pub fn width(&self) -> f32 {
+        self.width
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.glyphs.is_empty()
+    }
+
+    /// The x where a caret sitting *before* byte `offset` belongs.
+    ///
+    /// "Before" is in reading order, so for a glyph in an RTL run that is its
+    /// **right** edge, not its left — which is the whole reason gpui's version
+    /// can't be reused. An offset past the end of the text resolves to the
+    /// line's trailing edge: the right edge for LTR, x = 0 for a line that
+    /// ends in RTL.
+    pub fn x_for_index(&self, offset: usize) -> f32 {
+        if self.glyphs.is_empty() {
+            return 0.0;
+        }
+        if offset >= self.len {
+            return self.trailing_edge();
+        }
+        // The glyph this offset falls inside: the last one whose logical index
+        // is <= offset. Several glyphs can share an index (a ligature or a
+        // combining sequence); the first of those owns the caret.
+        match self.glyph_at_logical(offset) {
+            Some(gi) => {
+                let g = self.glyphs[gi];
+                if self.is_rtl_at(gi) {
+                    self.right_edge(gi)
+                } else {
+                    g.x
+                }
+            }
+            // Before the first logical glyph — the line's leading edge.
+            None => self.leading_edge(),
+        }
+    }
+
+    /// The byte offset a click at `x` should place the caret at.
+    ///
+    /// Picks the nearer edge of whichever glyph `x` lands on, so clicking a
+    /// glyph's trailing half puts the caret after it in *reading* order — past
+    /// it on the left for RTL, on the right for LTR.
+    pub fn index_for_x(&self, x: f32) -> usize {
+        if self.glyphs.is_empty() {
+            return 0;
+        }
+        // Which glyph's advance contains x (they're x-sorted, so the last one
+        // starting at or before x).
+        let gi = match self.glyphs.iter().rposition(|g| g.x <= x) {
+            Some(i) => i,
+            // Left of every glyph: the leading edge of the visually-first one.
+            None => return self.edge_offset(0, false),
+        };
+        let past_middle = x >= (self.glyphs[gi].x + self.right_edge(gi)) / 2.0;
+        self.edge_offset(gi, past_middle)
+    }
+
+    /// The visual rectangles covering the logical byte range `range`, as
+    /// `(start x, end x)` pairs in the line's coordinate space.
+    ///
+    /// A logically contiguous selection can be **visually split** — selecting
+    /// across a direction change in `"hello سلام world"` covers two or three
+    /// separate stretches — so this returns however many runs it takes.
+    /// Adjacent runs are merged, and the result is sorted left to right.
+    pub fn rects_for_range(&self, range: Range<usize>) -> Vec<(f32, f32)> {
+        if range.is_empty() || self.glyphs.is_empty() {
+            return Vec::new();
+        }
+        // Collect the visual span of every glyph whose logical index is in
+        // range, then coalesce the ones that touch.
+        let mut spans: Vec<(f32, f32)> = self
+            .glyphs
+            .iter()
+            .enumerate()
+            .filter(|(_, g)| range.contains(&g.index))
+            .map(|(i, g)| (g.x, self.right_edge(i)))
+            .collect();
+        spans.sort_by(|a, b| a.0.total_cmp(&b.0));
+        let mut out: Vec<(f32, f32)> = Vec::new();
+        for (start, end) in spans {
+            match out.last_mut() {
+                // `>=` so glyphs that merely abut still merge into one rect.
+                Some(last) if start <= last.1 => last.1 = last.1.max(end),
+                _ => out.push((start, end)),
+            }
+        }
+        out
+    }
+
+    // --- internals ---
+
+    /// The entry in `glyphs` that owns logical `offset`: the last glyph whose
+    /// index is <= offset, preferring the first of a group sharing an index.
+    fn glyph_at_logical(&self, offset: usize) -> Option<usize> {
+        // `by_logical` is sorted by logical index — partition to the first
+        // entry whose index exceeds `offset`, then step back one.
+        let p = self
+            .by_logical
+            .partition_point(|&i| self.glyphs[i].index <= offset);
+        (p > 0).then(|| self.by_logical[p - 1])
+    }
+
+    /// Whether the glyph at visual position `gi` belongs to an RTL run, judged
+    /// by its neighbours: in RTL the logical index *decreases* as x rises.
+    ///
+    /// Both sides are checked, not just one. A run's LAST glyph has no
+    /// descending neighbour to its right — the next glyph belongs to the
+    /// following LTR run and has a higher index — so looking right alone
+    /// misclassifies it and puts the caret on the wrong edge. Its left
+    /// neighbour still carries the descent.
+    ///
+    /// A lone RTL glyph between two LTR runs has neither, and reads as LTR.
+    /// Visually that is a single glyph either way; the caret lands on its
+    /// left edge rather than its right, which is a one-glyph discrepancy in a
+    /// case the shaper itself renders ambiguously.
+    fn is_rtl_at(&self, gi: usize) -> bool {
+        let here = self.glyphs[gi].index;
+        let descends_right = self.glyphs.get(gi + 1).is_some_and(|n| n.index < here);
+        let descends_left = gi > 0 && self.glyphs[gi - 1].index > here;
+        descends_right || descends_left
+    }
+
+    /// The x just past the glyph at visual position `gi` — the next glyph's
+    /// leading edge, or the line's width for the last one.
+    fn right_edge(&self, gi: usize) -> f32 {
+        self.glyphs.get(gi + 1).map_or(self.width, |next| next.x)
+    }
+
+    /// The byte offset at one edge of the glyph at visual position `gi`.
+    /// `trailing` means the edge further along in *reading* order.
+    fn edge_offset(&self, gi: usize, trailing: bool) -> usize {
+        let g = self.glyphs[gi];
+        let rtl = self.is_rtl_at(gi);
+        // Reading-order "after this glyph" is the next logical offset; for RTL
+        // that is still index+1 in bytes, because indices are logical.
+        let after = self.next_logical_offset(g.index);
+        match (rtl, trailing) {
+            // LTR: leading edge = this offset, trailing = the next one.
+            (false, false) => g.index,
+            (false, true) => after,
+            // RTL: x rises against reading order, so a click past the visual
+            // middle is *earlier* in reading order.
+            (true, false) => after,
+            (true, true) => g.index,
+        }
+    }
+
+    /// The logical offset immediately after `index` — the next glyph's index
+    /// in logical order, or the text length past the last one.
+    fn next_logical_offset(&self, index: usize) -> usize {
+        let p = self
+            .by_logical
+            .partition_point(|&i| self.glyphs[i].index <= index);
+        self.by_logical
+            .get(p)
+            .map_or(self.len, |&i| self.glyphs[i].index)
+    }
+
+    /// x where reading starts: 0 for a line beginning LTR, the width for one
+    /// beginning RTL.
+    fn leading_edge(&self) -> f32 {
+        if self.starts_rtl() { self.width } else { 0.0 }
+    }
+
+    /// x where reading ends — the opposite of [`Self::leading_edge`].
+    fn trailing_edge(&self) -> f32 {
+        if self.ends_rtl() { 0.0 } else { self.width }
+    }
+
+    /// Whether the logically-first glyph sits at the right — an RTL line.
+    fn starts_rtl(&self) -> bool {
+        self.by_logical.first().is_some_and(|&i| self.is_rtl_at(i))
+    }
+
+    /// Whether the logically-last glyph belongs to an RTL run.
+    fn ends_rtl(&self) -> bool {
+        self.by_logical.last().is_some_and(|&i| self.is_rtl_at(i))
+    }
+}
+
+pub mod shaped;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `"hello"` — every glyph 8px wide, indices ascending with x.
+    fn ltr() -> VisualMap {
+        VisualMap::from_glyphs(
+            (0..5).map(|i| Glyph {
+                index: i,
+                x: i as f32 * 8.0,
+            }),
+            40.0,
+            5,
+        )
+    }
+
+    /// A pure-RTL line of 4 two-byte characters, the shape the probe measured:
+    /// glyph indices descend as x rises (6, 4, 2, 0), text length 8.
+    fn rtl() -> VisualMap {
+        VisualMap::from_glyphs(
+            (0..4).map(|k| Glyph {
+                index: 6 - k * 2,
+                x: k as f32 * 10.0,
+            }),
+            40.0,
+            8,
+        )
+    }
+
+    /// `"ab" + RTL(2 chars) + "cd"`: logical 0,1 | 2,4 | 6,7 laid out as
+    /// a b [rtl2 rtl1] c d.
+    fn mixed() -> VisualMap {
+        VisualMap::from_glyphs(
+            [
+                Glyph { index: 0, x: 0.0 },
+                Glyph { index: 1, x: 10.0 },
+                Glyph { index: 4, x: 20.0 }, // second RTL char, drawn first
+                Glyph { index: 2, x: 30.0 }, // first RTL char, drawn second
+                Glyph { index: 6, x: 40.0 },
+                Glyph { index: 7, x: 50.0 },
+            ],
+            60.0,
+            8,
+        )
+    }
+
+    #[test]
+    fn ltr_behaves_exactly_like_a_plain_line() {
+        let m = ltr();
+        assert!(!m.is_bidi());
+        for i in 0..5 {
+            assert_eq!(m.x_for_index(i), i as f32 * 8.0);
+        }
+        // Past the end → the right edge.
+        assert_eq!(m.x_for_index(5), 40.0);
+        // Clicks: leading half picks this glyph, trailing half the next.
+        assert_eq!(m.index_for_x(0.0), 0);
+        assert_eq!(m.index_for_x(7.0), 1);
+        assert_eq!(m.index_for_x(9.0), 1);
+        assert_eq!(m.index_for_x(39.0), 5);
+    }
+
+    #[test]
+    fn rtl_caret_walks_right_to_left_instead_of_collapsing() {
+        let m = rtl();
+        assert!(m.is_bidi());
+        // This is the bug the crate exists for: gpui returns 0.0 for every one
+        // of these. Reading starts at the RIGHT edge and moves left.
+        assert_eq!(m.x_for_index(0), 40.0, "first char sits at the right edge");
+        assert_eq!(m.x_for_index(2), 30.0);
+        assert_eq!(m.x_for_index(4), 20.0);
+        assert_eq!(m.x_for_index(6), 10.0);
+        // Past the end of an RTL line is the LEFT edge.
+        assert_eq!(m.x_for_index(8), 0.0);
+        // Every position is distinct — the collapse is gone.
+        let xs: Vec<f32> = (0..4).map(|k| m.x_for_index(k * 2)).collect();
+        let mut sorted = xs.clone();
+        sorted.sort_by(f32::total_cmp);
+        sorted.dedup();
+        assert_eq!(sorted.len(), xs.len(), "caret positions must be distinct");
+    }
+
+    #[test]
+    fn rtl_clicks_map_back_to_the_right_characters() {
+        let m = rtl();
+        // Clicking the rightmost glyph's right half selects the FIRST
+        // character in reading order.
+        assert_eq!(m.index_for_x(39.0), 0);
+        // …and its left half moves one character along in reading order.
+        assert_eq!(m.index_for_x(31.0), 2);
+        // Leftmost glyph, left half → the last character's trailing edge.
+        assert_eq!(m.index_for_x(0.0), 8);
+        // Round-trip: every caret x maps back to the offset it came from.
+        for k in 0..4 {
+            let off = k * 2;
+            let x = m.x_for_index(off);
+            // Nudge just inside the glyph so we're not exactly on a boundary.
+            assert_eq!(m.index_for_x(x - 1.0), off, "round trip at offset {off}");
+        }
+    }
+
+    #[test]
+    fn mixed_runs_keep_their_own_direction() {
+        let m = mixed();
+        assert!(m.is_bidi());
+        // LTR head.
+        assert_eq!(m.x_for_index(0), 0.0);
+        assert_eq!(m.x_for_index(1), 10.0);
+        // RTL middle: offset 2 is the FIRST rtl char, drawn at the RIGHT of
+        // the run, so its caret is at that glyph's right edge (40.0).
+        assert_eq!(m.x_for_index(2), 40.0);
+        assert_eq!(m.x_for_index(4), 30.0);
+        // LTR tail resumes.
+        assert_eq!(m.x_for_index(6), 40.0);
+        assert_eq!(m.x_for_index(7), 50.0);
+        // The four offsets gpui collapsed onto one x are distinct again.
+        assert_ne!(m.x_for_index(1), m.x_for_index(2));
+        assert_ne!(m.x_for_index(2), m.x_for_index(4));
+    }
+
+    #[test]
+    fn a_selection_across_a_direction_change_is_visually_split() {
+        let m = mixed();
+        // Selecting the LTR head alone is one rect.
+        assert_eq!(m.rects_for_range(0..2), vec![(0.0, 20.0)]);
+        // Selecting the RTL middle alone is one rect too (its glyphs abut).
+        assert_eq!(m.rects_for_range(2..6), vec![(20.0, 40.0)]);
+        // Selecting head + middle merges, because they touch visually.
+        assert_eq!(m.rects_for_range(0..6), vec![(0.0, 40.0)]);
+        // The whole line is one rect.
+        assert_eq!(m.rects_for_range(0..8), vec![(0.0, 60.0)]);
+        // An empty or reversed range selects nothing.
+        assert!(m.rects_for_range(3..3).is_empty());
+    }
+
+    #[test]
+    fn selection_can_need_more_than_one_rect() {
+        // Visual order 0, 4, 2, 6 — a shape where one *contiguous* logical
+        // range lands in two separate places on screen. This is the case a
+        // single-rect-per-row painter gets wrong.
+        let split = VisualMap::from_glyphs(
+            [
+                Glyph { index: 0, x: 0.0 },
+                Glyph { index: 4, x: 10.0 },
+                Glyph { index: 2, x: 20.0 },
+                Glyph { index: 6, x: 30.0 },
+            ],
+            40.0,
+            8,
+        );
+        // Logical 0..3 covers glyphs 0 (x 0-10) and 2 (x 20-30); glyph 4 sits
+        // between them visually but is outside the range.
+        assert_eq!(split.rects_for_range(0..3), vec![(0.0, 10.0), (20.0, 30.0)]);
+        // Widening to 0..5 pulls in glyph 4 and the three merge into one.
+        assert_eq!(split.rects_for_range(0..5), vec![(0.0, 30.0)]);
+        // A tail-only range is a single rect at the far right.
+        let m = mixed();
+        assert_eq!(m.rects_for_range(6..8), vec![(40.0, 60.0)]);
+    }
+
+    #[test]
+    fn degenerate_lines_do_not_panic() {
+        let empty = VisualMap::from_glyphs([], 0.0, 0);
+        assert!(empty.is_empty());
+        assert_eq!(empty.x_for_index(0), 0.0);
+        assert_eq!(empty.x_for_index(99), 0.0);
+        assert_eq!(empty.index_for_x(10.0), 0);
+        assert!(empty.rects_for_range(0..5).is_empty());
+        assert!(!empty.is_bidi());
+
+        let one = VisualMap::from_glyphs([Glyph { index: 0, x: 0.0 }], 12.0, 1);
+        assert_eq!(one.x_for_index(0), 0.0);
+        assert_eq!(one.x_for_index(1), 12.0);
+        assert_eq!(one.index_for_x(0.0), 0);
+        assert_eq!(one.index_for_x(11.0), 1);
+    }
+}

--- a/crates/gpui-bidi/src/lib.rs
+++ b/crates/gpui-bidi/src/lib.rs
@@ -291,6 +291,22 @@ impl VisualMap {
         stops
     }
 
+    /// Does the byte range read right-to-left?
+    ///
+    /// From the UAX #9 levels when they're available (see
+    /// [`Self::with_levels`]); otherwise from the glyph order, which is right
+    /// in the middle of a run and unreliable at its edges.
+    pub fn is_rtl_range(&self, range: Range<usize>) -> bool {
+        if let Some(levels) = &self.levels {
+            return levels
+                .get(range.start..range.end.min(levels.len()))
+                .is_some_and(|s| s.iter().any(|l| l % 2 == 1));
+        }
+        (0..self.glyphs.len())
+            .filter(|&gi| range.contains(&self.glyphs[gi].index))
+            .any(|gi| self.is_rtl_at(gi))
+    }
+
     /// The byte offset at one edge of the glyph at visual position `gi`.
     /// `trailing` means the edge further along in *reading* order.
     fn edge_offset(&self, gi: usize, trailing: bool) -> usize {
@@ -426,6 +442,24 @@ mod tests {
         sorted.sort_by(f32::total_cmp);
         sorted.dedup();
         assert_eq!(sorted.len(), xs.len(), "caret positions must be distinct");
+    }
+
+    #[test]
+    fn a_neutral_run_takes_the_direction_of_the_text_around_it() {
+        // "سلام [[x]] دنیا" — the bracket pair is neutral, so UAX #9 gives it
+        // the paragraph's direction (RTL). Painting a styled row re-shapes each
+        // run on its own, which loses that context and would render `[[` in
+        // LTR order; the run's direction has to come from the levels.
+        let text = "سلام [[x]] دنیا";
+        let m = VisualMap::from_glyphs([Glyph { index: 0, x: 0.0 }], 10.0, text.len())
+            .with_levels(text);
+        let open = text.find("[[").unwrap();
+        assert!(
+            m.is_rtl_range(open..open + 2),
+            "the brackets read RTL, like the prose around them"
+        );
+        let x = text.find('x').unwrap();
+        assert!(!m.is_rtl_range(x..x + 1), "the Latin between them does not");
     }
 
     #[test]

--- a/crates/gpui-bidi/src/lib.rs
+++ b/crates/gpui-bidi/src/lib.rs
@@ -270,6 +270,7 @@ impl VisualMap {
     }
 }
 
+pub mod paragraph;
 pub mod shaped;
 
 #[cfg(test)]

--- a/crates/gpui-bidi/src/lib.rs
+++ b/crates/gpui-bidi/src/lib.rs
@@ -15,8 +15,13 @@
 //! `closest_index_for_x` fail the same way, and mixed content is worse: in
 //! `"hello سلام world"` the four offsets 6, 8, 10, 12 all map to one x.
 //!
-//! So this crate is **not** an implementation of the bidi algorithm — the
-//! shaper did that. It reads an already-reordered glyph table correctly.
+//! So this crate is mostly **not** an implementation of the bidi algorithm —
+//! the shaper did that, and this reads its already-reordered glyph table
+//! correctly. The one thing the glyph table cannot tell you is a glyph's
+//! embedding LEVEL: at the edge of an embedded run the glyph beside it belongs
+//! to the other run and carries a misleading index, so direction inferred from
+//! geometry is wrong exactly there. Those levels come from `unicode-bidi`,
+//! given the text — see [`VisualMap::with_levels`].
 //!
 //! # Shape of the API
 //!
@@ -29,8 +34,9 @@
 //!
 //! - **Paragraph direction** (which side a line starts on) is the host's, from
 //!   the first strong character. This crate only maps within a shaped line.
-//! - **Logical caret movement.** Left/right arrows moving in *logical* order is
-//!   what most editors do, and it needs nothing from here.
+//! - **Logical caret movement.** Left/right arrows moving in *logical* order
+//!   needs nothing from here. For the *visual* movement platforms actually do
+//!   in bidi text, see [`VisualMap::step_visual`].
 
 use std::ops::Range;
 
@@ -61,6 +67,9 @@ pub struct VisualMap {
     width: f32,
     /// Byte length of the shaped text — the offset one past the last glyph.
     len: usize,
+    /// UAX #9 embedding level per byte of the shaped text, when the caller
+    /// supplied the text ([`Self::with_levels`]). Odd = right-to-left.
+    levels: Option<Vec<u8>>,
 }
 
 impl VisualMap {
@@ -78,7 +87,23 @@ impl VisualMap {
             by_logical,
             width,
             len,
+            levels: None,
         }
+    }
+
+    /// Attach the text these glyphs were shaped from, so glyph direction comes
+    /// from the UAX #9 embedding levels rather than being inferred.
+    ///
+    /// Inference from `(index, x)` alone is exact in the middle of a run and
+    /// WRONG at its edges: the glyph visually beside the last letter of a Latin
+    /// word embedded in Persian belongs to the surrounding RTL run and carries
+    /// a lower index, which reads as "descending, therefore RTL". The caret
+    /// then sits on that letter's far edge — one glyph out, which is what a
+    /// reader sees as the caret skipping a character.
+    pub fn with_levels(mut self, text: &str) -> Self {
+        let info = unicode_bidi::BidiInfo::new(text, None);
+        self.levels = Some(info.levels.iter().map(|l| l.number()).collect());
+        self
     }
 
     /// Whether any glyph sits out of logical order — i.e. the line contains
@@ -207,6 +232,11 @@ impl VisualMap {
     /// case the shaper itself renders ambiguously.
     fn is_rtl_at(&self, gi: usize) -> bool {
         let here = self.glyphs[gi].index;
+        // The levels know, when we have them: no inference, and correct at the
+        // edges of an embedded run where inference cannot be.
+        if let Some(levels) = &self.levels {
+            return levels.get(here).is_some_and(|l| l % 2 == 1);
+        }
         let descends_right = self.glyphs.get(gi + 1).is_some_and(|n| n.index < here);
         let descends_left = gi > 0 && self.glyphs[gi - 1].index > here;
         descends_right || descends_left
@@ -216,6 +246,49 @@ impl VisualMap {
     /// leading edge, or the line's width for the last one.
     fn right_edge(&self, gi: usize) -> f32 {
         self.glyphs.get(gi + 1).map_or(self.width, |next| next.x)
+    }
+
+    /// The logical offset one caret step to the visual left/right of `offset`.
+    ///
+    /// `None` when there is no glyph that way — the caret is leaving the line,
+    /// and the caller moves it to the neighbouring row instead.
+    ///
+    /// Arrow keys move visually, and inside a line that is NOT a matter of
+    /// "this line is RTL, so flip left and right". A Latin word or a URL
+    /// embedded in Persian runs the other way, and the caret has to flow
+    /// through it in ITS direction, not jump over it to the far end. Stepping
+    /// by x rather than by byte gets that for free: the glyph table is already
+    /// in visual order, so "the next caret position to the right" is just the
+    /// next distinct x.
+    pub fn step_visual(&self, offset: usize, right: bool) -> Option<usize> {
+        let stops = self.caret_stops();
+        // Where the caret is now in that order. An offset with no stop of its
+        // own (mid-glyph, say) has no neighbour to step to.
+        let pos = stops.iter().position(|&(_, o)| o == offset)?;
+        if right {
+            stops.get(pos + 1).map(|&(_, o)| o)
+        } else {
+            pos.checked_sub(1).map(|i| stops[i].1)
+        }
+    }
+
+    /// Every caret position on the line as `(x, offset)`, ordered left to
+    /// right.
+    ///
+    /// Ordering by x ALONE is not enough: at a direction change two different
+    /// offsets sit at the same x — the trailing edge of one run and the leading
+    /// edge of the next — and stepping by "the next bigger x" makes one of them
+    /// unreachable, which shows up as the caret skipping a character or two at
+    /// the edge of an embedded word. Ties break on the offset, so the order is
+    /// total and every stop can be reached.
+    fn caret_stops(&self) -> Vec<(f32, usize)> {
+        let mut stops: Vec<(f32, usize)> = (0..self.glyphs.len())
+            .flat_map(|gi| [self.edge_offset(gi, false), self.edge_offset(gi, true)])
+            .map(|off| (self.x_for_index(off), off))
+            .collect();
+        stops.sort_by(|a, b| a.0.total_cmp(&b.0).then(a.1.cmp(&b.1)));
+        stops.dedup();
+        stops
     }
 
     /// The byte offset at one edge of the glyph at visual position `gi`.
@@ -353,6 +426,95 @@ mod tests {
         sorted.sort_by(f32::total_cmp);
         sorted.dedup();
         assert_eq!(sorted.len(), xs.len(), "caret positions must be distinct");
+    }
+
+    #[test]
+    fn levels_fix_the_edges_of_an_embedded_run() {
+        // "سلام Demo x" — a Latin word inside Persian. Shaped, the Latin runs
+        // left-to-right while the Persian around it runs the other way. Build
+        // the glyph table by hand in VISUAL order to mimic that.
+        //
+        // Bytes: "سلام" = 0..8 (4 chars, 2 bytes each), ' ' = 8, "Demo" = 9..13,
+        // ' ' = 13, "x" = 14.
+        let text = "سلام Demo x";
+        let m = VisualMap::from_glyphs(
+            [
+                // Persian, drawn right to left: it sits at the RIGHT, so its
+                // glyphs take the higher x's. Latin sits to its left.
+                Glyph { index: 14, x: 0.0 },  // x
+                Glyph { index: 13, x: 10.0 }, // space
+                Glyph { index: 9, x: 20.0 },  // D
+                Glyph { index: 10, x: 30.0 }, // e
+                Glyph { index: 11, x: 40.0 }, // m
+                Glyph { index: 12, x: 50.0 }, // o
+                Glyph { index: 8, x: 60.0 },  // space
+                Glyph { index: 6, x: 70.0 },
+                Glyph { index: 4, x: 80.0 },
+                Glyph { index: 2, x: 90.0 },
+                Glyph { index: 0, x: 100.0 },
+            ],
+            110.0,
+            text.len(),
+        )
+        .with_levels(text);
+
+        // The caret before 'o' (byte 12) belongs on 'o's LEFT edge, because 'o'
+        // is left-to-right. Inference put it on the right edge — the glyph to
+        // 'o's right is the Persian space, whose lower index reads as
+        // "descending, therefore RTL" — and the caret appeared to skip a
+        // character at the end of the embedded word.
+        assert_eq!(m.x_for_index(12), 50.0, "caret before 'o' sits left of it");
+        assert_eq!(m.x_for_index(9), 20.0, "and before 'D' at the run's start");
+        // Stepping right through the Latin run advances one letter at a time.
+        assert_eq!(m.step_visual(9, true), Some(10));
+        assert_eq!(m.step_visual(10, true), Some(11));
+        assert_eq!(m.step_visual(11, true), Some(12));
+        // Persian around it still reads right-to-left.
+        assert_eq!(m.x_for_index(0), 110.0, "first Persian char at the right");
+    }
+
+    #[test]
+    fn visual_steps_flow_through_an_embedded_run_instead_of_jumping_it() {
+        // `mixed()`: LTR bytes 0,1 — an RTL pair at 2,4 drawn in reverse — then
+        // LTR 6,7. Walking right from the line's left edge must visit every
+        // caret stop in x order, INCLUDING both ends of the embedded run. The
+        // bug this covers: keying the step off "the line is RTL" made the caret
+        // skip to the far side of an embedded Latin word or URL.
+        let m = mixed();
+        let mut seen = vec![0usize];
+        let mut at = 0usize;
+        while let Some(next) = m.step_visual(at, true) {
+            seen.push(next);
+            at = next;
+            assert!(seen.len() < 20, "stepping right must terminate");
+        }
+        // Never moves backwards, and never lands on the same stop twice —
+        // co-located stops at a direction change must each be reachable, which
+        // is what "the caret skipped the last two characters" was.
+        let xs: Vec<f32> = seen.iter().map(|&o| m.x_for_index(o)).collect();
+        assert!(
+            xs.windows(2).all(|w| w[1] >= w[0]),
+            "no step moves left: {xs:?} from {seen:?}"
+        );
+        let mut uniq = seen.clone();
+        uniq.sort_unstable();
+        uniq.dedup();
+        assert_eq!(uniq.len(), seen.len(), "no stop visited twice: {seen:?}");
+        // Every caret stop on the line is reachable by stepping.
+        assert_eq!(seen.len(), m.caret_stops().len(), "all stops visited");
+        // And it reaches the line's right edge rather than stopping early at
+        // the direction change.
+        assert_eq!(*xs.last().unwrap(), 60.0);
+
+        // Walking back left returns to where it started.
+        let mut back = at;
+        let mut steps = 0;
+        while let Some(prev) = m.step_visual(back, false) {
+            back = prev;
+            steps += 1;
+            assert!(steps < 20, "stepping left must terminate");
+        }
+        assert_eq!(m.x_for_index(back), 0.0, "back at the left edge");
     }
 
     #[test]

--- a/crates/gpui-bidi/src/paragraph.rs
+++ b/crates/gpui-bidi/src/paragraph.rs
@@ -1,0 +1,494 @@
+//! Logical-order line breaking for right-to-left paragraphs.
+//!
+//! # Why this exists
+//!
+//! gpui shapes a paragraph as ONE long line and only then slices it into wrap
+//! rows, walking the glyph table by ascending x
+//! (`LineLayout::compute_wrap_boundaries`). Glyph order is *visual*, so in an
+//! RTL paragraph the leftmost glyphs — the ones that end up in the first row —
+//! are the paragraph's LAST words. A wrapped Persian note therefore reads
+//! bottom-to-top, and no amount of alignment fixes it: the row contents
+//! themselves are wrong.
+//!
+//! UAX #9 says to do it the other way round: break into lines in *logical*
+//! order first, then reorder each line independently. That is what this module
+//! does, and it needs nothing from gpui that isn't already public:
+//!
+//! - `TextSystem::shape_text` splits its input on `\n` and shapes each line
+//!   separately, in order. So injecting a `\n` at each logical break makes the
+//!   shaper do the per-line reordering for us, in the right sequence.
+//! - Where the breaks GO is ours. gpui's `LineWrapper` walks the text (its
+//!   offsets are logical, so it looked like the tool for this) but its
+//!   `is_word_char` knows Latin, Cyrillic, Vietnamese and Bengali and not
+//!   Arabic, so Persian takes its "CJK may not be space separated" path and
+//!   every character becomes a break candidate — words split down the middle.
+//!   Arabic script is space-separated, so [`wrap_at_words`] measures words.
+//!
+//! The whole trick is [`insert_breaks`]: turn one paragraph into a `\n`-joined
+//! sequence of lines that already fit. Everything after that is ordinary
+//! painting.
+
+use std::cell::RefCell;
+use std::ops::Range;
+use std::rc::Rc;
+
+use gpui::{
+    App, AvailableSpace, Bounds, Element, ElementId, GlobalElementId, HighlightStyle,
+    InspectorElementId, IntoElement, LayoutId, Pixels, Point, SharedString, Size, TextAlign,
+    TextRun, TextStyle, Window, WrappedLine, px,
+};
+
+/// Split `text` into lines at `breaks` (logical byte offsets, ascending) by
+/// injecting `\n`, and grow `runs` to cover the injected bytes.
+///
+/// `shape_text` requires the runs to span every byte of the text it is handed,
+/// including the `\n`s (it consumes one byte of run per line break), so a
+/// break inside a run lengthens that run by one rather than splitting it — the
+/// newline inherits the style of the text it interrupts, which is invisible
+/// either way since a line break paints nothing.
+///
+/// Offsets at 0, at `text.len()`, or repeated are ignored: they would produce
+/// an empty line, which would paint as a blank row the reader never asked for.
+pub fn insert_breaks(
+    text: &str,
+    runs: &[TextRun],
+    breaks: &[usize],
+) -> (SharedString, Vec<TextRun>) {
+    let mut wanted: Vec<usize> = breaks
+        .iter()
+        .copied()
+        .filter(|ix| *ix > 0 && *ix < text.len() && text.is_char_boundary(*ix))
+        .collect();
+    wanted.sort_unstable();
+    wanted.dedup();
+    if wanted.is_empty() {
+        return (SharedString::from(text.to_string()), runs.to_vec());
+    }
+
+    let mut out = String::with_capacity(text.len() + wanted.len());
+    let mut last = 0usize;
+    for ix in &wanted {
+        out.push_str(&text[last..*ix]);
+        out.push('\n');
+        last = *ix;
+    }
+    out.push_str(&text[last..]);
+
+    // Walk the runs alongside the break list, widening whichever run contains
+    // each break. A break exactly on a run boundary belongs to the run that
+    // ENDS there, matching how the text was split above.
+    let mut new_runs = Vec::with_capacity(runs.len());
+    let mut run_start = 0usize;
+    let mut next = 0usize;
+    for run in runs {
+        let run_end = run_start + run.len;
+        let mut extra = 0usize;
+        while next < wanted.len() && wanted[next] <= run_end {
+            if wanted[next] > run_start {
+                extra += 1;
+            }
+            next += 1;
+        }
+        let mut run = run.clone();
+        run.len += extra;
+        new_runs.push(run);
+        run_start = run_end;
+    }
+    // Any break past the last run (runs that don't cover the text — gpui logs
+    // and truncates in that case) has nowhere to go; the text still carries it.
+    (SharedString::from(out), new_runs)
+}
+
+/// The byte range of each word in `text`, where a word runs up to and including
+/// the spaces that follow it — trailing spaces belong to the line they end, the
+/// same convention gpui's wrapper uses.
+///
+/// Only ASCII space and tab separate words. Notably NOT the zero-width
+/// non-joiner (U+200C), which sits *inside* Persian words (می‌گیرد) and would
+/// split them if treated as a break.
+fn words(text: &str) -> Vec<Range<usize>> {
+    let mut out = Vec::new();
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let start = i;
+        while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t') {
+            i += 1;
+        }
+        while i < bytes.len() && matches!(bytes[i], b' ' | b'\t') {
+            i += 1;
+        }
+        out.push(start..i);
+    }
+    out
+}
+
+/// The sub-runs covering `range`, so a slice of text can be measured with the
+/// styles it actually has (a bold word is wider than the same word in regular).
+fn slice_runs(runs: &[TextRun], range: Range<usize>) -> Vec<TextRun> {
+    let mut out = Vec::new();
+    let mut at = 0usize;
+    for run in runs {
+        let end = at + run.len;
+        let lo = at.max(range.start);
+        let hi = end.min(range.end);
+        if lo < hi {
+            let mut r = run.clone();
+            r.len = hi - lo;
+            out.push(r);
+        }
+        at = end;
+        if at >= range.end {
+            break;
+        }
+    }
+    out
+}
+
+/// Greedy word wrap: the byte offsets where a new line should start.
+///
+/// Words are measured once each and summed, rather than re-measuring the whole
+/// line as it grows — shaping is per-word for Arabic script (contextual forms
+/// join within a word, never across a space), so the sum is exact and the pass
+/// stays linear. A single word wider than `wrap_width` overflows rather than
+/// being chopped mid-word: chopping is what the reader complained about.
+fn wrap_at_words(
+    text: &str,
+    runs: &[TextRun],
+    wrap_width: Pixels,
+    font_size: Pixels,
+    window: &Window,
+) -> Vec<usize> {
+    let mut breaks = Vec::new();
+    let mut line_width = px(0.);
+    let mut line_has_word = false;
+    for word in words(text) {
+        let measured = window.text_system().shape_line(
+            SharedString::from(text[word.clone()].to_string()),
+            font_size,
+            &slice_runs(runs, word.clone()),
+            None,
+        );
+        // Trailing spaces don't push a line over: they hang past the edge, as
+        // they do in every text engine.
+        let trimmed = text[word.clone()].trim_end();
+        let ink = if trimmed.len() == word.len() {
+            measured.width
+        } else {
+            window
+                .text_system()
+                .shape_line(
+                    SharedString::from(trimmed.to_string()),
+                    font_size,
+                    &slice_runs(runs, word.start..word.start + trimmed.len()),
+                    None,
+                )
+                .width
+        };
+
+        if line_has_word && line_width + ink > wrap_width {
+            breaks.push(word.start);
+            line_width = measured.width;
+        } else {
+            line_width += measured.width;
+        }
+        line_has_word = true;
+    }
+    breaks
+}
+
+/// A paragraph laid out in logical order, then painted right-aligned.
+///
+/// Build it for blocks whose base direction is RTL; LTR text needs none of
+/// this and should keep using `StyledText`, which is cheaper and carries the
+/// interactive-text machinery.
+pub struct RtlText {
+    text: SharedString,
+    highlights: Vec<(Range<usize>, HighlightStyle)>,
+    state: Rc<RefCell<Option<Laid>>>,
+}
+
+/// Expand `highlights` into runs covering all of `text`, the way `StyledText`
+/// does — its own `compute_runs` is private, but it is only `to_run` and
+/// `highlight`, both public. Ranges must be sorted and non-overlapping.
+fn runs_from_highlights(
+    text: &str,
+    default_style: &TextStyle,
+    highlights: &[(Range<usize>, HighlightStyle)],
+) -> Vec<TextRun> {
+    let mut runs = Vec::new();
+    let mut ix = 0;
+    for (range, highlight) in highlights {
+        if range.start > text.len() || range.end > text.len() || range.start < ix {
+            continue;
+        }
+        if ix < range.start {
+            runs.push(default_style.clone().to_run(range.start - ix));
+        }
+        runs.push(
+            default_style
+                .clone()
+                .highlight(*highlight)
+                .to_run(range.len()),
+        );
+        ix = range.end;
+    }
+    if ix < text.len() {
+        runs.push(default_style.to_run(text.len() - ix));
+    }
+    runs
+}
+
+/// What the measure pass worked out, reused by paint.
+struct Laid {
+    lines: Vec<WrappedLine>,
+    line_height: Pixels,
+    wrap_width: Option<Pixels>,
+    size: Size<Pixels>,
+}
+
+impl RtlText {
+    pub fn new(text: impl Into<SharedString>) -> Self {
+        Self {
+            text: text.into(),
+            highlights: Vec::new(),
+            state: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    /// Styled ranges, exactly as `StyledText::with_highlights` takes them:
+    /// sorted, non-overlapping, on char boundaries.
+    pub fn with_highlights(
+        mut self,
+        highlights: impl IntoIterator<Item = (Range<usize>, HighlightStyle)>,
+    ) -> Self {
+        self.highlights = highlights.into_iter().collect();
+        self
+    }
+}
+
+impl IntoElement for RtlText {
+    type Element = Self;
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for RtlText {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        _cx: &mut App,
+    ) -> (LayoutId, ()) {
+        let text_style = window.text_style();
+        let font_size = text_style.font_size.to_pixels(window.rem_size());
+        let line_height = window.pixel_snap(
+            text_style
+                .line_height
+                .to_pixels(font_size.into(), window.rem_size()),
+        );
+        let text = self.text.clone();
+        let runs = runs_from_highlights(&text, &text_style, &self.highlights);
+        let state = self.state.clone();
+
+        let id = window.request_measured_layout(
+            Default::default(),
+            move |known, available, window, _cx| {
+                let wrap_width = known.width.or(match available.width {
+                    AvailableSpace::Definite(w) => Some(w),
+                    _ => None,
+                });
+
+                if let Some(laid) = state.borrow().as_ref()
+                    && laid.wrap_width == wrap_width
+                {
+                    return laid.size;
+                }
+
+                // Break in LOGICAL order, at word boundaries we pick ourselves.
+                //
+                // gpui's `LineWrapper` walks the text (so its offsets ARE
+                // logical, which is why this looked like the obvious tool), but
+                // its `is_word_char` covers Latin, Cyrillic, Vietnamese and
+                // Bengali — not Arabic. Persian therefore takes its "CJK may
+                // not be space separated" branch, which makes every character a
+                // break candidate and splits words down the middle. Arabic
+                // script IS space-separated, so we measure words instead.
+                let breaks: Vec<usize> = match wrap_width {
+                    Some(w) => wrap_at_words(&text, &runs, w, font_size, window),
+                    None => Vec::new(),
+                };
+                let (broken, broken_runs) = insert_breaks(&text, &runs, &breaks);
+
+                // Each line now fits, so shaping with no wrap width leaves the
+                // rows exactly where we put them — and each is reordered on
+                // its own, which is the whole point.
+                let lines = window
+                    .text_system()
+                    .shape_text(broken, font_size, &broken_runs, None, None)
+                    .map(|l| l.into_iter().collect::<Vec<_>>())
+                    .unwrap_or_default();
+
+                let height = line_height * lines.len().max(1);
+                let widest = lines.iter().map(|l| l.width()).fold(px(0.), Pixels::max);
+                let size = Size {
+                    width: wrap_width.unwrap_or(widest),
+                    height,
+                };
+                *state.borrow_mut() = Some(Laid {
+                    lines,
+                    line_height,
+                    wrap_width,
+                    size,
+                });
+                size
+            },
+        );
+        (id, ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut (),
+        _window: &mut Window,
+        _cx: &mut App,
+    ) {
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut (),
+        _prepaint: &mut (),
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let state = self.state.borrow();
+        let Some(laid) = state.as_ref() else {
+            return;
+        };
+        // Top-to-bottom in the order we broke them: logical order. Each row is
+        // right-aligned across the full width, which is where an RTL reader
+        // starts — gpui's own `TextAlign` handles the within-row placement.
+        for (i, line) in laid.lines.iter().enumerate() {
+            let origin = Point {
+                x: bounds.origin.x,
+                y: bounds.origin.y + laid.line_height * i,
+            };
+            let _ = line.paint(
+                origin,
+                laid.line_height,
+                TextAlign::Right,
+                Some(bounds),
+                window,
+                cx,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{Hsla, font};
+
+    fn run(len: usize) -> TextRun {
+        TextRun {
+            len,
+            font: font("Helvetica"),
+            color: Hsla::default(),
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+        }
+    }
+
+    #[test]
+    fn breaks_split_text_and_widen_the_run_that_holds_them() {
+        let text = "one two three";
+        let (out, runs) = insert_breaks(text, &[run(text.len())], &[4, 8]);
+        assert_eq!(out.as_ref(), "one \ntwo \nthree");
+        // Runs must still cover every byte, newlines included, or `shape_text`
+        // warns and drops the tail.
+        assert_eq!(runs.iter().map(|r| r.len).sum::<usize>(), out.len());
+    }
+
+    #[test]
+    fn a_break_falls_in_the_run_that_ends_at_it() {
+        let text = "boldplain";
+        // Two runs: "bold" then "plain". A break exactly at 4 belongs to the
+        // first, so the newline inherits the style it interrupts.
+        let (out, runs) = insert_breaks(text, &[run(4), run(5)], &[4]);
+        assert_eq!(out.as_ref(), "bold\nplain");
+        assert_eq!(runs[0].len, 5);
+        assert_eq!(runs[1].len, 5);
+        assert_eq!(runs.iter().map(|r| r.len).sum::<usize>(), out.len());
+    }
+
+    #[test]
+    fn degenerate_offsets_never_make_an_empty_row() {
+        let text = "hello";
+        // 0 and len would each produce a blank line; duplicates would produce
+        // one per repeat.
+        let (out, runs) = insert_breaks(text, &[run(5)], &[0, 5, 2, 2]);
+        assert_eq!(out.as_ref(), "he\nllo");
+        assert_eq!(runs.iter().map(|r| r.len).sum::<usize>(), out.len());
+    }
+
+    #[test]
+    fn words_keep_trailing_spaces_and_never_split_on_a_non_joiner() {
+        assert_eq!(words("one two"), vec![0..4, 4..7]);
+        assert_eq!(words("a  b"), vec![0..3, 3..4]);
+        // U+200C (ZWNJ) is 3 bytes and lives INSIDE Persian words: می‌گیرد is
+        // one word, and breaking at it would split it visually.
+        let w = "می\u{200C}گیرد دنیا";
+        assert_eq!(words(w).len(), 2);
+        assert!(w[words(w)[0].clone()].contains('\u{200C}'));
+    }
+
+    #[test]
+    fn sliced_runs_cover_exactly_the_requested_range() {
+        let runs = [run(4), run(6)];
+        let got = slice_runs(&runs, 2..7);
+        assert_eq!(got.iter().map(|r| r.len).sum::<usize>(), 5);
+        assert_eq!(got.len(), 2, "the range straddles both runs");
+        assert_eq!(slice_runs(&runs, 0..0).len(), 0);
+    }
+
+    #[test]
+    fn no_breaks_leaves_the_paragraph_untouched() {
+        let text = "سلام دنیا";
+        let (out, runs) = insert_breaks(text, &[run(text.len())], &[]);
+        assert_eq!(out.as_ref(), text);
+        assert_eq!(runs[0].len, text.len());
+    }
+
+    #[test]
+    fn breaks_land_on_char_boundaries_of_multibyte_text() {
+        // "سلام دنیا" — the space is at byte 8, inside multibyte content.
+        let text = "سلام دنیا";
+        let (out, _) = insert_breaks(text, &[run(text.len())], &[9]);
+        assert_eq!(out.as_ref(), "سلام \nدنیا");
+        // A mid-codepoint offset is refused rather than panicking the shaper.
+        let (same, _) = insert_breaks(text, &[run(text.len())], &[1]);
+        assert_eq!(same.as_ref(), text);
+    }
+}

--- a/crates/gpui-bidi/src/paragraph.rs
+++ b/crates/gpui-bidi/src/paragraph.rs
@@ -244,8 +244,8 @@ fn runs_from_highlights(
 
 /// What the measure pass worked out, reused by paint.
 struct Laid {
-    lines: Vec<WrappedLine>,
-    /// Per line, in the same order: where it starts in the ORIGINAL text (the
+    font_size: Pixels,
+    /// The rows, in reading order: where each starts in the ORIGINAL text (the
     /// injected `\n`s don't exist there) and how to read its glyphs.
     rows: Vec<Row>,
     line_height: Pixels,
@@ -256,15 +256,135 @@ struct Laid {
     bounds: Option<Bounds<Pixels>>,
 }
 
-/// One painted row: its span in the original text, plus the visual map that
+/// One laid-out row: its span in the original text, plus the visual map that
 /// turns a logical offset inside it into an x and back.
-struct Row {
+///
+/// Public because both engines need it — the reader's [`RtlText`] and the
+/// editor, which has its own line pipeline but the same problem.
+pub struct Row {
     /// Byte offset in the ORIGINAL text where this row starts.
-    start: usize,
+    pub start: usize,
     /// Byte length of the row's own text.
-    len: usize,
-    width: Pixels,
-    map: VisualMap,
+    pub len: usize,
+    pub width: Pixels,
+    pub map: VisualMap,
+    /// The row's style runs, with row-local ranges. Carried because gpui can't
+    /// paint a multi-styled RTL row correctly — see [`paint_row`].
+    pub runs: Vec<(Range<usize>, TextRun)>,
+    /// The shaped row, ready to paint.
+    pub line: WrappedLine,
+}
+
+/// Lay `text` out as right-to-left rows: break it in LOGICAL order at word
+/// boundaries, then shape each row on its own so the shaper reorders it
+/// independently — the sequence gpui's own wrapping gets backwards.
+///
+/// `runs` must cover every byte of `text`. Rows come back in reading order, so
+/// row 0 is the paragraph's first line whichever way the script runs.
+pub fn layout_rows(
+    text: &str,
+    runs: &[TextRun],
+    wrap_width: Option<Pixels>,
+    font_size: Pixels,
+    window: &Window,
+) -> Vec<Row> {
+    let breaks: Vec<usize> = match wrap_width {
+        Some(w) => wrap_at_words(text, runs, w, font_size, window),
+        None => Vec::new(),
+    };
+    let (broken, broken_runs) = insert_breaks(text, runs, &breaks);
+
+    // Each row now fits, so shaping with no wrap width leaves the rows exactly
+    // where we put them — and each is reordered on its own, which is the point.
+    let lines = window
+        .text_system()
+        .shape_text(broken, font_size, &broken_runs, None, None)
+        .map(|l| l.into_iter().collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    // `orig` walks the ORIGINAL text, where the injected breaks do not exist,
+    // so it advances by the row length alone. `broken_at` walks the string we
+    // built, which DOES carry them. Conflating the two slides every row after
+    // the first by a byte per break.
+    let mut rows = Vec::with_capacity(lines.len());
+    let mut orig = 0usize;
+    let mut broken_at = 0usize;
+    for line in lines {
+        let len = line.text.len();
+        let mut row_runs = Vec::new();
+        let mut at = 0usize;
+        for run in slice_runs(&broken_runs, broken_at..broken_at + len) {
+            let end = at + run.len;
+            row_runs.push((at..end, run));
+            at = end;
+        }
+        rows.push(Row {
+            start: orig,
+            len,
+            width: line.width(),
+            map: crate::shaped::map_of_wrapped(&line, len),
+            runs: row_runs,
+            line,
+        });
+        orig += len;
+        broken_at += len + 1;
+    }
+    rows
+}
+
+/// Paint one row at `origin`, whose x is the row's LEFT edge.
+///
+/// A row with a single style goes through gpui's painter. A row with more than
+/// one can't: `paint_line` walks glyphs in visual order but pulls decorations
+/// from a forward-only iterator keyed on `glyph.index >= run_end`. In an RTL
+/// row the first glyph carries the HIGHEST index, so that first step consumes
+/// every run up to the last and the iterator never advances again — the whole
+/// row is painted in the colour of whichever run covers the logically-last
+/// character. That is why a link inside Persian text came out body-coloured.
+/// So each run is painted itself, seated at the visual box the row layout says
+/// it occupies.
+///
+/// ponytail: a run is shaped in isolation, so cursive joining across a style
+/// boundary is lost — visible only if a style starts INSIDE an Arabic word
+/// (`**می**گیرد`), since joining never crosses the spaces styles normally break
+/// at. Fixing it properly needs per-glyph colour, which gpui doesn't expose.
+pub fn paint_row(
+    row: &Row,
+    origin: Point<Pixels>,
+    line_height: Pixels,
+    font_size: Pixels,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    if row.runs.len() < 2 {
+        let _ = row
+            .line
+            .paint(origin, line_height, TextAlign::Left, None, window, cx);
+        return;
+    }
+    let text_system = window.text_system().clone();
+    for (range, run) in &row.runs {
+        let Some(&(x0, _)) = row.map.rects_for_range(range.clone()).first() else {
+            continue;
+        };
+        let shaped = text_system.shape_line(
+            SharedString::from(row.line.text[range.clone()].to_string()),
+            font_size,
+            std::slice::from_ref(run),
+            None,
+        );
+        let _ = shaped.paint(
+            Point {
+                x: origin.x + px(x0),
+                y: origin.y,
+            },
+            line_height,
+            TextAlign::Left,
+            None,
+            window,
+            cx,
+        );
+    }
 }
 
 /// A handle onto the last layout, for hosts that need to map between a point on
@@ -314,6 +434,41 @@ impl RtlLayout {
         } else {
             Ok(offset)
         }
+    }
+
+    /// Every window-space box logical `range` occupies, one per visual run per
+    /// row — a link wrapped across two rows gives two, and a range split by a
+    /// direction change inside a row gives one per piece.
+    pub fn rects_for_range(&self, range: Range<usize>) -> Vec<Bounds<Pixels>> {
+        let state = self.0.borrow();
+        let Some(laid) = state.as_ref() else {
+            return Vec::new();
+        };
+        let Some(bounds) = laid.bounds else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for (row_ix, row) in laid.rows.iter().enumerate() {
+            let row_end = row.start + row.len;
+            if range.end <= row.start || range.start >= row_end {
+                continue;
+            }
+            let local = range.start.max(row.start) - row.start..range.end.min(row_end) - row.start;
+            let row_left = bounds.origin.x + bounds.size.width - row.width;
+            for (x0, x1) in row.map.rects_for_range(local) {
+                out.push(Bounds::new(
+                    Point {
+                        x: row_left + px(x0),
+                        y: bounds.origin.y + laid.line_height * row_ix,
+                    },
+                    Size {
+                        width: px(x1 - x0),
+                        height: laid.line_height,
+                    },
+                ));
+            }
+        }
+        out
     }
 
     /// Top-left corner of the visual box that logical `range` occupies.
@@ -416,7 +571,7 @@ impl IntoElement for RtlText {
 
 impl Element for RtlText {
     type RequestLayoutState = ();
-    type PrepaintState = Option<Hitbox>;
+    type PrepaintState = Vec<Hitbox>;
 
     fn id(&self) -> Option<ElementId> {
         None
@@ -458,57 +613,17 @@ impl Element for RtlText {
                     return laid.size;
                 }
 
-                // Break in LOGICAL order, at word boundaries we pick ourselves.
-                //
-                // gpui's `LineWrapper` walks the text (so its offsets ARE
-                // logical, which is why this looked like the obvious tool), but
-                // its `is_word_char` covers Latin, Cyrillic, Vietnamese and
-                // Bengali — not Arabic. Persian therefore takes its "CJK may
-                // not be space separated" branch, which makes every character a
-                // break candidate and splits words down the middle. Arabic
-                // script IS space-separated, so we measure words instead.
-                let breaks: Vec<usize> = match wrap_width {
-                    Some(w) => wrap_at_words(&text, &runs, w, font_size, window),
-                    None => Vec::new(),
-                };
-                let (broken, broken_runs) = insert_breaks(&text, &runs, &breaks);
+                let rows = layout_rows(&text, &runs, wrap_width, font_size, window);
 
-                // Each line now fits, so shaping with no wrap width leaves the
-                // rows exactly where we put them — and each is reordered on
-                // its own, which is the whole point.
-                let lines = window
-                    .text_system()
-                    .shape_text(broken, font_size, &broken_runs, None, None)
-                    .map(|l| l.into_iter().collect::<Vec<_>>())
-                    .unwrap_or_default();
-
-                // Walk the rows back onto the ORIGINAL text. `shape_text` hands
-                // each line its own text and glyph indices relative to it, and
-                // the injected `\n`s exist only in the string we built — so a
-                // row starting at `orig` in the source is `orig + rel` here.
-                let mut rows = Vec::with_capacity(lines.len());
-                let mut orig = 0usize;
-                for line in &lines {
-                    let len = line.text.len();
-                    rows.push(Row {
-                        start: orig,
-                        len,
-                        width: line.width(),
-                        map: crate::shaped::map_of_wrapped(line, len),
-                    });
-                    // +1 for the break we injected, which the source lacks.
-                    orig += len + 1;
-                }
-
-                let height = line_height * lines.len().max(1);
-                let widest = lines.iter().map(|l| l.width()).fold(px(0.), Pixels::max);
+                let height = line_height * rows.len().max(1);
+                let widest = rows.iter().map(|r| r.width).fold(px(0.), Pixels::max);
                 let size = Size {
                     width: wrap_width.unwrap_or(widest),
                     height,
                 };
                 let bounds = state.borrow().as_ref().and_then(|l| l.bounds);
                 *state.borrow_mut() = Some(Laid {
-                    lines,
+                    font_size,
                     rows,
                     line_height,
                     wrap_width,
@@ -529,11 +644,24 @@ impl Element for RtlText {
         _request_layout: &mut (),
         window: &mut Window,
         _cx: &mut App,
-    ) -> Option<Hitbox> {
-        // Only paragraphs with links need one; plain prose shouldn't pay for a
-        // hitbox it will never consult.
-        (!self.pointer_ranges.is_empty())
-            .then(|| window.insert_hitbox(bounds, HitboxBehavior::Normal))
+    ) -> Vec<Hitbox> {
+        // Record where we landed here rather than in paint: hit-testing (and
+        // the hitboxes just below) need it, and prepaint is the first phase
+        // that knows.
+        if let Some(laid) = self.layout.0.borrow_mut().as_mut() {
+            laid.bounds = Some(bounds);
+        }
+        // One hitbox per link box, rather than gpui's one-per-element plus a
+        // paint-time "is the mouse over a link?" test. That test only re-runs
+        // when something else repaints the frame, so the cursor lagged or never
+        // changed at all; a hitbox is re-tested by the window on every mouse
+        // move, and it is exact — the hand appears over the link's glyphs and
+        // nowhere else.
+        self.pointer_ranges
+            .iter()
+            .flat_map(|range| self.layout.rects_for_range(range.clone()))
+            .map(|rect| window.insert_hitbox(rect, HitboxBehavior::Normal))
+            .collect()
     }
 
     fn paint(
@@ -542,44 +670,35 @@ impl Element for RtlText {
         _inspector_id: Option<&InspectorElementId>,
         bounds: Bounds<Pixels>,
         _request_layout: &mut (),
-        hitbox: &mut Option<Hitbox>,
+        hitboxes: &mut Vec<Hitbox>,
         window: &mut Window,
         cx: &mut App,
     ) {
-        let mut state = self.layout.0.borrow_mut();
-        let Some(laid) = state.as_mut() else {
+        // The hand over each link box. Registered unconditionally: the window
+        // decides which (if any) is hovered when it applies the cursor, so this
+        // doesn't depend on a repaint happening as the mouse moves.
+        for hitbox in hitboxes.iter() {
+            window.set_cursor_style(gpui::CursorStyle::PointingHand, hitbox);
+        }
+
+        let state = self.layout.0.borrow();
+        let Some(laid) = state.as_ref() else {
             return;
         };
-        // Hit-testing happens in window space, so the mapping is only valid
-        // once we know where the element actually landed.
-        laid.bounds = Some(bounds);
         // Top-to-bottom in the order we broke them: logical order. Each row is
-        // right-aligned across the full width, which is where an RTL reader
-        // starts — gpui's own `TextAlign` handles the within-row placement.
-        for (i, line) in laid.lines.iter().enumerate() {
-            let origin = Point {
-                x: bounds.origin.x,
-                y: bounds.origin.y + laid.line_height * i,
-            };
-            let _ = line.paint(
-                origin,
+        // right-aligned, which is where an RTL reader starts.
+        for (i, row) in laid.rows.iter().enumerate() {
+            paint_row(
+                row,
+                Point {
+                    x: bounds.origin.x + bounds.size.width - row.width,
+                    y: bounds.origin.y + laid.line_height * i,
+                },
                 laid.line_height,
-                TextAlign::Right,
-                Some(bounds),
+                laid.font_size,
                 window,
                 cx,
             );
-        }
-        drop(state);
-
-        // Hovering a link shows the hand, same as `InteractiveText` gives LTR
-        // text — resolved through OUR mapping, so it lands on the right words
-        // in a reordered line.
-        if let Some(hitbox) = hitbox
-            && let Ok(ix) = self.layout.index_for_position(window.mouse_position())
-            && self.pointer_ranges.iter().any(|r| r.contains(&ix))
-        {
-            window.set_cursor_style(gpui::CursorStyle::PointingHand, hitbox);
         }
     }
 }

--- a/crates/gpui-bidi/src/paragraph.rs
+++ b/crates/gpui-bidi/src/paragraph.rs
@@ -32,10 +32,12 @@ use std::cell::RefCell;
 use std::ops::Range;
 use std::rc::Rc;
 
+use crate::VisualMap;
+
 use gpui::{
-    App, AvailableSpace, Bounds, Element, ElementId, GlobalElementId, HighlightStyle,
-    InspectorElementId, IntoElement, LayoutId, Pixels, Point, SharedString, Size, TextAlign,
-    TextRun, TextStyle, Window, WrappedLine, px,
+    App, AvailableSpace, Bounds, Element, ElementId, GlobalElementId, HighlightStyle, Hitbox,
+    HitboxBehavior, InspectorElementId, IntoElement, LayoutId, Pixels, Point, SharedString, Size,
+    TextAlign, TextRun, TextStyle, Window, WrappedLine, px,
 };
 
 /// Split `text` into lines at `breaks` (logical byte offsets, ascending) by
@@ -205,7 +207,8 @@ fn wrap_at_words(
 pub struct RtlText {
     text: SharedString,
     highlights: Vec<(Range<usize>, HighlightStyle)>,
-    state: Rc<RefCell<Option<Laid>>>,
+    pointer_ranges: Vec<Range<usize>>,
+    layout: RtlLayout,
 }
 
 /// Expand `highlights` into runs covering all of `text`, the way `StyledText`
@@ -242,9 +245,128 @@ fn runs_from_highlights(
 /// What the measure pass worked out, reused by paint.
 struct Laid {
     lines: Vec<WrappedLine>,
+    /// Per line, in the same order: where it starts in the ORIGINAL text (the
+    /// injected `\n`s don't exist there) and how to read its glyphs.
+    rows: Vec<Row>,
     line_height: Pixels,
     wrap_width: Option<Pixels>,
     size: Size<Pixels>,
+    /// Where the element was last painted — hit-testing is in window space, so
+    /// there is nothing to map against until it has been on screen once.
+    bounds: Option<Bounds<Pixels>>,
+}
+
+/// One painted row: its span in the original text, plus the visual map that
+/// turns a logical offset inside it into an x and back.
+struct Row {
+    /// Byte offset in the ORIGINAL text where this row starts.
+    start: usize,
+    /// Byte length of the row's own text.
+    len: usize,
+    width: Pixels,
+    map: VisualMap,
+}
+
+/// A handle onto the last layout, for hosts that need to map between a point on
+/// screen and an offset in the text — link hit-testing, click-to-caret, and
+/// positioning an inline formula over its spacer.
+///
+/// Mirrors `StyledText::layout()`: cheap to clone, empty until first paint.
+#[derive(Clone, Default)]
+pub struct RtlLayout(Rc<RefCell<Option<Laid>>>);
+
+impl RtlLayout {
+    /// Height of one row, or zero before the first layout.
+    pub fn line_height(&self) -> Pixels {
+        self.0.borrow().as_ref().map_or(px(0.), |l| l.line_height)
+    }
+
+    /// The logical byte offset under `position`.
+    ///
+    /// `Ok` when the point is inside the painted text, `Err` with the nearest
+    /// offset when it is outside — the same contract as gpui's
+    /// `TextLayout::index_for_position`, so callers can treat them alike.
+    pub fn index_for_position(&self, position: Point<Pixels>) -> Result<usize, usize> {
+        let state = self.0.borrow();
+        let Some(laid) = state.as_ref() else {
+            return Err(0);
+        };
+        let Some(bounds) = laid.bounds else {
+            return Err(0);
+        };
+        if laid.rows.is_empty() {
+            return Err(0);
+        }
+
+        let rel_y = position.y - bounds.origin.y;
+        let row_f = f32::from(rel_y) / f32::from(laid.line_height).max(1.0);
+        let outside = row_f < 0.0 || row_f >= laid.rows.len() as f32;
+        let row_ix = (row_f.floor().max(0.0) as usize).min(laid.rows.len() - 1);
+        let row = &laid.rows[row_ix];
+
+        // Rows are right-aligned across the full width (see `paint`), so the
+        // row's own coordinate space starts at its left edge, not the element's.
+        let row_left = bounds.origin.x + bounds.size.width - row.width;
+        let local = f32::from(position.x - row_left);
+        let offset = row.start + row.map.index_for_x(local);
+        if outside || position.x < row_left || position.x > bounds.origin.x + bounds.size.width {
+            Err(offset)
+        } else {
+            Ok(offset)
+        }
+    }
+
+    /// Top-left corner of the visual box that logical `range` occupies.
+    ///
+    /// A logical range is one contiguous run of text but not necessarily one
+    /// contiguous box — in mixed text it can be split across the line — so the
+    /// leftmost edge of all its pieces is what's returned. That is where an
+    /// inline raster (a formula, an image) sits over the spacer it reserved:
+    /// anchoring to `range.start` would be the RIGHT edge in an RTL line and
+    /// would paint the raster over the neighbouring words.
+    pub fn left_edge_of(&self, range: Range<usize>) -> Option<Point<Pixels>> {
+        let state = self.0.borrow();
+        let laid = state.as_ref()?;
+        let bounds = laid.bounds?;
+        let (row_ix, row) = laid
+            .rows
+            .iter()
+            .enumerate()
+            .find(|(_, r)| range.start >= r.start && range.start <= r.start + r.len)?;
+        let local = range.start.saturating_sub(row.start)..range.end.saturating_sub(row.start);
+        let left = row
+            .map
+            .rects_for_range(local)
+            .into_iter()
+            .map(|(x0, _)| x0)
+            .fold(f32::INFINITY, f32::min);
+        if !left.is_finite() {
+            return None;
+        }
+        let row_left = bounds.origin.x + bounds.size.width - row.width;
+        Some(Point {
+            x: row_left + px(left),
+            y: bounds.origin.y + laid.line_height * row_ix,
+        })
+    }
+
+    /// Where the glyph at logical `offset` starts, in window space. `None`
+    /// before the first paint, or if the offset is past the end of the text.
+    pub fn position_for_index(&self, offset: usize) -> Option<Point<Pixels>> {
+        let state = self.0.borrow();
+        let laid = state.as_ref()?;
+        let bounds = laid.bounds?;
+        let (row_ix, row) = laid
+            .rows
+            .iter()
+            .enumerate()
+            .find(|(_, r)| offset >= r.start && offset <= r.start + r.len)?;
+        let row_left = bounds.origin.x + bounds.size.width - row.width;
+        Some(Point {
+            x: row_left + px(row.map.x_for_index(offset - row.start)),
+            y: bounds.origin.y + laid.line_height * row_ix,
+        })
+    }
 }
 
 impl RtlText {
@@ -252,8 +374,26 @@ impl RtlText {
         Self {
             text: text.into(),
             highlights: Vec::new(),
-            state: Rc::new(RefCell::new(None)),
+            pointer_ranges: Vec::new(),
+            layout: RtlLayout::default(),
         }
+    }
+
+    /// Ranges that should show the pointing-hand cursor on hover — links.
+    ///
+    /// `InteractiveText` does this for LTR text, but it hit-tests through
+    /// gpui's layout, which is the thing that's wrong for an RTL line. Same
+    /// approach as gpui's, though: one hitbox for the element, and the hover
+    /// test runs at paint time against the mouse's current position.
+    pub fn with_pointer_ranges(mut self, ranges: Vec<Range<usize>>) -> Self {
+        self.pointer_ranges = ranges;
+        self
+    }
+
+    /// The handle hosts hit-test through — clone it before the element is
+    /// consumed by the tree, exactly as `StyledText::layout()` is used.
+    pub fn layout(&self) -> &RtlLayout {
+        &self.layout
     }
 
     /// Styled ranges, exactly as `StyledText::with_highlights` takes them:
@@ -276,7 +416,7 @@ impl IntoElement for RtlText {
 
 impl Element for RtlText {
     type RequestLayoutState = ();
-    type PrepaintState = ();
+    type PrepaintState = Option<Hitbox>;
 
     fn id(&self) -> Option<ElementId> {
         None
@@ -302,7 +442,7 @@ impl Element for RtlText {
         );
         let text = self.text.clone();
         let runs = runs_from_highlights(&text, &text_style, &self.highlights);
-        let state = self.state.clone();
+        let state = self.layout.0.clone();
 
         let id = window.request_measured_layout(
             Default::default(),
@@ -342,17 +482,38 @@ impl Element for RtlText {
                     .map(|l| l.into_iter().collect::<Vec<_>>())
                     .unwrap_or_default();
 
+                // Walk the rows back onto the ORIGINAL text. `shape_text` hands
+                // each line its own text and glyph indices relative to it, and
+                // the injected `\n`s exist only in the string we built — so a
+                // row starting at `orig` in the source is `orig + rel` here.
+                let mut rows = Vec::with_capacity(lines.len());
+                let mut orig = 0usize;
+                for line in &lines {
+                    let len = line.text.len();
+                    rows.push(Row {
+                        start: orig,
+                        len,
+                        width: line.width(),
+                        map: crate::shaped::map_of_wrapped(line, len),
+                    });
+                    // +1 for the break we injected, which the source lacks.
+                    orig += len + 1;
+                }
+
                 let height = line_height * lines.len().max(1);
                 let widest = lines.iter().map(|l| l.width()).fold(px(0.), Pixels::max);
                 let size = Size {
                     width: wrap_width.unwrap_or(widest),
                     height,
                 };
+                let bounds = state.borrow().as_ref().and_then(|l| l.bounds);
                 *state.borrow_mut() = Some(Laid {
                     lines,
+                    rows,
                     line_height,
                     wrap_width,
                     size,
+                    bounds,
                 });
                 size
             },
@@ -364,11 +525,15 @@ impl Element for RtlText {
         &mut self,
         _id: Option<&GlobalElementId>,
         _inspector_id: Option<&InspectorElementId>,
-        _bounds: Bounds<Pixels>,
+        bounds: Bounds<Pixels>,
         _request_layout: &mut (),
-        _window: &mut Window,
+        window: &mut Window,
         _cx: &mut App,
-    ) {
+    ) -> Option<Hitbox> {
+        // Only paragraphs with links need one; plain prose shouldn't pay for a
+        // hitbox it will never consult.
+        (!self.pointer_ranges.is_empty())
+            .then(|| window.insert_hitbox(bounds, HitboxBehavior::Normal))
     }
 
     fn paint(
@@ -377,14 +542,17 @@ impl Element for RtlText {
         _inspector_id: Option<&InspectorElementId>,
         bounds: Bounds<Pixels>,
         _request_layout: &mut (),
-        _prepaint: &mut (),
+        hitbox: &mut Option<Hitbox>,
         window: &mut Window,
         cx: &mut App,
     ) {
-        let state = self.state.borrow();
-        let Some(laid) = state.as_ref() else {
+        let mut state = self.layout.0.borrow_mut();
+        let Some(laid) = state.as_mut() else {
             return;
         };
+        // Hit-testing happens in window space, so the mapping is only valid
+        // once we know where the element actually landed.
+        laid.bounds = Some(bounds);
         // Top-to-bottom in the order we broke them: logical order. Each row is
         // right-aligned across the full width, which is where an RTL reader
         // starts — gpui's own `TextAlign` handles the within-row placement.
@@ -401,6 +569,17 @@ impl Element for RtlText {
                 window,
                 cx,
             );
+        }
+        drop(state);
+
+        // Hovering a link shows the hand, same as `InteractiveText` gives LTR
+        // text — resolved through OUR mapping, so it lands on the right words
+        // in a reordered line.
+        if let Some(hitbox) = hitbox
+            && let Ok(ix) = self.layout.index_for_position(window.mouse_position())
+            && self.pointer_ranges.iter().any(|r| r.contains(&ix))
+        {
+            window.set_cursor_style(gpui::CursorStyle::PointingHand, hitbox);
         }
     }
 }
@@ -451,6 +630,116 @@ mod tests {
         let (out, runs) = insert_breaks(text, &[run(5)], &[0, 5, 2, 2]);
         assert_eq!(out.as_ref(), "he\nllo");
         assert_eq!(runs.iter().map(|r| r.len).sum::<usize>(), out.len());
+    }
+
+    /// Walk `runs` over `broken` exactly as `TextSystem::shape_text` does —
+    /// per line, then consuming ONE byte of the run at the front for the `\n`
+    /// it skips — and report the colour landing on each byte. This is the
+    /// contract `insert_breaks` has to satisfy: get the newline's owner wrong
+    /// and every colour after the first break slides.
+    fn colours_per_byte(broken: &str, runs: &[TextRun]) -> Vec<Hsla> {
+        let mut queue: Vec<TextRun> = runs.to_vec();
+        let mut out = Vec::new();
+        let mut q = 0usize;
+        for (i, line) in broken.split('\n').enumerate() {
+            if i > 0 {
+                // The `\n` itself: shape_text charges it to the front run.
+                if let Some(run) = queue.get_mut(q) {
+                    run.len -= 1;
+                    if run.len == 0 {
+                        q += 1;
+                    }
+                }
+                out.push(Hsla::default()); // placeholder for the newline byte
+            }
+            let mut taken = 0usize;
+            while taken < line.len() {
+                let Some(run) = queue.get_mut(q) else {
+                    panic!(
+                        "runs ran out with {} bytes of line left",
+                        line.len() - taken
+                    );
+                };
+                let take = (line.len() - taken).min(run.len);
+                for _ in 0..take {
+                    out.push(run.color);
+                }
+                run.len -= take;
+                if run.len == 0 {
+                    q += 1;
+                }
+                taken += take;
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn a_break_does_not_slide_the_colours_after_it() {
+        let text = "plain LINK plain";
+        let blue = Hsla {
+            h: 0.6,
+            s: 1.0,
+            l: 0.5,
+            a: 1.0,
+        };
+        let style = TextStyle::default();
+        let runs = runs_from_highlights(
+            text,
+            &style,
+            &[(
+                6..10,
+                HighlightStyle {
+                    color: Some(blue),
+                    ..Default::default()
+                },
+            )],
+        );
+        // Break BEFORE the link and again after it, so the link sits on its own
+        // row — the arrangement that shifts if the newline is charged wrong.
+        let (broken, broken_runs) = insert_breaks(text, &runs, &[6, 11]);
+        assert_eq!(broken.as_ref(), "plain \nLINK \nplain");
+        let colours = colours_per_byte(&broken, &broken_runs);
+        assert_eq!(colours.len(), broken.len());
+        let link_at = broken.find("LINK").unwrap();
+        for (i, c) in colours.iter().enumerate() {
+            let in_link = (link_at..link_at + 4).contains(&i);
+            assert_eq!(
+                *c == blue,
+                in_link,
+                "byte {i} ({:?}) coloured wrong",
+                &broken[i..(i + 1).min(broken.len())]
+            );
+        }
+    }
+
+    #[test]
+    fn highlighted_ranges_keep_their_colour_and_still_cover_the_text() {
+        // A link's colour reaches the shaper through these runs, so a gap or a
+        // dropped range shows up as unstyled text on screen.
+        let text = "before LINK after";
+        let blue = Hsla {
+            h: 0.6,
+            s: 1.0,
+            l: 0.5,
+            a: 1.0,
+        };
+        let style = TextStyle::default();
+        let runs = runs_from_highlights(
+            text,
+            &style,
+            &[(
+                7..11,
+                HighlightStyle {
+                    color: Some(blue),
+                    ..Default::default()
+                },
+            )],
+        );
+        assert_eq!(runs.iter().map(|r| r.len).sum::<usize>(), text.len());
+        let coloured: Vec<_> = runs.iter().filter(|r| r.color == blue).collect();
+        assert_eq!(coloured.len(), 1, "exactly the highlighted range is blue");
+        assert_eq!(coloured[0].len, 4, "and it covers LINK, nothing more");
     }
 
     #[test]

--- a/crates/gpui-bidi/src/paragraph.rs
+++ b/crates/gpui-bidi/src/paragraph.rs
@@ -206,6 +206,7 @@ fn wrap_at_words(
 /// interactive-text machinery.
 pub struct RtlText {
     text: SharedString,
+    base_rtl: bool,
     highlights: Vec<(Range<usize>, HighlightStyle)>,
     pointer_ranges: Vec<Range<usize>>,
     layout: RtlLayout,
@@ -244,6 +245,9 @@ fn runs_from_highlights(
 
 /// What the measure pass worked out, reused by paint.
 struct Laid {
+    /// Does the paragraph READ right-to-left? A left-to-right one can still
+    /// contain an RTL phrase and need all of this mapping.
+    base_rtl: bool,
     /// The rows, in reading order: where each starts in the ORIGINAL text (the
     /// injected `\n`s don't exist there) and how to read its glyphs.
     rows: Vec<Row>,
@@ -346,13 +350,12 @@ pub fn layout_rows(
 /// every run up to the last and the iterator never advances again — the whole
 /// row is painted in the colour of whichever run covers the logically-last
 /// character. That is why a link inside Persian text came out body-coloured.
-/// So each run is painted itself, seated at the visual box the row layout says
-/// it occupies.
 ///
-/// ponytail: a run is shaped in isolation, so cursive joining across a style
-/// boundary is lost — visible only if a style starts INSIDE an Arabic word
-/// (`**می**گیرد`), since joining never crosses the spaces styles normally break
-/// at. Fixing it properly needs per-glyph colour, which gpui doesn't expose.
+/// So the row is painted once per style, each pass coloured uniformly for that
+/// style (making the collapse harmless) and clipped to the boxes that style
+/// occupies. The whole row is shaped every pass, with its real fonts — cursive
+/// joining and kerning survive a style boundary INSIDE a word (`**می**گیرد`),
+/// which shaping each run separately would break.
 pub fn paint_row(
     row: &Row,
     origin: Point<Pixels>,
@@ -361,6 +364,11 @@ pub fn paint_row(
     cx: &mut App,
 ) {
     if row.runs.len() < 2 {
+        // Backgrounds (the inline-code tint) are a separate pass from the
+        // glyphs — `paint` alone would drop them.
+        let _ = row
+            .line
+            .paint_background(origin, line_height, TextAlign::Left, None, window, cx);
         let _ = row
             .line
             .paint(origin, line_height, TextAlign::Left, None, window, cx);
@@ -414,9 +422,25 @@ pub fn paint_row(
             // scene layer for z-order and clips nothing, so every pass painted
             // the whole row and the overdraw showed up as faux-bold text.
             window.with_content_mask(Some(ContentMask { bounds: clip }), |window| {
+                let _ =
+                    shaped.paint_background(origin, line_height, TextAlign::Left, None, window, cx);
                 let _ = shaped.paint(origin, line_height, TextAlign::Left, None, window, cx);
             });
         }
+    }
+}
+
+/// Where row `row` starts, in window space.
+///
+/// An RTL paragraph is right-aligned, so each row hangs off the right edge; a
+/// left-to-right one containing an RTL phrase still starts at the left. Every
+/// lookup and the paint go through this, or the caret would sit somewhere the
+/// glyphs are not.
+fn row_left(laid: &Laid, bounds: Bounds<Pixels>, row: &Row) -> Pixels {
+    if laid.base_rtl {
+        bounds.origin.x + bounds.size.width - row.width
+    } else {
+        bounds.origin.x
     }
 }
 
@@ -459,7 +483,7 @@ impl RtlLayout {
 
         // Rows are right-aligned across the full width (see `paint`), so the
         // row's own coordinate space starts at its left edge, not the element's.
-        let row_left = bounds.origin.x + bounds.size.width - row.width;
+        let row_left = row_left(laid, bounds, row);
         let local = f32::from(position.x - row_left);
         let offset = row.start + row.map.index_for_x(local);
         if outside || position.x < row_left || position.x > bounds.origin.x + bounds.size.width {
@@ -487,7 +511,7 @@ impl RtlLayout {
                 continue;
             }
             let local = range.start.max(row.start) - row.start..range.end.min(row_end) - row.start;
-            let row_left = bounds.origin.x + bounds.size.width - row.width;
+            let row_left = row_left(laid, bounds, row);
             for (x0, x1) in row.map.rects_for_range(local) {
                 out.push(Bounds::new(
                     Point {
@@ -531,7 +555,7 @@ impl RtlLayout {
         if !left.is_finite() {
             return None;
         }
-        let row_left = bounds.origin.x + bounds.size.width - row.width;
+        let row_left = row_left(laid, bounds, row);
         Some(Point {
             x: row_left + px(left),
             y: bounds.origin.y + laid.line_height * row_ix,
@@ -549,7 +573,7 @@ impl RtlLayout {
             .iter()
             .enumerate()
             .find(|(_, r)| offset >= r.start && offset <= r.start + r.len)?;
-        let row_left = bounds.origin.x + bounds.size.width - row.width;
+        let row_left = row_left(laid, bounds, row);
         Some(Point {
             x: row_left + px(row.map.x_for_index(offset - row.start)),
             y: bounds.origin.y + laid.line_height * row_ix,
@@ -561,10 +585,20 @@ impl RtlText {
     pub fn new(text: impl Into<SharedString>) -> Self {
         Self {
             text: text.into(),
+            base_rtl: true,
             highlights: Vec::new(),
             pointer_ranges: Vec::new(),
             layout: RtlLayout::default(),
         }
+    }
+
+    /// Does the paragraph read right-to-left (so it right-aligns)? Default
+    /// `true`. Pass `false` for a left-to-right paragraph that merely CONTAINS
+    /// right-to-left text: it still needs the index↔x mapping, or the caret
+    /// misplaces inside that phrase, but it must stay left-aligned.
+    pub fn with_base_rtl(mut self, rtl: bool) -> Self {
+        self.base_rtl = rtl;
+        self
     }
 
     /// Ranges that should show the pointing-hand cursor on hover — links.
@@ -629,6 +663,7 @@ impl Element for RtlText {
                 .to_pixels(font_size.into(), window.rem_size()),
         );
         let text = self.text.clone();
+        let base_rtl = self.base_rtl;
         let runs = runs_from_highlights(&text, &text_style, &self.highlights);
         let state = self.layout.0.clone();
 
@@ -656,6 +691,7 @@ impl Element for RtlText {
                 };
                 let bounds = state.borrow().as_ref().and_then(|l| l.bounds);
                 *state.borrow_mut() = Some(Laid {
+                    base_rtl,
                     rows,
                     line_height,
                     wrap_width,
@@ -723,7 +759,7 @@ impl Element for RtlText {
             paint_row(
                 row,
                 Point {
-                    x: bounds.origin.x + bounds.size.width - row.width,
+                    x: row_left(laid, bounds, row),
                     y: bounds.origin.y + laid.line_height * i,
                 },
                 laid.line_height,

--- a/crates/gpui-bidi/src/paragraph.rs
+++ b/crates/gpui-bidi/src/paragraph.rs
@@ -244,7 +244,6 @@ fn runs_from_highlights(
 
 /// What the measure pass worked out, reused by paint.
 struct Laid {
-    font_size: Pixels,
     /// The rows, in reading order: where each starts in the ORIGINAL text (the
     /// injected `\n`s don't exist there) and how to read its glyphs.
     rows: Vec<Row>,
@@ -273,6 +272,11 @@ pub struct Row {
     pub runs: Vec<(Range<usize>, TextRun)>,
     /// The shaped row, ready to paint.
     pub line: WrappedLine,
+    /// The size it was shaped at. Carried so painting can re-shape a run
+    /// without the caller passing a size that might not be this row's — a
+    /// heading is not the body size, and getting that wrong is invisible until
+    /// a styled heading paints at the wrong scale.
+    pub font_size: Pixels,
 }
 
 /// Lay `text` out as right-to-left rows: break it in LOGICAL order at word
@@ -325,6 +329,7 @@ pub fn layout_rows(
             map: crate::shaped::map_of_wrapped(&line, len),
             runs: row_runs,
             line,
+            font_size,
         });
         orig += len;
         broken_at += len + 1;
@@ -352,7 +357,6 @@ pub fn paint_row(
     row: &Row,
     origin: Point<Pixels>,
     line_height: Pixels,
-    font_size: Pixels,
     window: &mut Window,
     cx: &mut App,
 ) {
@@ -367,12 +371,21 @@ pub fn paint_row(
         let Some(&(x0, _)) = row.map.rects_for_range(range.clone()).first() else {
             continue;
         };
-        let shaped = text_system.shape_line(
-            SharedString::from(row.line.text[range.clone()].to_string()),
-            font_size,
-            std::slice::from_ref(run),
-            None,
-        );
+        // Shaping a slice on its own loses the surrounding direction, and a run
+        // of neutrals — markdown's `[[`, `](`, `**` — then comes out in LTR
+        // order and unmirrored, so the brackets around a Latin link inside
+        // Persian rendered backwards. Re-assert the run's direction with an
+        // explicit embedding so the isolated shaping matches what the full row
+        // laid out.
+        let seg = &row.line.text[range.clone()];
+        let text = if row.map.is_rtl_range(range.clone()) {
+            SharedString::from(format!("\u{202b}{seg}\u{202c}"))
+        } else {
+            SharedString::from(seg.to_string())
+        };
+        let mut run = run.clone();
+        run.len = text.len();
+        let shaped = text_system.shape_line(text, row.font_size, std::slice::from_ref(&run), None);
         let _ = shaped.paint(
             Point {
                 x: origin.x + px(x0),
@@ -623,7 +636,6 @@ impl Element for RtlText {
                 };
                 let bounds = state.borrow().as_ref().and_then(|l| l.bounds);
                 *state.borrow_mut() = Some(Laid {
-                    font_size,
                     rows,
                     line_height,
                     wrap_width,
@@ -695,7 +707,6 @@ impl Element for RtlText {
                     y: bounds.origin.y + laid.line_height * i,
                 },
                 laid.line_height,
-                laid.font_size,
                 window,
                 cx,
             );

--- a/crates/gpui-bidi/src/paragraph.rs
+++ b/crates/gpui-bidi/src/paragraph.rs
@@ -35,9 +35,9 @@ use std::rc::Rc;
 use crate::VisualMap;
 
 use gpui::{
-    App, AvailableSpace, Bounds, Element, ElementId, GlobalElementId, HighlightStyle, Hitbox,
-    HitboxBehavior, InspectorElementId, IntoElement, LayoutId, Pixels, Point, SharedString, Size,
-    TextAlign, TextRun, TextStyle, Window, WrappedLine, px,
+    App, AvailableSpace, Bounds, ContentMask, Element, ElementId, GlobalElementId, HighlightStyle,
+    Hitbox, HitboxBehavior, InspectorElementId, IntoElement, LayoutId, Pixels, Point, SharedString,
+    Size, TextAlign, TextRun, TextStyle, Window, WrappedLine, px,
 };
 
 /// Split `text` into lines at `breaks` (logical byte offsets, ascending) by
@@ -366,37 +366,57 @@ pub fn paint_row(
             .paint(origin, line_height, TextAlign::Left, None, window, cx);
         return;
     }
+
+    // Paint the row once PER STYLE, each pass coloured uniformly for that style
+    // and CLIPPED to the boxes that style actually occupies.
+    //
+    // The uniform colour is what makes gpui's painter usable here at all: it
+    // walks glyphs in visual order but pulls decorations from a forward-only
+    // iterator keyed on `glyph.index >= run_end`, and in an RTL row the first
+    // glyph carries the HIGHEST index — so the iterator jumps to the last run
+    // and never advances, painting the whole row in one colour. If that colour
+    // is the one we want for this pass, the collapse stops mattering.
+    //
+    // Only the decoration differs between passes; fonts, weights and sizes stay
+    // the row's own, so every pass lays out exactly as the row did. Shaping each
+    // run on its OWN instead gives it a slightly different width than it has in
+    // context, and the pieces overlap and swallow the spaces between them.
     let text_system = window.text_system().clone();
-    for (range, run) in &row.runs {
-        let Some(&(x0, _)) = row.map.rects_for_range(range.clone()).first() else {
+    for (range, style) in &row.runs {
+        let rects = row.map.rects_for_range(range.clone());
+        if rects.is_empty() {
             continue;
-        };
-        // Shaping a slice on its own loses the surrounding direction, and a run
-        // of neutrals — markdown's `[[`, `](`, `**` — then comes out in LTR
-        // order and unmirrored, so the brackets around a Latin link inside
-        // Persian rendered backwards. Re-assert the run's direction with an
-        // explicit embedding so the isolated shaping matches what the full row
-        // laid out.
-        let seg = &row.line.text[range.clone()];
-        let text = if row.map.is_rtl_range(range.clone()) {
-            SharedString::from(format!("\u{202b}{seg}\u{202c}"))
-        } else {
-            SharedString::from(seg.to_string())
-        };
-        let mut run = run.clone();
-        run.len = text.len();
-        let shaped = text_system.shape_line(text, row.font_size, std::slice::from_ref(&run), None);
-        let _ = shaped.paint(
-            Point {
-                x: origin.x + px(x0),
-                y: origin.y,
-            },
-            line_height,
-            TextAlign::Left,
-            None,
-            window,
-            cx,
-        );
+        }
+        let uniform: Vec<TextRun> = row
+            .runs
+            .iter()
+            .map(|(_, r)| TextRun {
+                color: style.color,
+                background_color: style.background_color,
+                underline: style.underline,
+                strikethrough: style.strikethrough,
+                ..r.clone()
+            })
+            .collect();
+        let shaped = text_system.shape_line(row.line.text.clone(), row.font_size, &uniform, None);
+        for (x0, x1) in rects {
+            let clip = Bounds::from_corners(
+                Point {
+                    x: origin.x + px(x0),
+                    y: origin.y,
+                },
+                Point {
+                    x: origin.x + px(x1),
+                    y: origin.y + line_height,
+                },
+            );
+            // `with_content_mask`, not `paint_layer`: the latter pushes a
+            // scene layer for z-order and clips nothing, so every pass painted
+            // the whole row and the overdraw showed up as faux-bold text.
+            window.with_content_mask(Some(ContentMask { bounds: clip }), |window| {
+                let _ = shaped.paint(origin, line_height, TextAlign::Left, None, window, cx);
+            });
+        }
     }
 }
 

--- a/crates/gpui-bidi/src/shaped.rs
+++ b/crates/gpui-bidi/src/shaped.rs
@@ -1,0 +1,54 @@
+//! The gpui adapter: read a [`VisualMap`] out of a shaped line.
+//!
+//! Kept apart from the core deliberately — everything in the crate root works
+//! on plain numbers and is testable without a window, a GPU, or a font. Only
+//! this module needs gpui, and all it does is copy each glyph's logical index
+//! and laid-out x across.
+//!
+//! `ShapedLine` derefs to `LineLayout`, so `runs` is reachable even though the
+//! `layout` field itself is `pub(crate)` — which is what lets this work
+//! without forking gpui. Worth re-checking whenever the gpui pin moves.
+
+use gpui::{ShapedLine, WrappedLine};
+
+use crate::{Glyph, VisualMap};
+
+/// Build a map from a shaped line.
+///
+/// `len` is the byte length of the text that was shaped — the caret can sit
+/// one past the last glyph, and only the caller knows where that is.
+pub fn map_of(line: &ShapedLine, len: usize) -> VisualMap {
+    let glyphs = line
+        .runs
+        .iter()
+        .flat_map(|run| run.glyphs.iter())
+        .map(|g| Glyph {
+            index: g.index,
+            x: f32::from(g.position.x),
+        });
+    VisualMap::from_glyphs(glyphs, f32::from(line.width), len)
+}
+
+/// [`map_of`] for a wrapped line, over its **pre-wrap** layout.
+///
+/// A `WrappedLine` keeps one unwrapped glyph list plus the boundaries it was
+/// wrapped at, so the x values here are positions along the single long line,
+/// not within a visual row. That is the right input for a caller that resolves
+/// a row's glyph span itself (via `wrap_boundaries`); a caller that wants
+/// per-row coordinates must subtract the row's start x.
+///
+/// No per-row helper is offered yet: getting it right means reasoning about
+/// where a bidi run straddles a wrap boundary, and that belongs with the code
+/// that actually paints rows rather than being guessed at here.
+pub fn map_of_wrapped(line: &WrappedLine, len: usize) -> VisualMap {
+    let layout = &line.unwrapped_layout;
+    let glyphs = layout
+        .runs
+        .iter()
+        .flat_map(|run| run.glyphs.iter())
+        .map(|g| Glyph {
+            index: g.index,
+            x: f32::from(g.position.x),
+        });
+    VisualMap::from_glyphs(glyphs, f32::from(layout.width), len)
+}

--- a/crates/gpui-bidi/src/shaped.rs
+++ b/crates/gpui-bidi/src/shaped.rs
@@ -26,7 +26,7 @@ pub fn map_of(line: &ShapedLine, len: usize) -> VisualMap {
             index: g.index,
             x: f32::from(g.position.x),
         });
-    VisualMap::from_glyphs(glyphs, f32::from(line.width), len)
+    VisualMap::from_glyphs(glyphs, f32::from(line.width), len).with_levels(&line.text)
 }
 
 /// [`map_of`] for a wrapped line, over its **pre-wrap** layout.
@@ -50,5 +50,5 @@ pub fn map_of_wrapped(line: &WrappedLine, len: usize) -> VisualMap {
             index: g.index,
             x: f32::from(g.position.x),
         });
-    VisualMap::from_glyphs(glyphs, f32::from(layout.width), len)
+    VisualMap::from_glyphs(glyphs, f32::from(layout.width), len).with_levels(&line.text)
 }

--- a/crates/gpui-editor/Cargo.toml
+++ b/crates/gpui-editor/Cargo.toml
@@ -19,6 +19,11 @@ unicode-segmentation = "1"
 # (see AGENTS.md); rendering stays entirely this crate's own.
 gpui-markdown = { path = "../gpui-markdown", default-features = false }
 
+# Bidi index↔x mapping (#66). gpui's own `x_for_index` / `index_for_x` assume
+# byte index and x rise together, which is false for a right-to-left line — so
+# every caret/click lookup in this crate goes through `VisualMap` on RTL rows.
+gpui-bidi = { path = "../gpui-bidi" }
+
 # The standalone demo needs a platform backend to open a real window (the `gpui`
 # crate alone has no app entry point in this setup — it's split into
 # `gpui_platform`, same as the host app). Shared workspace spec, one graph.

--- a/crates/gpui-editor/README.md
+++ b/crates/gpui-editor/README.md
@@ -25,7 +25,14 @@ return contracts, edge cases, and the seat/commit protocols, lives in
   (coalesced), click + drag selection, double-click word / triple-click line.
   **Lists continue on Enter** (an empty item exits the list), and **bold /
   italic / inline-code** toggles (`cmd`/`ctrl`-`b`/`i`/`e`).
-- **Soft-wrap** with content-driven height.
+- **Soft-wrap** with content-driven height. A line containing right-to-left
+  text is instead broken in *logical* order and laid out row by row via
+  [`gpui-bidi`](../gpui-bidi/README.md) — gpui's own wrapping slices the
+  already-reordered glyph run, which reads bottom-to-top and splits words.
+- **Bidirectional text:** caret, selection, click hit-testing and visual arrow
+  movement work in Persian/Hebrew prose, table cells and mixed lines, including
+  a Latin word embedded in RTL. Direction comes from each line's *content*, so
+  markdown markers (`- [x]`, `> [!NOTE]`) don't decide it.
 - **Spell-check squiggles:** the host feeds in misspelled byte ranges
   (`Diagnostic`); a right-click menu offers replacements via a lazy provider.
 - **Live-preview Markdown ("WYSIWYG"):** with a `SyntaxStyle` installed, the

--- a/crates/gpui-editor/src/element.rs
+++ b/crates/gpui-editor/src/element.rs
@@ -472,17 +472,28 @@ impl Element for EditorElement {
         let rtl: Vec<Option<RtlRow>> = rtl_layout
             .into_iter()
             .enumerate()
-            .map(|(i, rows)| {
-                let rows = rows?;
+            .map(|(i, entry)| {
+                let (base_rtl, rows) = entry?;
                 let inset = row_inset(
                     backgrounds.get(i).copied().flatten(),
                     marks.get(i).copied().flatten(),
                 );
                 let shifts = rows
                     .iter()
-                    .map(|r| rtl_shift(bounds.size.width, inset, r.width))
+                    .map(|r| {
+                        if base_rtl {
+                            rtl_shift(bounds.size.width, inset, r.width)
+                        } else {
+                            // Reads left-to-right; it only needed the mapping.
+                            px(0.)
+                        }
+                    })
                     .collect();
-                Some(RtlRow { rows, shifts })
+                Some(RtlRow {
+                    rows,
+                    shifts,
+                    base_rtl,
+                })
             })
             .collect();
         // Row text origin, this frame: the row's inset plus its RTL shift.
@@ -3843,7 +3854,17 @@ fn shape_document(
                 last_strong_rtl = rtl;
                 rtl
             };
-            let rtl_rows = (bg.is_none() && widget.is_none() && table.is_none() && line_rtl)
+            // Lay out any line CONTAINING right-to-left text, not just one that
+            // reads that way: an English sentence quoting a Persian name still
+            // needs the mapping, or the caret misplaces inside that run. Such a
+            // line stays left-aligned (`line_rtl` drives the shift, this drives
+            // the mapping).
+            //
+            // ponytail: word breaking is space-based, so a line mixing RTL with
+            // unspaced CJK would wrap poorly. Lines without any RTL keep gpui's
+            // wrapping, so plain CJK is untouched.
+            let has_rtl = line_rtl || gpui_markdown::syntax::contains_rtl(line);
+            let rtl_rows = (bg.is_none() && widget.is_none() && table.is_none() && has_rtl)
                 .then(|| {
                     gpui_bidi::paragraph::layout_rows(&shaped_text, &runs, line_wrap, fs, window)
                 })
@@ -3855,7 +3876,7 @@ fn shape_document(
                 caches.line_heights.borrow_mut().insert(hk, (h, span));
             }
             out.wrap_rows.push(span);
-            out.rtl_rows.push(rtl_rows);
+            out.rtl_rows.push(rtl_rows.map(|rows| (line_rtl, rows)));
             out.wrapped.push(wl);
             out.heights.push(h);
             out.widgets.push(widget);

--- a/crates/gpui-editor/src/element.rs
+++ b/crates/gpui-editor/src/element.rs
@@ -362,6 +362,7 @@ impl Element for EditorElement {
             marks,
             inline_maths,
             wrap_rows,
+            rtl_rows: rtl_layout,
         } = if let Some(m) = memo {
             m.shaped
         } else if editor.content.is_empty() {
@@ -385,6 +386,8 @@ impl Element for EditorElement {
                 marks: vec![None; n],
                 inline_maths: vec![Vec::new(); n],
                 wrap_rows: rows,
+                // The placeholder is the host's own string; no RTL layout.
+                rtl_rows: (0..n).map(|_| None).collect(),
             }
         } else {
             shape_document(
@@ -462,44 +465,26 @@ impl Element for EditorElement {
         // rows qualify: a code block is LTR by convention, and a table/image
         // widget row paints its own geometry (flipping those is a follow-up).
         // An all-LTR document leaves every entry `None` and pays nothing.
-        let rtl: Vec<Option<RtlRow>> = {
-            // One split, not `line_end(i)` per row — that rebuilds the whole
-            // line-start table each call.
-            let src_lines: Vec<&str> = editor.content.split('\n').collect();
-            wrapped
-                .iter()
-                .enumerate()
-                .map(|(i, line)| {
-                    let plain = backgrounds.get(i).copied().flatten().is_none()
-                        && widgets.get(i).and_then(Option::as_ref).is_none()
-                        && tables.get(i).and_then(Option::as_ref).is_none();
-                    let src = src_lines.get(i).copied().unwrap_or("");
-                    if !plain || !gpui_markdown::syntax::base_direction(src).is_rtl() {
-                        return None;
-                    }
-                    // A `VisualMap`'s x's are positions along the single
-                    // *pre-wrap* line, so it only describes a row that IS one
-                    // visual row. Splitting one per wrap row means reasoning
-                    // about a bidi run straddling a boundary (gpui wraps in
-                    // visual order) — a follow-up, not a guess; until then a
-                    // wrapped RTL row is left exactly as it was, which also
-                    // keeps its gutter markers on the side its text is on.
-                    let map = line
-                        .wrap_boundaries()
-                        .is_empty()
-                        .then(|| gpui_bidi::shaped::map_of_wrapped(line, line.len()))
-                        .filter(gpui_bidi::VisualMap::is_bidi)?;
-                    let inset = row_inset(
-                        backgrounds.get(i).copied().flatten(),
-                        marks.get(i).copied().flatten(),
-                    );
-                    Some(RtlRow {
-                        shift: rtl_shift(bounds.size.width, inset, line.width()),
-                        map,
-                    })
-                })
-                .collect()
-        };
+        // The RTL layout computed while shaping (that is where the row COUNT
+        // had to be decided), turned into per-row right-align shifts. Rows are
+        // shifted individually: a short last row sits further right than a full
+        // one, which is what right-aligned text means.
+        let rtl: Vec<Option<RtlRow>> = rtl_layout
+            .into_iter()
+            .enumerate()
+            .map(|(i, rows)| {
+                let rows = rows?;
+                let inset = row_inset(
+                    backgrounds.get(i).copied().flatten(),
+                    marks.get(i).copied().flatten(),
+                );
+                let shifts = rows
+                    .iter()
+                    .map(|r| rtl_shift(bounds.size.width, inset, r.width))
+                    .collect();
+                Some(RtlRow { rows, shifts })
+            })
+            .collect();
         // Row text origin, this frame: the row's inset plus its RTL shift.
         // Fresh-data twin of `EditorState::row_origin_x` (the committed state
         // lags a frame — see `disp_col` below).
@@ -510,9 +495,10 @@ impl Element for EditorElement {
             ) + rtl
                 .get(row)
                 .and_then(Option::as_ref)
-                .map_or(px(0.), |r| r.shift)
+                .and_then(|r| r.shifts.first().copied())
+                .unwrap_or(px(0.))
         };
-        let bidi = |row: usize| rtl.get(row).and_then(Option::as_ref).map(|r| &r.map);
+        let bidi = |row: usize| rtl.get(row).and_then(Option::as_ref);
 
         // Corner-grip hitboxes for each inline image, in `widgets` order (matching
         // the order paint walks them) — hitboxes must be inserted during prepaint,
@@ -1225,6 +1211,39 @@ impl Element for EditorElement {
                             ),
                             color,
                         ));
+                    } else if let Some(r) = bidi(row) {
+                        // RTL, spanning wrap rows: the selection runs the other
+                        // way. It leaves the first row at its LEFT edge,
+                        // continues from the right on each following row, and
+                        // ends part-way across the last. Rows are banded to
+                        // their own extent, not the content width — a
+                        // right-aligned row doesn't span it.
+                        let row_of = |y: Pixels| {
+                            (f32::from(y) / f32::from(lh).max(1.0)).round().max(0.) as usize
+                        };
+                        let (ka, kb) = (row_of(pa.y), row_of(pb.y));
+                        let mut band = |k: usize, from: Option<Pixels>, to: Option<Pixels>| {
+                            let (l, rt) = r.row_extent(k);
+                            let (l, rt) = (l + inset, rt + inset);
+                            let (x0, x1) = (from.unwrap_or(l), to.unwrap_or(rt));
+                            if x1 > x0 {
+                                sels.push(fill(
+                                    Bounds::from_corners(
+                                        to_screen(top, point(x0, lh * k)),
+                                        to_screen(top, point(x1, lh * k + lh)),
+                                    ),
+                                    color,
+                                ));
+                            }
+                        };
+                        // The start is the row's RIGHT-hand portion: from the
+                        // row's left edge up to the caret x.
+                        band(ka, None, Some(pa.x));
+                        for k in (ka + 1)..kb.min(r.row_count()) {
+                            band(k, None, None);
+                        }
+                        // ...and the last row from the end x rightwards.
+                        band(kb, Some(pb.x), None);
                     } else {
                         // First wrap row: start x → right edge.
                         sels.push(fill(
@@ -1489,7 +1508,11 @@ impl Element for EditorElement {
             // every gutter decoration mirrors to the other side so the markers
             // sit where the text now starts — matching the reader.
             let rtl = prepaint.rtl.get(i).and_then(Option::as_ref);
-            let shift = rtl.map_or(px(0.), |r| r.shift);
+            // Row 0's shift: the gutter decorations mirror against the line as
+            // a whole, and the per-row shifts only move the text.
+            let shift = rtl
+                .and_then(|r| r.shifts.first().copied())
+                .unwrap_or(px(0.));
             let content_w = bounds.size.width;
             // Nesting guides for a list/task row: a thin vertical line at each
             // ancestor bullet's x, spanning this row (contiguous rows stack into a
@@ -1931,17 +1954,42 @@ impl Element for EditorElement {
                     prepaint.marks.get(i).copied().flatten(),
                 );
                 let text_origin = point(origin.x + inset + shift, origin.y);
-                // Run backgrounds (the inline-code highlight) paint separately from
-                // the glyphs — `paint` alone wouldn't show them.
-                let _ = line.paint_background(
-                    text_origin,
-                    *lh,
-                    gpui::TextAlign::Left,
-                    None,
-                    window,
-                    cx,
-                );
-                let _ = line.paint(text_origin, *lh, gpui::TextAlign::Left, None, window, cx);
+                if let Some(r) = rtl {
+                    // Our own rows, painted in reading order — gpui's wrapping
+                    // is not used for this line at all (#66). Each row is
+                    // right-aligned on its own, so a short last row sits
+                    // further right than a full one.
+                    //
+                    // ponytail: run backgrounds (the inline-code highlight) are
+                    // not painted here; `paint_row` draws glyphs only. An RTL
+                    // line with inline code loses that tint — add it when
+                    // someone writes `code` inside Persian prose.
+                    for (k, row) in r.rows.iter().enumerate() {
+                        gpui_bidi::paragraph::paint_row(
+                            row,
+                            point(
+                                origin.x + inset + r.shifts.get(k).copied().unwrap_or(px(0.)),
+                                origin.y + *lh * k,
+                            ),
+                            *lh,
+                            font_size,
+                            window,
+                            cx,
+                        );
+                    }
+                } else {
+                    // Run backgrounds (the inline-code highlight) paint separately from
+                    // the glyphs — `paint` alone wouldn't show them.
+                    let _ = line.paint_background(
+                        text_origin,
+                        *lh,
+                        gpui::TextAlign::Left,
+                        None,
+                        window,
+                        cx,
+                    );
+                    let _ = line.paint(text_origin, *lh, gpui::TextAlign::Left, None, window, cx);
+                }
                 // Inline `$…$` formulas: paint each typeset raster over its spacer, centered on
                 // the text row. `position_for_index` gives the spacer's x + wrap-row offset.
                 // Record each formula's window bounds for click-to-edit; the one being edited
@@ -2842,6 +2890,9 @@ fn shape_document(
     // Fenced-code-block tracking: collect a block's line indices (so its box can
     // be sized to its widest line + the first/last line marked for rounding) and
     // the running max line width.
+    // Direction of the last line that had a strong character, so blank lines
+    // between paragraphs inherit it (#66).
+    let mut last_strong_rtl = false;
     let mut code_block: Vec<usize> = Vec::new();
     let mut code_w = px(0.);
     // Token colors per code line (line index → in-line ranges), from the host
@@ -3753,13 +3804,39 @@ fn shape_document(
                 }
             };
             let line_w = wl.width();
+            // #66: an RTL line can't use gpui's wrapping. gpui slices the
+            // already-reordered glyph run by ascending x, so its rows come out
+            // in reverse reading order, and its break candidates come from an
+            // `is_word_char` that doesn't know Arabic — so words split down the
+            // middle. Lay the line out in LOGICAL order instead. This has to
+            // happen here, not later with the rest of the RTL geometry: our
+            // break points give a different row COUNT, and the row span and
+            // height are decided right here.
+            // A blank line has no strong character, so it has no direction of
+            // its own — it inherits the paragraph it sits in. Without this the
+            // caret jumps to the LEFT margin the moment you press Enter after a
+            // Persian paragraph, and a selection running through the blank line
+            // puts its marker on the wrong side.
+            let line_rtl = if line.trim().is_empty() {
+                last_strong_rtl
+            } else {
+                let rtl = gpui_markdown::syntax::base_direction(line).is_rtl();
+                last_strong_rtl = rtl;
+                rtl
+            };
+            let rtl_rows = (bg.is_none() && widget.is_none() && table.is_none() && line_rtl)
+                .then(|| {
+                    gpui_bidi::paragraph::layout_rows(&shaped_text, &runs, line_wrap, fs, window)
+                })
+                .filter(|rows| !rows.is_empty());
+            let span = rtl_rows
+                .as_ref()
+                .map_or(wl.wrap_boundaries().len() + 1, Vec::len);
             if let Some(hk) = plain_hkey {
-                caches
-                    .line_heights
-                    .borrow_mut()
-                    .insert(hk, (h, wl.wrap_boundaries().len() + 1));
+                caches.line_heights.borrow_mut().insert(hk, (h, span));
             }
-            out.wrap_rows.push(wl.wrap_boundaries().len() + 1);
+            out.wrap_rows.push(span);
+            out.rtl_rows.push(rtl_rows);
             out.wrapped.push(wl);
             out.heights.push(h);
             out.widgets.push(widget);

--- a/crates/gpui-editor/src/element.rs
+++ b/crates/gpui-editor/src/element.rs
@@ -1972,7 +1972,6 @@ impl Element for EditorElement {
                                 origin.y + *lh * k,
                             ),
                             *lh,
-                            font_size,
                             window,
                             cx,
                         );
@@ -1991,17 +1990,35 @@ impl Element for EditorElement {
                     let _ = line.paint(text_origin, *lh, gpui::TextAlign::Left, None, window, cx);
                 }
                 // Inline `$…$` formulas: paint each typeset raster over its spacer, centered on
-                // the text row. `position_for_index` gives the spacer's x + wrap-row offset.
-                // Record each formula's window bounds for click-to-edit; the one being edited
-                // shows the seated editor instead of its raster. (Deliberately NOT bidi-mapped:
-                // a raster needs its spacer's *left* edge, which on an RTL run is the caret x of
-                // the offset one past it — a formula inside RTL prose is a follow-up. It still
-                // rides the row's shift, so it stays with the text.)
+                // the text row. Record each formula's window bounds for click-to-edit; the one
+                // being edited shows the seated editor instead of its raster.
                 for im in prepaint.inline_maths.get(i).into_iter().flatten() {
-                    if let Some(p) = line.position_for_index(im.display_off, *lh) {
-                        let x = text_origin.x + p.x;
-                        // Center the formula in the (grown-to-fit) wrap row at p.y.
-                        let y = origin.y + p.y + (*lh - im.height) / 2.0;
+                    // The spacer's LEFT edge and which row it landed on. On an
+                    // RTL row `display_off` is its RIGHT edge — anchoring there
+                    // paints the formula over the words beside it and leaves
+                    // the reserved gap empty — so the row's map gives the
+                    // spacer's actual visual box instead.
+                    let seat = match rtl {
+                        Some(r) => {
+                            let (k, local) = r.row_of(im.display_off);
+                            r.rows.get(k).and_then(|rr| {
+                                let end = local + im.len;
+                                rr.map.rects_for_range(local..end).first().map(|&(x0, _)| {
+                                    (
+                                        inset + r.shifts.get(k).copied().unwrap_or(px(0.)) + px(x0),
+                                        *lh * k,
+                                    )
+                                })
+                            })
+                        }
+                        None => line
+                            .position_for_index(im.display_off, *lh)
+                            .map(|p| (inset + p.x, p.y)),
+                    };
+                    if let Some((x, row_y)) = seat {
+                        let x = origin.x + x;
+                        // Center the formula in the (grown-to-fit) wrap row.
+                        let y = origin.y + row_y + (*lh - im.height) / 2.0;
                         let b = Bounds::new(point(x, y), size(im.width, im.height));
                         inline_math_rects.push((im.source.clone(), im.latex.clone(), b));
                         if editing_inline.as_ref() != Some(&im.source) {
@@ -2520,6 +2537,7 @@ fn shape_inline_math(
         .zip(imgs)
         .map(|(p, (img, width, height, latex))| InlineMath {
             display_off: p.display_off,
+            len: p.len,
             // Absolute byte range in the document, for hit-test / seating / commit.
             source: line_start + p.source.start..line_start + p.source.end,
             latex,
@@ -2598,6 +2616,7 @@ fn shape_inline_images(
         .zip(imgs)
         .map(|(p, (img, width, height))| InlineMath {
             display_off: p.display_off,
+            len: p.len,
             source: line_start + p.source.start..line_start + p.source.end,
             latex: SharedString::default(), // empty = image, not a formula
             img,

--- a/crates/gpui-editor/src/element.rs
+++ b/crates/gpui-editor/src/element.rs
@@ -31,6 +31,9 @@ pub(crate) struct PrepaintState {
     maps: Vec<Option<std::rc::Rc<Vec<usize>>>>,
     /// Per-line gutter decoration (blockquote / list / checkbox).
     marks: Vec<Option<LineMark>>,
+    /// Per-line right-to-left geometry (#66); `None` on LTR rows. Committed to
+    /// [`EditorState::rtl_rows`] in paint, like `line_insets`.
+    rtl: Vec<Option<RtlRow>>,
     /// Per-line inline `$…$` formulas (image + display offset + source range), painted over
     /// their spacers in the shaped text.
     inline_maths: Vec<Vec<InlineMath>>,
@@ -452,6 +455,65 @@ impl Element for EditorElement {
             y += *lh * wrap_rows[idx] as f32 + bot_pad;
         }
 
+        // Right-to-left rows (#66): direction from the SOURCE line — the same
+        // `base_direction` the reader uses, so the two views can never disagree
+        // about which lines are RTL (markdown markers, digits and whitespace
+        // are neutral under UAX #9, so `- سلام` reads RTL). Only plain text
+        // rows qualify: a code block is LTR by convention, and a table/image
+        // widget row paints its own geometry (flipping those is a follow-up).
+        // An all-LTR document leaves every entry `None` and pays nothing.
+        let rtl: Vec<Option<RtlRow>> = {
+            // One split, not `line_end(i)` per row — that rebuilds the whole
+            // line-start table each call.
+            let src_lines: Vec<&str> = editor.content.split('\n').collect();
+            wrapped
+                .iter()
+                .enumerate()
+                .map(|(i, line)| {
+                    let plain = backgrounds.get(i).copied().flatten().is_none()
+                        && widgets.get(i).and_then(Option::as_ref).is_none()
+                        && tables.get(i).and_then(Option::as_ref).is_none();
+                    let src = src_lines.get(i).copied().unwrap_or("");
+                    if !plain || !gpui_markdown::syntax::base_direction(src).is_rtl() {
+                        return None;
+                    }
+                    // A `VisualMap`'s x's are positions along the single
+                    // *pre-wrap* line, so it only describes a row that IS one
+                    // visual row. Splitting one per wrap row means reasoning
+                    // about a bidi run straddling a boundary (gpui wraps in
+                    // visual order) — a follow-up, not a guess; until then a
+                    // wrapped RTL row is left exactly as it was, which also
+                    // keeps its gutter markers on the side its text is on.
+                    let map = line
+                        .wrap_boundaries()
+                        .is_empty()
+                        .then(|| gpui_bidi::shaped::map_of_wrapped(line, line.len()))
+                        .filter(gpui_bidi::VisualMap::is_bidi)?;
+                    let inset = row_inset(
+                        backgrounds.get(i).copied().flatten(),
+                        marks.get(i).copied().flatten(),
+                    );
+                    Some(RtlRow {
+                        shift: rtl_shift(bounds.size.width, inset, line.width()),
+                        map,
+                    })
+                })
+                .collect()
+        };
+        // Row text origin, this frame: the row's inset plus its RTL shift.
+        // Fresh-data twin of `EditorState::row_origin_x` (the committed state
+        // lags a frame — see `disp_col` below).
+        let row_x = |row: usize| {
+            row_inset(
+                backgrounds.get(row).copied().flatten(),
+                marks.get(row).copied().flatten(),
+            ) + rtl
+                .get(row)
+                .and_then(Option::as_ref)
+                .map_or(px(0.), |r| r.shift)
+        };
+        let bidi = |row: usize| rtl.get(row).and_then(Option::as_ref).map(|r| &r.map);
+
         // Corner-grip hitboxes for each inline image, in `widgets` order (matching
         // the order paint walks them) — hitboxes must be inserted during prepaint,
         // but the resize cursor is set during paint via these. Mirrors the paint's
@@ -490,7 +552,8 @@ impl Element for EditorElement {
             if let Some(LineMark::Check { bullet_x, .. }) = marks.get(i).copied().flatten() {
                 let sz = font_size * CHECKBOX_SCALE;
                 let pad = px(4.);
-                let bx = bounds.origin.x + bullet_x;
+                let is_rtl = rtl.get(i).and_then(Option::as_ref).is_some();
+                let bx = bounds.origin.x + checkbox_x(bullet_x, sz, bounds.size.width, is_rtl);
                 let by = bounds.origin.y + line_tops[i] + (*lh - sz) / 2.;
                 let hit = Bounds::new(
                     point(bx - pad, by - pad),
@@ -701,10 +764,7 @@ impl Element for EditorElement {
                     continue;
                 };
                 let line = &editor.content[start..editor.line_end(i)];
-                let inset = row_inset(
-                    backgrounds.get(i).copied().flatten(),
-                    marks.get(i).copied().flatten(),
-                );
+                let inset = row_x(i);
                 // The reference-count badge over a hidden ` ^id` anchor is
                 // clickable too (skipped on the caret's line, where the raw
                 // anchor is revealed for editing).
@@ -727,8 +787,8 @@ impl Element for EditorElement {
                     let d1 = display_col_in(map, range.start);
                     let d2 = display_col_in(map, range.end);
                     let (Some(p1), Some(p2)) = (
-                        line_shaped.position_for_index(d1, *lh),
-                        line_shaped.position_for_index(d2, *lh),
+                        line_pos(line_shaped, bidi(i), d1, *lh),
+                        line_pos(line_shaped, bidi(i), d2, *lh),
                     ) else {
                         continue;
                     };
@@ -737,9 +797,11 @@ impl Element for EditorElement {
                     }
                     let origin = point(bounds.origin.x + inset, bounds.origin.y + line_tops[i]);
                     if p1.y == p2.y {
+                        // An RTL link ends to the LEFT of where it starts, so
+                        // the box spans min→max x rather than p1→p2.
                         let hit = Bounds::new(
-                            point(origin.x + p1.x, origin.y + p1.y),
-                            size(p2.x - p1.x, *lh),
+                            point(origin.x + p1.x.min(p2.x), origin.y + p1.y),
+                            size((p2.x - p1.x).abs(), *lh),
                         );
                         link_grips.push(window.insert_hitbox(hit, HitboxBehavior::Normal));
                     } else {
@@ -876,9 +938,13 @@ impl Element for EditorElement {
                     let range = f32::from(width - avail);
                     let sx = editor.table_sx(tbl_header, width, avail);
                     // Track left is FIXED (the gutter edge) — `left` is the
-                    // scrolled content edge and would drift the thumb.
-                    let track = bounds.origin.x + px(TABLE_GUTTER);
-                    let th_x = track + (avail - th_w) * (f32::from(sx) / range);
+                    // scrolled content edge and would drift the thumb. An RTL
+                    // table's band sits on the other side and its scroll runs
+                    // the other way, so the thumb starts at the track's right.
+                    let (track, _) = table_visible_band(bounds.origin.x, bounds.size.width, t.rtl);
+                    let frac = f32::from(sx) / range;
+                    let frac = if t.rtl { 1. - frac } else { frac };
+                    let th_x = track + (avail - th_w) * frac;
                     let mut th_c = t.border;
                     th_c.a = (th_c.a * 1.5).min(0.8);
                     let rect = Bounds::new(point(th_x, bottom - px(4.)), size(th_w, px(3.)));
@@ -891,7 +957,11 @@ impl Element for EditorElement {
                             rect,
                             grab,
                             header: tbl_header,
-                            factor: range / f32::from(avail - th_w).max(1.),
+                            // Negative on RTL: the thumb runs against the
+                            // scroll offset there (see `frac` above), so a
+                            // drag right must decrease it.
+                            factor: range / f32::from(avail - th_w).max(1.)
+                                * if t.rtl { -1. } else { 1. },
                             color: th_c,
                         },
                         window.insert_hitbox(grab, HitboxBehavior::Normal),
@@ -940,7 +1010,11 @@ impl Element for EditorElement {
                     }
                 }
                 if zone.contains(&mouse) {
-                    // Hovered BODY row → outline + a vertical pill on its left border.
+                    // Hovered BODY row → outline + a vertical pill on the border
+                    // the reserved gutter is on: the left one, or an RTL
+                    // table's right one (#66) — the pill must land in empty
+                    // gutter, not over the note column's edge.
+                    let pill_x = if t.rtl { left + width } else { left };
                     for line in tbl_header..=i {
                         let Some(rt) = tables.get(line).and_then(Option::as_ref) else {
                             continue;
@@ -953,7 +1027,7 @@ impl Element for EditorElement {
                         if mouse.y >= rtop && mouse.y < rtop + rh {
                             let ph = px(PILL_ALONG).min(rh - px(2.));
                             let py0 = rtop + (rh - ph) / 2.;
-                            let pill = Bounds::new(point(left - g / 2., py0), size(g, ph));
+                            let pill = Bounds::new(point(pill_x - g / 2., py0), size(g, ph));
                             let plus = Bounds::new(pill.origin, size(g, ph / 2.));
                             let minus =
                                 Bounds::new(point(pill.origin.x, py0 + ph / 2.), size(g, ph / 2.));
@@ -1025,12 +1099,6 @@ impl Element for EditorElement {
         // that hides/reveals markers).
         let disp_col =
             |row: usize, sc: usize| display_col_in(maps.get(row).and_then(Option::as_ref), sc);
-        let code_inset = |row: usize| {
-            row_inset(
-                backgrounds.get(row).copied().flatten(),
-                marks.get(row).copied().flatten(),
-            )
-        };
 
         // Quads covering source range `s..e`, one per wrap row — the
         // selection's multi-row geometry, shared with the find-match
@@ -1071,8 +1139,8 @@ impl Element for EditorElement {
                         // Clamp to the table's visible band — a wide
                         // (scrolling) table's cells extend past the
                         // viewport, but its highlight must not.
-                        let vis_l = bounds.left() + px(TABLE_GUTTER);
-                        let vis_r = bounds.left() + bounds.size.width;
+                        let (vis_l, vis_r) =
+                            table_visible_band(bounds.left(), bounds.size.width, t.rtl);
                         let mut band = |lo: Pixels, hi: Pixels, y: Pixels, h: Pixels| {
                             let (lo, hi) = (lo.max(vis_l), hi.min(vis_r));
                             if hi > lo {
@@ -1137,20 +1205,23 @@ impl Element for EditorElement {
                         }
                         continue;
                     }
-                    let inset = code_inset(row);
-                    let pa = line
-                        .position_for_index(disp_col(row, a), lh)
-                        .unwrap_or_default();
-                    let pb = line
-                        .position_for_index(disp_col(row, b), lh)
-                        .unwrap_or_default();
+                    let inset = row_x(row);
+                    let pa = line_pos(line, bidi(row), disp_col(row, a), lh).unwrap_or_default();
+                    let pb = line_pos(line, bidi(row), disp_col(row, b), lh).unwrap_or_default();
                     let pa = point(pa.x + inset, pa.y);
                     let pb = point(pb.x + inset, pb.y);
                     if pa.y == pb.y {
+                        // On an RTL row the range's END sits to the LEFT of its
+                        // start, so order the corners by x. One rect per row is
+                        // still all this paints: a selection spanning a
+                        // direction change is visually split (see
+                        // `VisualMap::rects_for_range`) and needs N — a
+                        // follow-up.
+                        let (x0, x1) = (pa.x.min(pb.x), pa.x.max(pb.x));
                         sels.push(fill(
                             Bounds::from_corners(
-                                to_screen(top, pa),
-                                to_screen(top, point(pb.x.max(pa.x + px(2.)), pb.y + lh)),
+                                to_screen(top, point(x0, pa.y)),
+                                to_screen(top, point(x1.max(x0 + px(2.)), pb.y + lh)),
                             ),
                             color,
                         ));
@@ -1221,7 +1292,7 @@ impl Element for EditorElement {
             // — before the picture at the line's start, after it anywhere else —
             // instead of a text caret placed by the hidden source glyphs.
             if let Some(Block::Image(img)) = widgets.get(row).and_then(Option::as_ref) {
-                let inset = code_inset(row);
+                let inset = row_x(row);
                 let (img_w, img_h) = image_display_size(img, image_resize, row);
                 let x = bounds.left() + inset + if col == 0 { px(-3.) } else { img_w + px(3.) };
                 let c = fill(
@@ -1252,9 +1323,9 @@ impl Element for EditorElement {
             } else {
                 let p = wrapped
                     .get(row)
-                    .and_then(|l| l.position_for_index(disp_col(row, col), lh))
+                    .and_then(|l| line_pos(l, bidi(row), disp_col(row, col), lh))
                     .unwrap_or_default();
-                let inset = code_inset(row);
+                let inset = row_x(row);
                 // A row can be taller than its text — grown to fit an inline
                 // formula, or breathing like a list item (LIST_ROW_GAP) — with
                 // the glyphs centered in it. The caret matches the TEXT height
@@ -1308,6 +1379,7 @@ impl Element for EditorElement {
             tables,
             maps,
             marks,
+            rtl,
             inline_maths,
             image_grips,
             checkbox_grips,
@@ -1413,6 +1485,12 @@ impl Element for EditorElement {
             .enumerate()
         {
             let origin = point(bounds.origin.x, bounds.origin.y + *top);
+            // Right-to-left row (#66): its text right-aligns by `shift`, and
+            // every gutter decoration mirrors to the other side so the markers
+            // sit where the text now starts — matching the reader.
+            let rtl = prepaint.rtl.get(i).and_then(Option::as_ref);
+            let shift = rtl.map_or(px(0.), |r| r.shift);
+            let content_w = bounds.size.width;
             // Nesting guides for a list/task row: a thin vertical line at each
             // ancestor bullet's x, spanning this row (contiguous rows stack into a
             // continuous guide).
@@ -1431,8 +1509,14 @@ impl Element for EditorElement {
                         ..color
                     };
                     for &gx in &outline {
+                        let g = gx + px(3.);
+                        let g = if rtl.is_some() {
+                            rtl_marker_x(content_w, g, px(1.))
+                        } else {
+                            g
+                        };
                         window.paint_quad(fill(
-                            Bounds::new(point(origin.x + gx + px(3.), origin.y), size(px(1.), *lh)),
+                            Bounds::new(point(origin.x + g, origin.y), size(px(1.), *lh)),
                             guide,
                         ));
                     }
@@ -1472,7 +1556,13 @@ impl Element for EditorElement {
             // Blockquote: a muted 2px left border down the line (the body is inset
             // past it by QUOTE_INSET).
             if let Some(LineMark::Quote { bar, .. }) = prepaint.marks.get(i).copied().flatten() {
-                window.paint_quad(fill(Bounds::new(origin, size(px(2.), *lh)), bar));
+                // RTL: the rule belongs on the right, where the text starts —
+                // the reader's `border_r_2` (see `gpui-markdown`'s blockquote).
+                let bx = origin.x + rtl.map_or(px(0.), |_| content_w - px(2.));
+                window.paint_quad(fill(
+                    Bounds::new(point(bx, origin.y), size(px(2.), *lh)),
+                    bar,
+                ));
             }
             // Heading fold chevron (hovered or folded headings only): painted
             // past the heading text, muted; clicking toggles the fold (rects
@@ -1637,8 +1727,13 @@ impl Element for EditorElement {
                 let shaped = window
                     .text_system()
                     .shape_line(glyph, font_size, &[run], None);
+                let bx = if rtl.is_some() {
+                    rtl_marker_x(content_w, bullet_x, shaped.width())
+                } else {
+                    bullet_x
+                };
                 let _ = shaped.paint(
-                    point(origin.x + bullet_x, origin.y),
+                    point(origin.x + bx, origin.y),
                     *lh,
                     gpui::TextAlign::Left,
                     None,
@@ -1657,7 +1752,7 @@ impl Element for EditorElement {
             }) = prepaint.marks.get(i).copied().flatten()
             {
                 let sz = font_size * CHECKBOX_SCALE;
-                let bx = origin.x + bullet_x;
+                let bx = origin.x + checkbox_x(bullet_x, sz, content_w, rtl.is_some());
                 let by = origin.y + (*lh - sz) / 2.; // vertically centered on the line
                 let box_bounds = Bounds::new(point(bx, by), size(sz, sz));
                 checkbox_rects.push((i, box_bounds));
@@ -1698,7 +1793,8 @@ impl Element for EditorElement {
                 // clipped to the viewport — rows paint shifted under a mask.
                 let table_w: Pixels = t.col_widths.iter().copied().sum();
                 let avail = bounds.size.width - px(TABLE_GUTTER);
-                let tleft = origin.x + px(TABLE_GUTTER);
+                // The clip band, on the side this table's gutter ISN'T (#66).
+                let (tleft, _) = table_visible_band(origin.x, bounds.size.width, t.rtl);
                 let content_left = self.editor.read(cx).table_left(t, i, &bounds);
                 let g = px(TABLE_GUTTER);
                 let mask = gpui::ContentMask {
@@ -1834,7 +1930,7 @@ impl Element for EditorElement {
                     prepaint.backgrounds.get(i).copied().flatten(),
                     prepaint.marks.get(i).copied().flatten(),
                 );
-                let text_origin = point(origin.x + inset, origin.y);
+                let text_origin = point(origin.x + inset + shift, origin.y);
                 // Run backgrounds (the inline-code highlight) paint separately from
                 // the glyphs — `paint` alone wouldn't show them.
                 let _ = line.paint_background(
@@ -1849,7 +1945,10 @@ impl Element for EditorElement {
                 // Inline `$…$` formulas: paint each typeset raster over its spacer, centered on
                 // the text row. `position_for_index` gives the spacer's x + wrap-row offset.
                 // Record each formula's window bounds for click-to-edit; the one being edited
-                // shows the seated editor instead of its raster.
+                // shows the seated editor instead of its raster. (Deliberately NOT bidi-mapped:
+                // a raster needs its spacer's *left* edge, which on an RTL run is the caret x of
+                // the offset one past it — a formula inside RTL prose is a follow-up. It still
+                // rides the row's shift, so it stays with the text.)
                 for im in prepaint.inline_maths.get(i).into_iter().flatten() {
                     if let Some(p) = line.position_for_index(im.display_off, *lh) {
                         let x = text_origin.x + p.x;
@@ -2163,6 +2262,7 @@ impl Element for EditorElement {
             editor.offset_maps = offset_maps;
             editor.chip_rows = chip_rows;
             editor.line_insets = line_insets;
+            editor.rtl_rows = std::mem::take(&mut prepaint.rtl);
             editor.table_rows = table_rows;
             editor.image_rects = image_rects;
             editor.inline_math_rects = inline_math_rects;
@@ -3062,6 +3162,7 @@ fn shape_document(
                     style: r.style,
                     border: md.map_or(base_color, |m| m.marker),
                     shade: md.map_or(hsla(0., 0., 0., 0.), |m| m.code_bg),
+                    rtl: r.rtl,
                 }
             });
 

--- a/crates/gpui-editor/src/element.rs
+++ b/crates/gpui-editor/src/element.rs
@@ -973,7 +973,7 @@ impl Element for EditorElement {
                     && !rt.col_widths.is_empty()
                 {
                     let cc = ccell.min(rt.col_widths.len() - 1);
-                    let x: Pixels = left + rt.col_widths[..cc].iter().copied().sum::<Pixels>();
+                    let x: Pixels = left + col_offset(&rt.col_widths, rt.cells.len(), cc, rt.rtl);
                     let rect = Bounds::new(
                         point(x, bounds.origin.y + line_tops[crow]),
                         size(
@@ -988,9 +988,11 @@ impl Element for EditorElement {
                 // border (hover-gated; kept while a drag on this table is live).
                 if zone.contains(&mouse) || dragging_col.is_some_and(|r| r.header_row == tbl_header)
                 {
-                    let mut xacc = left;
                     for (col, &cw) in t.col_widths.iter().enumerate() {
-                        xacc += cw;
+                        // The grip sits on the edge where this column ENDS: its
+                        // left on an RTL table, its right otherwise.
+                        let cx = left + col_offset(&t.col_widths, t.cells.len(), col, t.rtl);
+                        let xacc = if t.rtl { cx } else { cx + cw };
                         let band =
                             Bounds::new(point(xacc - px(3.), top), size(px(6.), bottom - top));
                         col_resize_grips.push(ColResizeGrip {
@@ -1048,9 +1050,11 @@ impl Element for EditorElement {
                         .as_ref()
                         .is_some_and(|a| a.plus.contains(&mouse) || a.minus.contains(&mouse));
                     if !on_row_pill && mouse.x >= left && mouse.x < left + width {
-                        let mut colx = left;
                         for (col, &cw) in t.col_widths.iter().enumerate() {
-                            if mouse.x < colx + cw || col + 1 == t.col_widths.len() {
+                            let colx = left + col_offset(&t.col_widths, t.cells.len(), col, t.rtl);
+                            if (mouse.x >= colx && mouse.x < colx + cw)
+                                || col + 1 == t.col_widths.len()
+                            {
                                 let pw = px(PILL_ALONG).min(cw - px(2.));
                                 let px0 = colx + (cw - pw) / 2.;
                                 let pill = Bounds::new(point(px0, top - g / 2.), size(pw, g));
@@ -1071,7 +1075,6 @@ impl Element for EditorElement {
                                 });
                                 break;
                             }
-                            colx += cw;
                         }
                     }
                 }
@@ -1159,11 +1162,8 @@ impl Element for EditorElement {
                             // one full-height band would smear the whole row.
                             (Some((xa, ya, ca, _)), Some((xb, yb, cb, _))) if ca == cb => {
                                 let pad = px(TABLE_CELL_PAD);
-                                let cell_x = tleft
-                                    + t.col_widths[..ca.min(t.col_widths.len())]
-                                        .iter()
-                                        .copied()
-                                        .sum::<Pixels>();
+                                let cell_x =
+                                    tleft + col_offset(&t.col_widths, t.cells.len(), ca, t.rtl);
                                 let cw = cell_span_width(&t.col_widths, t.cells.len(), ca);
                                 let (cl, cr) = (cell_x + pad, cell_x + cw - pad);
                                 let y0 = bounds.top() + top + px(6.);

--- a/crates/gpui-editor/src/element.rs
+++ b/crates/gpui-editor/src/element.rs
@@ -1650,7 +1650,24 @@ impl Element for EditorElement {
                 ..
             }) = prepaint.marks.get(i).copied().flatten()
             {
-                window.paint_quad(fill(Bounds::new(origin, size(px(2.), *lh)), bar));
+                // An RTL callout mirrors like the rest of the row: the rule on
+                // the right, then the icon, then the label running leftward.
+                // Each box is reflected on its own, which reverses their order
+                // exactly as intended.
+                let amirror = |x: Pixels, w: Pixels| {
+                    if rtl.is_some() {
+                        origin.x + content_w - (x - origin.x) - w
+                    } else {
+                        x
+                    }
+                };
+                window.paint_quad(fill(
+                    Bounds::new(
+                        point(amirror(origin.x, px(2.)), origin.y),
+                        size(px(2.), *lh),
+                    ),
+                    bar,
+                ));
                 // Foldable callout: a chevron after the label; clicking it flips
                 // the `-`/`+` in the source (rects committed for on_mouse_down).
                 if let Some(folded) = fold {
@@ -1666,7 +1683,7 @@ impl Element for EditorElement {
                     let shaped = window
                         .text_system()
                         .shape_line(glyph, font_size, &[run], None);
-                    let cx0 = origin.x + chevron_x;
+                    let cx0 = amirror(origin.x + chevron_x, shaped.width());
                     let _ = shaped.paint(
                         point(cx0, origin.y),
                         *lh,
@@ -1691,8 +1708,10 @@ impl Element for EditorElement {
                 let mut label_x = origin.x + px(QUOTE_INSET);
                 if let Some(icons) = &prepaint.alert_icons {
                     let sz = font_size;
-                    let icon_bounds =
-                        Bounds::new(point(label_x, origin.y + (*lh - sz) / 2.), size(sz, sz));
+                    let icon_bounds = Bounds::new(
+                        point(amirror(label_x, sz), origin.y + (*lh - sz) / 2.),
+                        size(sz, sz),
+                    );
                     let _ = window.paint_svg(
                         icon_bounds,
                         icons.get(kind),
@@ -1719,7 +1738,7 @@ impl Element for EditorElement {
                     .text_system()
                     .shape_line(label.into(), font_size, &[run], None);
                 let _ = shaped.paint(
-                    point(label_x, origin.y),
+                    point(amirror(label_x, shaped.width()), origin.y),
                     *lh,
                     gpui::TextAlign::Left,
                     None,
@@ -1949,6 +1968,7 @@ impl Element for EditorElement {
                 paint_prop_panel(
                     p,
                     origin,
+                    content_w,
                     &font,
                     font_size,
                     window,
@@ -3847,12 +3867,21 @@ fn shape_document(
             // caret jumps to the LEFT margin the moment you press Enter after a
             // Persian paragraph, and a selection running through the blank line
             // puts its marker on the wrong side.
-            let line_rtl = if line.trim().is_empty() {
-                last_strong_rtl
-            } else {
-                let rtl = gpui_markdown::syntax::base_direction(line).is_rtl();
-                last_strong_rtl = rtl;
-                rtl
+            // A line with no strong character of its own — blank, or nothing
+            // but markers like `> [!NOTE]` — inherits the paragraph it sits in.
+            // Otherwise a Persian callout's title sat on the opposite side from
+            // its body, and pressing Enter after a Persian paragraph dropped the
+            // caret on the left margin.
+            //
+            // ponytail: it inherits from ABOVE, so an alert whose title follows
+            // English text but whose body is Persian still splits. Looking ahead
+            // to the body would fix it; no one has hit that yet.
+            let line_rtl = match gpui_markdown::syntax::content_direction_opt(line) {
+                Some(d) => {
+                    last_strong_rtl = d.is_rtl();
+                    d.is_rtl()
+                }
+                None => last_strong_rtl,
             };
             // Lay out any line CONTAINING right-to-left text, not just one that
             // reads that way: an English sentence quoting a Persian name still
@@ -4057,6 +4086,7 @@ fn prop_pill_bounds(
 fn paint_prop_panel(
     p: &PropPanel,
     origin: Point<Pixels>,
+    content_w: Pixels,
     font: &Font,
     font_size: Pixels,
     window: &mut Window,
@@ -4068,6 +4098,35 @@ fn paint_prop_panel(
     let line_h = font_size * LINE_HEIGHT_RATIO;
     let pad = px(10.);
     let mouse = window.mouse_position();
+    // Follow the VALUES, not the keys: a Persian note's property keys are
+    // usually Latin (`tags`, `key`), so the key would decide the wrong way.
+    // Panel-wide, so the key column doesn't stagger row to row.
+    let rtl = p.rows.iter().any(|(_, _, segs)| {
+        segs.iter().any(|s| {
+            let t = match s {
+                PanelSeg::Plain(t) => t,
+                PanelSeg::Pill { text, .. } => text,
+            };
+            gpui_markdown::syntax::content_direction(t).is_rtl()
+        })
+    });
+    // The panel is sized to its content, so mirroring INSIDE it is not enough —
+    // it also has to sit on the right, where the rest of an RTL block does.
+    let origin = if rtl {
+        point(origin.x + content_w - p.width, origin.y)
+    } else {
+        origin
+    };
+    // Reflect a box across the panel: everything below is laid out
+    // left-to-right and mirrored on the way out, so the two directions can't
+    // drift apart.
+    let mirror = |x: Pixels, w: Pixels| {
+        if rtl {
+            origin.x + p.width - (x - origin.x) - w
+        } else {
+            x
+        }
+    };
     for (ri, (key, icon, segs)) in p.rows.iter().enumerate() {
         let row_top = origin.y + p.row_h * ri as f32;
         let row_bounds = Bounds::new(point(origin.x, row_top), size(p.width, p.row_h));
@@ -4087,7 +4146,10 @@ fn paint_prop_panel(
         // Optional key icon (host-resolved), then the muted key name inset past it.
         if let Some(path) = icon {
             let ib = Bounds::new(
-                point(origin.x + pad, row_top + (p.row_h - p.icon_sz) / 2.),
+                point(
+                    mirror(origin.x + pad, p.icon_sz),
+                    row_top + (p.row_h - p.icon_sz) / 2.,
+                ),
                 size(p.icon_sz, p.icon_sz),
             );
             let _ = window.paint_svg(
@@ -4111,7 +4173,7 @@ fn paint_prop_panel(
             .text_system()
             .shape_line(key.clone(), font_size, &[krun], None);
         let _ = ks.paint(
-            point(origin.x + pad + p.key_indent, ty),
+            point(mirror(origin.x + pad + p.key_indent, ks.width()), ty),
             line_h,
             gpui::TextAlign::Left,
             None,
@@ -4145,13 +4207,14 @@ fn paint_prop_panel(
                 let mut bg = color;
                 bg.a = 0.16;
                 let ph = line_h + px(2.);
+                let pw = tw + px(PILL_PAD_X * 2.);
                 let pb = Bounds::new(
-                    point(x, row_top + (p.row_h - ph) / 2.),
-                    size(tw + px(PILL_PAD_X * 2.), ph),
+                    point(mirror(x, pw), row_top + (p.row_h - ph) / 2.),
+                    size(pw, ph),
                 );
                 window.paint_quad(fill(pb, bg).corner_radii(Corners::all(px(6.))));
                 let _ = shaped.paint(
-                    point(x + px(PILL_PAD_X), ty),
+                    point(pb.origin.x + px(PILL_PAD_X), ty),
                     line_h,
                     gpui::TextAlign::Left,
                     None,
@@ -4162,7 +4225,7 @@ fn paint_prop_panel(
                 x += tw + px(PILL_PAD_X * 2. + PILL_GAP);
             } else {
                 let _ = shaped.paint(
-                    point(x, ty),
+                    point(mirror(x, tw), ty),
                     line_h,
                     gpui::TextAlign::Left,
                     None,

--- a/crates/gpui-editor/src/element.rs
+++ b/crates/gpui-editor/src/element.rs
@@ -1989,12 +1989,8 @@ impl Element for EditorElement {
                     // Our own rows, painted in reading order — gpui's wrapping
                     // is not used for this line at all (#66). Each row is
                     // right-aligned on its own, so a short last row sits
-                    // further right than a full one.
-                    //
-                    // ponytail: run backgrounds (the inline-code highlight) are
-                    // not painted here; `paint_row` draws glyphs only. An RTL
-                    // line with inline code loses that tint — add it when
-                    // someone writes `code` inside Persian prose.
+                    // further right than a full one. `paint_row` draws the run
+                    // backgrounds (the inline-code tint) too.
                     for (k, row) in r.rows.iter().enumerate() {
                         gpui_bidi::paragraph::paint_row(
                             row,
@@ -3881,6 +3877,17 @@ fn shape_document(
                     last_strong_rtl = d.is_rtl();
                     d.is_rtl()
                 }
+                // Nothing but markers (`> [!NOTE]`, a bare `- `): its content is
+                // the line BELOW, so take that one's direction — a callout's
+                // title has to land on the same side as its body. Only within
+                // the block: a blank line ends it, and there the line above is
+                // what matters (pressing Enter after a Persian paragraph should
+                // keep the caret on the right).
+                None if !line.trim().is_empty() => lines
+                    .get(idx + 1)
+                    .filter(|next| !next.trim().is_empty())
+                    .and_then(|next| gpui_markdown::syntax::content_direction_opt(next))
+                    .map_or(last_strong_rtl, |d| d.is_rtl()),
                 None => last_strong_rtl,
             };
             // Lay out any line CONTAINING right-to-left text, not just one that

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1725,7 +1725,8 @@ impl EditorState {
         self.rtl_rows
             .get(row)
             .and_then(Option::as_ref)
-            .map_or(px(0.), |r| r.shift)
+            .and_then(|r| r.shifts.first().copied())
+            .unwrap_or(px(0.))
     }
 
     /// Where logical line `row`'s painted text actually starts: its inset plus
@@ -1736,12 +1737,52 @@ impl EditorState {
         self.line_inset(row) + self.rtl_shift(row)
     }
 
-    /// The bidi index↔x map for `row`, if it has one (see [`RtlRow`]).
-    fn bidi_map(&self, row: usize) -> Option<&gpui_bidi::VisualMap> {
-        self.rtl_rows
-            .get(row)
-            .and_then(Option::as_ref)
-            .map(|r| &r.map)
+    /// Does the caret's line read right-to-left?
+    ///
+    /// Arrow keys move VISUALLY — Right steps to the character on the right of
+    /// the screen, which every platform does in bidi text and which readers of
+    /// Persian expect. On an RTL row that character is the logically PREVIOUS
+    /// one, so the two step functions swap.
+    fn caret_row_is_rtl(&self) -> bool {
+        let (row, _) = self.row_col(self.cursor_offset());
+        self.rtl_rows.get(row).and_then(Option::as_ref).is_some()
+    }
+
+    /// The offset one step to the visual left/right of the caret, taking the
+    /// row's direction into account.
+    fn horizontal_step(&self, visual_right: bool) -> usize {
+        let off = self.cursor_offset();
+        let (row, col) = self.row_col(off);
+        // Inside a bidi row, "one step right" is not "one byte forward, maybe
+        // flipped". A Latin word or URL embedded in Persian runs the other way,
+        // and the caret has to flow THROUGH it rather than jump to its far end
+        // — so the step comes from the glyph order, via the row's map.
+        if let Some(r) = self.bidi_map(row) {
+            let dcol = self.display_col(row, col);
+            let (k, local) = r.row_of(dcol);
+            if let Some(rr) = r.rows.get(k)
+                && let Some(next) = rr.map.step_visual(local, visual_right)
+            {
+                return self.line_starts()[row] + self.source_col(row, rr.start + next);
+            }
+            // Off the end of this row: fall through to the logical neighbour,
+            // which is what carries the caret onto the next row or line.
+            return if visual_right != self.caret_row_is_rtl() {
+                self.next_visible_boundary(off)
+            } else {
+                self.prev_visible_boundary(off)
+            };
+        }
+        if visual_right {
+            self.next_visible_boundary(off)
+        } else {
+            self.prev_visible_boundary(off)
+        }
+    }
+
+    /// The RTL layout for `row`, if it has one (see [`RtlRow`]).
+    fn bidi_map(&self, row: usize) -> Option<&RtlRow> {
+        self.rtl_rows.get(row).and_then(Option::as_ref)
     }
 
     /// Window-space bounds of the caret at `offset`, from the last paint's
@@ -1796,7 +1837,14 @@ impl EditorState {
 
     fn left(&mut self, _: &Left, _: &mut Window, cx: &mut Context<Self>) {
         if !self.selected_range.is_empty() {
-            self.move_to(self.selected_range.start, cx);
+            // Collapse to the selection's VISUALLY left edge, which on an RTL
+            // row is its logical end.
+            let to = if self.caret_row_is_rtl() {
+                self.selected_range.end
+            } else {
+                self.selected_range.start
+            };
+            self.move_to(to, cx);
             return;
         }
         if self.caret_in_table()
@@ -1805,7 +1853,7 @@ impl EditorState {
             self.move_to(off, cx);
             return;
         }
-        let off = self.prev_visible_boundary(self.cursor_offset());
+        let off = self.horizontal_step(false);
         if let Some((range, source)) = self.inline_math_span_at(off) {
             cx.emit(EditorEvent::EditMath {
                 range,
@@ -1839,7 +1887,12 @@ impl EditorState {
 
     fn right(&mut self, _: &Right, _: &mut Window, cx: &mut Context<Self>) {
         if !self.selected_range.is_empty() {
-            self.move_to(self.selected_range.end, cx);
+            let to = if self.caret_row_is_rtl() {
+                self.selected_range.start
+            } else {
+                self.selected_range.end
+            };
+            self.move_to(to, cx);
             return;
         }
         if self.caret_in_table()
@@ -1848,7 +1901,7 @@ impl EditorState {
             self.move_to(off, cx);
             return;
         }
-        let off = self.next_visible_boundary(self.cursor_offset());
+        let off = self.horizontal_step(true);
         if let Some((range, source)) = self.inline_math_span_at(off) {
             cx.emit(EditorEvent::EditMath {
                 range,
@@ -1970,12 +2023,14 @@ impl EditorState {
 
     fn select_left(&mut self, _: &SelectLeft, _: &mut Window, cx: &mut Context<Self>) {
         self.goal_x = None;
-        self.select_to(self.prev_visible_boundary(self.cursor_offset()), cx);
+        let off = self.horizontal_step(false);
+        self.select_to(off, cx);
     }
 
     fn select_right(&mut self, _: &SelectRight, _: &mut Window, cx: &mut Context<Self>) {
         self.goal_x = None;
-        self.select_to(self.next_visible_boundary(self.cursor_offset()), cx);
+        let off = self.horizontal_step(true);
+        self.select_to(off, cx);
     }
 
     fn select_up(&mut self, _: &SelectUp, _: &mut Window, cx: &mut Context<Self>) {
@@ -6016,8 +6071,13 @@ struct ShapedDoc {
     inline_maths: Vec<Vec<InlineMath>>,
     /// Per-line wrap-row count. Geometry (line tops, total height) reads THIS,
     /// not `wrap_boundaries()` — a windowed-out line's `WrappedLine` is an
-    /// empty placeholder, but its cached count keeps the layout exact.
+    /// empty placeholder, but its cached count keeps the layout exact. For an
+    /// RTL line it is OUR row count, which is not gpui's (#66).
     wrap_rows: Vec<usize>,
+    /// Per-line RTL layout: the rows we broke in logical order, or `None` for
+    /// the LTR lines that keep gpui's own wrapping. Drives that line's paint,
+    /// caret, selection and hit-testing.
+    rtl_rows: Vec<Option<Vec<gpui_bidi::paragraph::Row>>>,
 }
 
 impl ShapedDoc {
@@ -6054,6 +6114,7 @@ impl ShapedDoc {
         self.marks.push(mark);
         self.inline_maths.push(Vec::new());
         self.wrap_rows.push(rows);
+        self.rtl_rows.push(None);
     }
 }
 
@@ -6103,29 +6164,38 @@ fn display_col_in(map: Option<&std::rc::Rc<Vec<usize>>>, source_col: usize) -> u
 /// Excludes the row's insets — callers add [`EditorState::row_origin_x`].
 fn line_pos(
     line: &WrappedLine,
-    map: Option<&gpui_bidi::VisualMap>,
+    rtl: Option<&RtlRow>,
     dcol: usize,
     lh: Pixels,
 ) -> Option<Point<Pixels>> {
-    let p = line.position_for_index(dcol, lh)?;
-    Some(match map {
-        Some(m) => point(px(m.x_for_index(dcol)), p.y),
-        None => p,
-    })
+    match rtl {
+        // Our own rows: which one holds the offset decides the y, and the
+        // row's map the x. gpui's layout is not consulted at all — its rows
+        // are not ours.
+        Some(r) => {
+            let (row, local) = r.row_of(dcol);
+            let x = px(r.rows.get(row)?.map.x_for_index(local)) + r.shift_delta(row);
+            Some(point(x, lh * row))
+        }
+        None => line.position_for_index(dcol, lh),
+    }
 }
 
 /// The display column a click at row-local `p` names — the inverse of
 /// [`line_pos`], through the bidi map when the row has one (gpui's
 /// `closest_index_for_x` fails on RTL the same way `x_for_index` does).
-fn line_index_at(
-    line: &WrappedLine,
-    map: Option<&gpui_bidi::VisualMap>,
-    p: Point<Pixels>,
-    lh: Pixels,
-) -> usize {
-    match map {
-        Some(m) => m.index_for_x(f32::from(p.x)),
-        None => match line.closest_index_for_position(p, lh) {
+fn line_index_at(line: &WrappedLine, rtl: Option<&RtlRow>, p: Point<Pixels>, lh: Pixels) -> usize {
+    match rtl {
+        Some(r) if !r.rows.is_empty() => {
+            let row = ((f32::from(p.y) / f32::from(lh).max(1.0)).floor().max(0.) as usize)
+                .min(r.rows.len() - 1);
+            let x = p.x - r.shift_delta(row);
+            let Some(rr) = r.rows.get(row) else {
+                return 0;
+            };
+            rr.start + rr.map.index_for_x(f32::from(x))
+        }
+        _ => match line.closest_index_for_position(p, lh) {
             Ok(i) | Err(i) => i,
         },
     }
@@ -6137,14 +6207,68 @@ fn line_index_at(
 /// get one — the flag *is* `Option::is_some`, so an LTR document allocates
 /// nothing and keeps taking gpui's own (cheaper) lookups.
 pub(crate) struct RtlRow {
-    /// Added to the row's text origin so the line right-aligns in the content
-    /// width (see [`rtl_shift`]). Kept OUT of `line_insets` on purpose: the
-    /// list-marker + gutter math reads that, and must not move with the text.
-    shift: Pixels,
-    /// Logical↔visual mapping for the row's glyphs, so a caret/click lands on
-    /// the glyph it names. Only unwrapped rows get one (a map's x's run along
-    /// the single pre-wrap line) — see where it is built, in the prepaint.
-    map: gpui_bidi::VisualMap,
+    /// The line's visual rows, broken in LOGICAL order (gpui's own wrapping
+    /// slices the reordered glyph run and gets them backwards). Each carries
+    /// the map that turns an offset inside it into an x and back.
+    rows: Vec<gpui_bidi::paragraph::Row>,
+    /// Each row's right-align shift, parallel to `rows`: added to the text
+    /// origin so the row right-aligns in the content width (see [`rtl_shift`]).
+    /// Per ROW, not per line — a short last row shifts further than a full one.
+    /// Kept OUT of `line_insets` on purpose: the list-marker + gutter math
+    /// reads that, and must not move with the text.
+    shifts: Vec<Pixels>,
+}
+
+impl RtlRow {
+    /// The row holding display column `dcol`, and the column's offset within
+    /// it. Rows are in reading order and contiguous, so the last row wins for
+    /// an offset at the very end of the line.
+    fn row_of(&self, dcol: usize) -> (usize, usize) {
+        row_of_spans(self.rows.iter().map(|r| (r.start, r.len)), dcol)
+    }
+
+    /// A row's horizontal extent (left, right) relative to the FIRST row's
+    /// origin — the coordinate space callers already work in, since they add
+    /// `row_origin_x`. Used to band a selection across a row: an RTL row does
+    /// not span the content width, so "the whole row" is this, not 0..width.
+    pub(crate) fn row_extent(&self, row: usize) -> (Pixels, Pixels) {
+        let d = self.shift_delta(row);
+        (d, d + self.rows.get(row).map_or(px(0.), |r| r.width))
+    }
+
+    /// How many visual rows this line broke into.
+    pub(crate) fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// A row's shift relative to the FIRST row's. Callers already add
+    /// `row_origin_x`, which carries row 0's shift, so this is the remainder —
+    /// that keeps every existing caller correct without threading a wrap-row
+    /// index through all of them.
+    fn shift_delta(&self, row: usize) -> Pixels {
+        self.shifts.get(row).copied().unwrap_or(px(0.))
+            - self.shifts.first().copied().unwrap_or(px(0.))
+    }
+}
+
+/// Which row holds display column `dcol`, and its offset within that row.
+///
+/// Split out from [`RtlRow::row_of`] so it can be tested without a window: a
+/// `Row` carries a shaped line, which needs one. Rows are contiguous and in
+/// reading order, so an offset at the very end of the line lands on the last
+/// row rather than falling off the end — that is where the caret sits after
+/// typing at the end of a paragraph.
+fn row_of_spans(rows: impl Iterator<Item = (usize, usize)>, dcol: usize) -> (usize, usize) {
+    let mut last = (0, dcol);
+    let mut seen = false;
+    for (i, (start, len)) in rows.enumerate() {
+        seen = true;
+        last = (i, dcol.saturating_sub(start));
+        if dcol < start + len {
+            return (i, dcol - start);
+        }
+    }
+    if seen { last } else { (0, dcol) }
 }
 
 /// The x a right-to-left row's text starts at within `content_width`, so its
@@ -6499,7 +6623,24 @@ mod tests {
 
     // --- RTL row geometry (#66) ---------------------------------------------
 
-    use super::{checkbox_x, px, rtl_marker_x, rtl_shift};
+    use super::{checkbox_x, px, row_of_spans, rtl_marker_x, rtl_shift};
+
+    #[test]
+    fn a_caret_offset_lands_on_the_row_that_holds_it() {
+        // Three rows: "0..5", "5..11", "11..14" — contiguous, reading order.
+        let rows = || [(0usize, 5usize), (5, 6), (11, 3)].into_iter();
+        assert_eq!(row_of_spans(rows(), 0), (0, 0));
+        assert_eq!(row_of_spans(rows(), 4), (0, 4));
+        // A boundary belongs to the row that STARTS there, not the one ending.
+        assert_eq!(row_of_spans(rows(), 5), (1, 0));
+        assert_eq!(row_of_spans(rows(), 12), (2, 1));
+        // The caret sits one past the last character after typing at the end
+        // of a paragraph: it must stay on the last row, not fall off.
+        assert_eq!(row_of_spans(rows(), 14), (2, 3));
+        assert_eq!(row_of_spans(rows(), 99), (2, 88));
+        // No rows at all (an empty line) is row 0.
+        assert_eq!(row_of_spans([].into_iter(), 0), (0, 0));
+    }
 
     #[test]
     fn rtl_shift_mirrors_the_row_inset() {

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1745,7 +1745,10 @@ impl EditorState {
     /// one, so the two step functions swap.
     fn caret_row_is_rtl(&self) -> bool {
         let (row, _) = self.row_col(self.cursor_offset());
-        self.rtl_rows.get(row).and_then(Option::as_ref).is_some()
+        self.rtl_rows
+            .get(row)
+            .and_then(Option::as_ref)
+            .is_some_and(|r| r.base_rtl)
     }
 
     /// The offset one step to the visual left/right of the caret, taking the
@@ -6104,10 +6107,11 @@ struct ShapedDoc {
     /// empty placeholder, but its cached count keeps the layout exact. For an
     /// RTL line it is OUR row count, which is not gpui's (#66).
     wrap_rows: Vec<usize>,
-    /// Per-line RTL layout: the rows we broke in logical order, or `None` for
-    /// the LTR lines that keep gpui's own wrapping. Drives that line's paint,
-    /// caret, selection and hit-testing.
-    rtl_rows: Vec<Option<Vec<gpui_bidi::paragraph::Row>>>,
+    /// Per-line bidi layout: whether the line READS right-to-left, plus the
+    /// rows we broke in logical order. `None` for lines with no RTL at all,
+    /// which keep gpui's own wrapping. Drives that line's paint, caret,
+    /// selection and hit-testing.
+    rtl_rows: Vec<Option<(bool, Vec<gpui_bidi::paragraph::Row>)>>,
 }
 
 impl ShapedDoc {
@@ -6247,6 +6251,10 @@ pub(crate) struct RtlRow {
     /// Kept OUT of `line_insets` on purpose: the list-marker + gutter math
     /// reads that, and must not move with the text.
     shifts: Vec<Pixels>,
+    /// Does the line READ right-to-left? A left-to-right line containing a
+    /// Persian phrase gets rows and maps too, but stays left-aligned and keeps
+    /// left-to-right arrow keys.
+    base_rtl: bool,
 }
 
 impl RtlRow {

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1763,7 +1763,33 @@ impl EditorState {
             if let Some(rr) = r.rows.get(k)
                 && let Some(next) = rr.map.step_visual(local, visual_right)
             {
-                return self.line_starts()[row] + self.source_col(row, rr.start + next);
+                let target = self.line_starts()[row] + self.source_col(row, rr.start + next);
+                // A visual step that doesn't move the caret in the DOCUMENT has
+                // landed inside something atomic — an inline formula's spacer,
+                // whose every display byte maps back to the span's start. The
+                // logical stepper knows how to cross those (and how to hand the
+                // formula to its editor), so defer to it rather than sitting
+                // still.
+                if target != off {
+                    // Landing ON a spacer resolves to the span's START, and the
+                    // "is the caret inside a formula?" test wants strictly
+                    // inside — so approaching a formula from its end side, the
+                    // caret stepped to the start, failed the test, and the next
+                    // press left the formula behind. Step one byte in so the
+                    // formula opens from either side.
+                    let line_start = self.line_starts()[row];
+                    let here = off.saturating_sub(line_start);
+                    let lands_on_a_formula = markdown_syntax::inline_math_spans(self.line_str(row))
+                        .into_iter()
+                        .any(|s| {
+                            line_start + s.start == target && !(s.start < here && here < s.end)
+                        });
+                    return if lands_on_a_formula {
+                        target + 1
+                    } else {
+                        target
+                    };
+                }
             }
             // Off the end of this row: fall through to the logical neighbour,
             // which is what carries the caret onto the next row or line.
@@ -5830,6 +5856,10 @@ struct BlockImg {
 #[derive(Clone)]
 struct InlineMath {
     display_off: usize,
+    /// Byte length of the spacer this raster sits over. On an RTL row
+    /// `display_off` is its RIGHT edge, so the whole span is needed to find the
+    /// left one — see where it is painted.
+    len: usize,
     /// ABSOLUTE byte range of the `$…$` span in the document — to hit-test a click on the
     /// formula back to its edit range and to position the seated editor.
     source: Range<usize>,

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1737,6 +1737,17 @@ impl EditorState {
         self.line_inset(row) + self.rtl_shift(row)
     }
 
+    /// Does the caret's TABLE row read right-to-left? Cells step through their
+    /// own stepper, which walks in logical order — so on an RTL table the
+    /// visual arrows map to the opposite step.
+    fn caret_table_is_rtl(&self) -> bool {
+        let (row, _) = self.row_col(self.cursor_offset());
+        self.table_rows
+            .get(row)
+            .and_then(Option::as_ref)
+            .is_some_and(|t| t.rtl)
+    }
+
     /// Does the caret's line read right-to-left?
     ///
     /// Arrow keys move VISUALLY — Right steps to the character on the right of
@@ -1877,7 +1888,8 @@ impl EditorState {
             return;
         }
         if self.caret_in_table()
-            && let Some(off) = self.table_move_horizontal(-1)
+            && let Some(off) =
+                self.table_move_horizontal(if self.caret_table_is_rtl() { 1 } else { -1 })
         {
             self.move_to(off, cx);
             return;
@@ -1925,7 +1937,8 @@ impl EditorState {
             return;
         }
         if self.caret_in_table()
-            && let Some(off) = self.table_move_horizontal(1)
+            && let Some(off) =
+                self.table_move_horizontal(if self.caret_table_is_rtl() { -1 } else { 1 })
         {
             self.move_to(off, cx);
             return;
@@ -6777,6 +6790,34 @@ mod tests {
             table_left_x(px(O), px(W), total, step, true)
                 > table_left_x(px(O), px(W), total, px(0.), true)
         );
+    }
+
+    #[test]
+    fn rtl_mirrors_the_column_order() {
+        use super::tables::{cell_span_width, col_offset};
+        // Three columns, 10/20/30 wide. Left to right they start at 0/10/30;
+        // mirrored, column 0 is the RIGHTMOST, so it starts at 50.
+        let w = [px(10.), px(20.), px(30.)];
+        assert_eq!(col_offset(&w, 3, 0, false), px(0.));
+        assert_eq!(col_offset(&w, 3, 1, false), px(10.));
+        assert_eq!(col_offset(&w, 3, 2, false), px(30.));
+        assert_eq!(col_offset(&w, 3, 0, true), px(50.));
+        assert_eq!(col_offset(&w, 3, 1, true), px(30.));
+        assert_eq!(col_offset(&w, 3, 2, true), px(0.));
+        // Either way the columns tile the table with no gap or overlap — paint,
+        // caret and hit-testing all read this, so a gap is a mis-click.
+        for rtl in [false, true] {
+            let mut spans: Vec<(f32, f32)> = (0..3)
+                .map(|c| {
+                    let x = f32::from(col_offset(&w, 3, c, rtl));
+                    (x, x + f32::from(cell_span_width(&w, 3, c)))
+                })
+                .collect();
+            spans.sort_by(|a, b| a.0.total_cmp(&b.0));
+            assert_eq!(spans[0].0, 0.0);
+            assert_eq!(spans[2].1, 60.0);
+            assert!(spans.windows(2).all(|s| s[0].1 == s[1].0), "{spans:?}");
+        }
     }
 
     #[test]

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -767,6 +767,9 @@ pub struct EditorState {
     /// inset): non-zero for fenced code blocks and gutter marks (blockquotes,
     /// lists). From the last paint.
     line_insets: Vec<Pixels>,
+    /// Per-logical-line right-to-left geometry (#66), `None` on every LTR row
+    /// so an LTR document pays nothing. From the last paint. See [`RtlRow`].
+    rtl_rows: Vec<Option<RtlRow>>,
     last_bounds: Option<Bounds<Pixels>>,
     line_height: Pixels,
     /// Font size from the last paint. Hit-testing that runs during event
@@ -1011,6 +1014,7 @@ impl EditorState {
             widget_rows: Vec::new(),
             offset_maps: Vec::new(),
             line_insets: Vec::new(),
+            rtl_rows: Vec::new(),
             table_rows: Vec::new(),
             table_row_add_rects: Vec::new(),
             table_col_add_rects: Vec::new(),
@@ -1715,6 +1719,31 @@ impl EditorState {
         self.line_insets.get(row).copied().unwrap_or(px(0.))
     }
 
+    /// The right-align shift of an RTL row (zero everywhere else) — see
+    /// [`RtlRow::shift`].
+    fn rtl_shift(&self, row: usize) -> Pixels {
+        self.rtl_rows
+            .get(row)
+            .and_then(Option::as_ref)
+            .map_or(px(0.), |r| r.shift)
+    }
+
+    /// Where logical line `row`'s painted text actually starts: its inset plus
+    /// the right-align shift of an RTL row (#66). Everything that positions
+    /// against a row's text — caret, click, selection, link boxes — goes
+    /// through this, so the two can never drift apart.
+    fn row_origin_x(&self, row: usize) -> Pixels {
+        self.line_inset(row) + self.rtl_shift(row)
+    }
+
+    /// The bidi index↔x map for `row`, if it has one (see [`RtlRow`]).
+    fn bidi_map(&self, row: usize) -> Option<&gpui_bidi::VisualMap> {
+        self.rtl_rows
+            .get(row)
+            .and_then(Option::as_ref)
+            .map(|r| &r.map)
+    }
+
     /// Window-space bounds of the caret at `offset`, from the last paint's
     /// layout — for anchoring a popup (e.g. a slash menu) at a document offset.
     /// `None` before the first paint or if `offset`'s row isn't laid out.
@@ -1723,9 +1752,9 @@ impl EditorState {
         let (row, col) = self.row_col(offset);
         let lh = self.line_h(row);
         let line = self.wrapped.get(row)?;
-        let p = line.position_for_index(self.display_col(row, col), lh)?;
+        let p = line_pos(line, self.bidi_map(row), self.display_col(row, col), lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
-        let x = bounds.left() + p.x + self.line_inset(row);
+        let x = bounds.left() + p.x + self.row_origin_x(row);
         Some(Bounds::from_corners(point(x, top), point(x, top + lh)))
     }
 
@@ -4057,12 +4086,15 @@ impl EditorState {
         let Some(cur) = self
             .wrapped
             .get(row)
-            .and_then(|l| l.position_for_index(self.display_col(row, col), cur_lh))
+            .and_then(|l| line_pos(l, self.bidi_map(row), self.display_col(row, col), cur_lh))
         else {
             return self.vertical_offset(dir);
         };
         let global_y = self.line_tops[row] + cur.y;
-        let goal = self.goal_x.unwrap_or(cur.x);
+        // The goal column is the caret's *visual* x, so it carries an RTL row's
+        // right-align shift — the target row's shift comes off again below.
+        // (Row insets stay out of it, as they always have.)
+        let goal = self.goal_x.unwrap_or(cur.x + self.rtl_shift(row));
         self.goal_x = Some(goal);
         // Step to the adjacent visual row. Down: to the bottom of the current
         // row (= the top of the next one). Up: just above the current row's top
@@ -4149,10 +4181,16 @@ impl EditorState {
                 }
             }
         }
-        let rel = point(goal, (target_y - self.line_tops[trow]).max(px(0.)));
-        let col = match self.wrapped[trow].closest_index_for_position(rel, self.line_h(trow)) {
-            Ok(i) | Err(i) => i,
-        };
+        let rel = point(
+            (goal - self.rtl_shift(trow)).max(px(0.)),
+            (target_y - self.line_tops[trow]).max(px(0.)),
+        );
+        let col = line_index_at(
+            &self.wrapped[trow],
+            self.bidi_map(trow),
+            rel,
+            self.line_h(trow),
+        );
         self.line_starts()[trow] + self.source_col(trow, col)
     }
 
@@ -4410,11 +4448,14 @@ impl EditorState {
         if self.widget_rows.get(row).copied().unwrap_or(false) {
             return self.line_starts()[row];
         }
-        let x = (rel.x - self.line_inset(row)).max(px(0.));
+        let x = (rel.x - self.row_origin_x(row)).max(px(0.));
         let line_rel = point(x, rel.y - self.line_tops[row]);
-        let col = match self.wrapped[row].closest_index_for_position(line_rel, self.line_h(row)) {
-            Ok(i) | Err(i) => i,
-        };
+        let col = line_index_at(
+            &self.wrapped[row],
+            self.bidi_map(row),
+            line_rel,
+            self.line_h(row),
+        );
         self.line_starts()[row] + self.source_col(row, col)
     }
 
@@ -4721,18 +4762,19 @@ impl EntityInputHandler for EditorState {
         let (row, col) = self.row_col(range.start);
         let lh = self.line_h(row);
         let line = self.wrapped.get(row)?;
-        let p = line.position_for_index(self.display_col(row, col), lh)?;
+        let map = self.bidi_map(row);
+        let p = line_pos(line, map, self.display_col(row, col), lh)?;
         let top = bounds.top() + self.line_tops.get(row).copied().unwrap_or(px(0.)) + p.y;
-        let x = bounds.left() + p.x + self.line_inset(row);
+        let x = bounds.left() + p.x + self.row_origin_x(row);
         // Span the whole range when it stays on one wrap row (the common IME
         // composition), so the candidate window anchors under the marked TEXT
         // rather than a zero-width bar at its start. Multi-row ranges keep the
         // start-anchored bar.
         let (erow, ecol) = self.row_col(range.end);
         let x2 = if erow == row && range.end > range.start {
-            line.position_for_index(self.display_col(row, ecol), lh)
+            line_pos(line, map, self.display_col(row, ecol), lh)
                 .filter(|e| e.y == p.y)
-                .map(|e| bounds.left() + e.x + self.line_inset(row))
+                .map(|e| bounds.left() + e.x + self.row_origin_x(row))
                 .unwrap_or(x)
         } else {
             x
@@ -5876,6 +5918,9 @@ struct TableRow {
     border: Hsla,
     /// Row-shade color for striped / header-shaded styles (a faint tint).
     shade: Hsla,
+    /// The table reads right-to-left (#66) — from its region's
+    /// [`markdown_syntax::TableRegion::rtl`], so every row of one table agrees.
+    rtl: bool,
 }
 
 /// A per-line "gutter" decoration: a left-margin treatment that hides its source
@@ -6045,6 +6090,90 @@ fn display_col_in(map: Option<&std::rc::Rc<Vec<usize>>>, source_col: usize) -> u
         // just before the formula must land at the spacer's LEFT edge, not somewhere inside it.
         Some(m) => m.partition_point(|&s| s < source_col),
         None => source_col,
+    }
+}
+
+/// The painted position of display column `dcol` on a shaped line: gpui's own
+/// lookup, with the x taken from the row's bidi map when it has one (#66).
+///
+/// gpui's `x_for_index` returns the first glyph whose `index >= dcol`, and the
+/// first glyph of an RTL line carries the HIGHEST index — so every offset in
+/// the line collapses onto x = 0. The y (which wrap row) stays gpui's; a row
+/// only gets a map while it is ONE visual row, so it is always 0 there.
+/// Excludes the row's insets — callers add [`EditorState::row_origin_x`].
+fn line_pos(
+    line: &WrappedLine,
+    map: Option<&gpui_bidi::VisualMap>,
+    dcol: usize,
+    lh: Pixels,
+) -> Option<Point<Pixels>> {
+    let p = line.position_for_index(dcol, lh)?;
+    Some(match map {
+        Some(m) => point(px(m.x_for_index(dcol)), p.y),
+        None => p,
+    })
+}
+
+/// The display column a click at row-local `p` names — the inverse of
+/// [`line_pos`], through the bidi map when the row has one (gpui's
+/// `closest_index_for_x` fails on RTL the same way `x_for_index` does).
+fn line_index_at(
+    line: &WrappedLine,
+    map: Option<&gpui_bidi::VisualMap>,
+    p: Point<Pixels>,
+    lh: Pixels,
+) -> usize {
+    match map {
+        Some(m) => m.index_for_x(f32::from(p.x)),
+        None => match line.closest_index_for_position(p, lh) {
+            Ok(i) | Err(i) => i,
+        },
+    }
+}
+
+/// A right-to-left row's editor-side geometry, built in prepaint (#66).
+///
+/// Only rows whose source reads RTL ([`gpui_markdown::syntax::base_direction`])
+/// get one — the flag *is* `Option::is_some`, so an LTR document allocates
+/// nothing and keeps taking gpui's own (cheaper) lookups.
+pub(crate) struct RtlRow {
+    /// Added to the row's text origin so the line right-aligns in the content
+    /// width (see [`rtl_shift`]). Kept OUT of `line_insets` on purpose: the
+    /// list-marker + gutter math reads that, and must not move with the text.
+    shift: Pixels,
+    /// Logical↔visual mapping for the row's glyphs, so a caret/click lands on
+    /// the glyph it names. Only unwrapped rows get one (a map's x's run along
+    /// the single pre-wrap line) — see where it is built, in the prepaint.
+    map: gpui_bidi::VisualMap,
+}
+
+/// The x a right-to-left row's text starts at within `content_width`, so its
+/// *trailing* edge sits `inset` in from the right — the mirror of the leading
+/// `inset` an LTR row gets. Zero once the text no longer fits (it wraps, and
+/// every wrap row starts at the left edge).
+///
+/// Callers add this to the origin they already inset, hence the doubled
+/// `inset`: `origin + inset + shift` lands the text `inset` from the right.
+fn rtl_shift(content_width: Pixels, inset: Pixels, line_width: Pixels) -> Pixels {
+    (content_width - inset * 2. - line_width).max(px(0.))
+}
+
+/// Mirror a gutter marker's x (a bullet, a number, a checkbox) to the right
+/// edge for an RTL row, so it sits on the side the text now starts at —
+/// matching the reader's `flex_row_reverse` list items. Nesting is preserved:
+/// a deeper level's larger `marker_x` indents further from the right.
+fn rtl_marker_x(content_width: Pixels, marker_x: Pixels, marker_width: Pixels) -> Pixels {
+    (content_width - marker_x - marker_width).max(px(0.))
+}
+
+/// A task row's checkbox x within the content width, mirrored on an RTL row.
+/// One function so the prepaint hitbox (the hand cursor) and the paint (the
+/// box, and the rects a click hit-tests) can never land on different sides.
+fn checkbox_x(bullet_x: Pixels, size: Pixels, content_width: Pixels, rtl: bool) -> Pixels {
+    if rtl {
+        rtl_marker_x(content_width, bullet_x, size)
+    } else {
+        bullet_x
     }
 }
 
@@ -6366,5 +6495,126 @@ mod tests {
         );
         // Not an image row: returned unchanged.
         assert_eq!(set_image_width("just text", 100), "just text");
+    }
+
+    // --- RTL row geometry (#66) ---------------------------------------------
+
+    use super::{checkbox_x, px, rtl_marker_x, rtl_shift};
+
+    #[test]
+    fn rtl_shift_mirrors_the_row_inset() {
+        // Plain paragraph (no inset): the text's right edge meets the content
+        // edge, so the shift is all the slack.
+        assert_eq!(rtl_shift(px(500.), px(0.), px(200.)), px(300.));
+        // Inset row (a list item / blockquote body): callers add the shift to
+        // an origin they already inset, so the doubled inset leaves the SAME
+        // gap on the right that an LTR row gets on the left.
+        assert_eq!(rtl_shift(px(500.), px(24.), px(200.)), px(252.));
+        assert_eq!(px(24.) + rtl_shift(px(500.), px(24.), px(200.)), px(276.));
+        // …i.e. text spans 276..476, exactly 24 in from the right edge.
+        // Text that fills or overflows the row wraps, and every wrap row starts
+        // at the left edge — no shift, never a negative one.
+        assert_eq!(rtl_shift(px(500.), px(0.), px(500.)), px(0.));
+        assert_eq!(rtl_shift(px(500.), px(0.), px(900.)), px(0.));
+        assert_eq!(rtl_shift(px(100.), px(60.), px(50.)), px(0.));
+    }
+
+    #[test]
+    fn rtl_markers_mirror_to_the_right_edge() {
+        // A bullet 8px wide at x=10 lands 10 in from the right edge instead.
+        assert_eq!(rtl_marker_x(px(500.), px(10.), px(8.)), px(482.));
+        // Nesting is preserved: a deeper level (larger x) indents further FROM
+        // THE RIGHT, so the levels keep their order.
+        let l1 = rtl_marker_x(px(500.), px(10.), px(8.));
+        let l2 = rtl_marker_x(px(500.), px(34.), px(8.));
+        assert!(l2 < l1, "level 2 must sit further in from the right");
+        assert_eq!(l1 - l2, px(24.), "the indent step survives the mirror");
+        // Never off the left edge, however wide the marker.
+        assert_eq!(rtl_marker_x(px(20.), px(10.), px(40.)), px(0.));
+        // The checkbox shares that math, and an LTR row is untouched.
+        assert_eq!(checkbox_x(px(10.), px(12.), px(500.), true), px(478.));
+        assert_eq!(checkbox_x(px(10.), px(12.), px(500.), false), px(10.));
+    }
+
+    // --- RTL table placement (#66) ------------------------------------------
+
+    use super::tables::{TABLE_GUTTER, table_left_x, table_visible_band};
+
+    /// The note column used throughout: origin 100, width 500 → the LTR band
+    /// is 122..600 and the RTL band 100..578, both `TABLE_GUTTER` wide.
+    const O: f32 = 100.;
+    const W: f32 = 500.;
+
+    #[test]
+    fn an_rtl_table_hugs_the_right_edge_with_the_gutter_mirrored() {
+        let g = TABLE_GUTTER;
+        // A table narrower than the column: LTR starts a gutter in from the
+        // left, RTL *ends* a gutter in from the right.
+        let ltr = table_left_x(px(O), px(W), px(300.), px(0.), false);
+        let rtl = table_left_x(px(O), px(W), px(300.), px(0.), true);
+        assert_eq!(ltr, px(O + g));
+        assert_eq!(rtl + px(300.), px(O + W - g), "right edge, one gutter in");
+        // The two are mirror images about the column's centre.
+        assert_eq!(
+            f32::from(ltr - px(O)),
+            f32::from(px(O + W) - (rtl + px(300.)))
+        );
+        // Column widths don't move an LTR table but do move an RTL one — it is
+        // anchored at its trailing edge.
+        assert_eq!(
+            table_left_x(px(O), px(W), px(120.), px(0.), false),
+            px(O + g)
+        );
+        assert_eq!(
+            table_left_x(px(O), px(W), px(120.), px(0.), true),
+            px(O + W - g - 120.)
+        );
+    }
+
+    #[test]
+    fn a_wide_table_scrolls_to_its_own_far_edge_either_way() {
+        let g = TABLE_GUTTER;
+        let total = px(900.);
+        let avail = px(W - g); // what `table_sx` clamps against
+        let max = total - avail;
+        // Unscrolled, each direction shows its own leading edge at the gutter.
+        assert_eq!(table_left_x(px(O), px(W), total, px(0.), false), px(O + g));
+        assert_eq!(
+            table_left_x(px(O), px(W), total, px(0.), true) + total,
+            px(O + W - g)
+        );
+        // Fully scrolled, each shows its trailing edge at the band's far side:
+        // LTR's right edge reaches the column's right, RTL's left edge the left.
+        assert_eq!(
+            table_left_x(px(O), px(W), total, max, false) + total,
+            px(O + W)
+        );
+        assert_eq!(table_left_x(px(O), px(W), total, max, true), px(O));
+        // Scroll moves the content in OPPOSITE directions — why the wheel and
+        // the thumb's `factor` invert their sign on an RTL table.
+        let step = px(50.);
+        assert!(table_left_x(px(O), px(W), total, step, false) < px(O + g));
+        assert!(
+            table_left_x(px(O), px(W), total, step, true)
+                > table_left_x(px(O), px(W), total, px(0.), true)
+        );
+    }
+
+    #[test]
+    fn the_visible_band_is_the_column_less_its_gutter() {
+        let g = TABLE_GUTTER;
+        assert_eq!(
+            table_visible_band(px(O), px(W), false),
+            (px(O + g), px(O + W))
+        );
+        assert_eq!(
+            table_visible_band(px(O), px(W), true),
+            (px(O), px(O + W - g))
+        );
+        // Both bands are the `avail` width the scroll clamp assumes.
+        for rtl in [false, true] {
+            let (l, r) = table_visible_band(px(O), px(W), rtl);
+            assert_eq!(r - l, px(W - g));
+        }
     }
 }

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -1942,6 +1942,9 @@ pub(crate) fn inline_math_spans(line: &str) -> Vec<Range<usize>> {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct InlineMathPlace {
     pub display_off: usize,
+    /// Byte length of the spacer. Needed to place the raster on an RTL row,
+    /// where `display_off` is the spacer's RIGHT edge, not its left.
+    pub len: usize,
     pub source: Range<usize>,
 }
 
@@ -2005,6 +2008,7 @@ pub(crate) fn splice_inline_math(
         // The spacer, mapped back to the span start.
         places.push(InlineMathPlace {
             display_off: nd.len(),
+            len: *n,
             source: src.clone(),
         });
         let src_at = map.get(d0).copied().unwrap_or(src.start);
@@ -2452,6 +2456,7 @@ mod tests {
             places,
             vec![InlineMathPlace {
                 display_off: 2,
+                len: 3,
                 source: 2..5
             }]
         );
@@ -2478,10 +2483,12 @@ mod tests {
             vec![
                 InlineMathPlace {
                     display_off: 0,
+                    len: 2,
                     source: 0..3
                 },
                 InlineMathPlace {
                     display_off: 7,
+                    len: 4,
                     source: 8..11
                 },
             ]

--- a/crates/gpui-editor/src/markdown_syntax.rs
+++ b/crates/gpui-editor/src/markdown_syntax.rs
@@ -2059,6 +2059,10 @@ pub(crate) struct TableRegion {
     /// Explicit column widths (logical px) from the marker's `cols=` attribute
     /// — written by drag-to-resize; `None` = content-measured.
     pub col_widths_attr: Option<Vec<f32>>,
+    /// The table reads right-to-left (#66), so its grid hugs the note column's
+    /// RIGHT edge with the 22px gutter on the other side — the reader's
+    /// `.mr(22).ml_auto()`. Column ORDER is not mirrored; see [`EditorState::table_left`].
+    pub rtl: bool,
 }
 
 /// Detect GFM table regions in `content` (W4c). A region is a row line (trimmed
@@ -2096,12 +2100,19 @@ pub(crate) fn table_regions(content: &str) -> Vec<TableRegion> {
             };
             let col_widths_attr =
                 marker_line.and_then(|m| gpui_markdown::syntax::table_col_widths(lines[m]));
+            // Writing direction of the whole table (#66) — the reader runs
+            // `base_direction` over the table's byte span, so join the region's
+            // lines and ask the same question: the first strong character
+            // anywhere in the table decides (pipes, dashes and digits are
+            // neutral under UAX #9). Once per scan, not per frame.
+            let rtl = gpui_markdown::syntax::base_direction(&lines[start..end].join("\n")).is_rtl();
             out.push(TableRegion {
                 lines: start..end,
                 aligns,
                 style,
                 marker_line,
                 col_widths_attr,
+                rtl,
             });
             i = end;
         } else {

--- a/crates/gpui-editor/src/tables.rs
+++ b/crates/gpui-editor/src/tables.rs
@@ -36,12 +36,12 @@ impl EditorState {
     /// hit-tests, caret, selection, affordances).
     pub(crate) fn table_left(&self, t: &TableRow, row: usize, bounds: &Bounds<Pixels>) -> Pixels {
         let total: Pixels = t.col_widths.iter().copied().sum();
-        bounds.origin.x + px(TABLE_GUTTER)
-            - self.table_sx(
-                table_header_row(t, row),
-                total,
-                bounds.size.width - px(TABLE_GUTTER),
-            )
+        let sx = self.table_sx(
+            table_header_row(t, row),
+            total,
+            bounds.size.width - px(TABLE_GUTTER),
+        );
+        table_left_x(bounds.origin.x, bounds.size.width, total, sx, t.rtl)
     }
 
     /// The clamped horizontal scroll of the table headed at `header_row`.
@@ -112,7 +112,9 @@ impl EditorState {
         }
         let max = f32::from(total - avail);
         let cur = self.table_scroll_x.get(&header).copied().unwrap_or(0.);
-        let new = (cur - dx).clamp(0., max);
+        // An RTL table's scroll offset runs the other way (see `table_left_x`),
+        // so the same physical swipe moves its content the same physical way.
+        let new = if t.rtl { cur + dx } else { cur - dx }.clamp(0., max);
         if new != cur {
             self.table_scroll_x.insert(header, new);
             cx.notify();
@@ -1108,6 +1110,44 @@ pub(crate) struct TableThumb {
     /// Content px scrolled per px of thumb travel.
     pub(crate) factor: f32,
     pub(crate) color: Hsla,
+}
+
+/// The table content's LEFT x, given the note column's `origin`/`width`, the
+/// table's `total` width and its already-clamped horizontal scroll `sx`.
+///
+/// LTR sits `TABLE_GUTTER` in from the left edge (the row handles live in that
+/// gutter) and scrolls leftward. An RTL table mirrors it (#66): the grid hugs
+/// the RIGHT edge with the gutter on the other side — the reader's
+/// `.mr(22).ml_auto()` — and its scroll reveals content to the left. Either
+/// way the visible band is `TABLE_GUTTER` narrower than the note column, so
+/// [`EditorState::table_sx`]'s clamp is direction-agnostic.
+///
+/// The single source for every x on a table: paint, hit-tests, the caret,
+/// the resize bands and the add/delete affordances all derive from it, so
+/// they cannot drift apart.
+pub(crate) fn table_left_x(
+    origin: Pixels,
+    width: Pixels,
+    total: Pixels,
+    sx: Pixels,
+    rtl: bool,
+) -> Pixels {
+    if rtl {
+        origin + width - px(TABLE_GUTTER) - total + sx
+    } else {
+        origin + px(TABLE_GUTTER) - sx
+    }
+}
+
+/// The x band a table is visible in: the note column less its gutter, on the
+/// side [`table_left_x`] put the gutter. Clamps the scroll thumb's track and a
+/// wide table's selection highlight.
+pub(crate) fn table_visible_band(origin: Pixels, width: Pixels, rtl: bool) -> (Pixels, Pixels) {
+    if rtl {
+        (origin, origin + width - px(TABLE_GUTTER))
+    } else {
+        (origin + px(TABLE_GUTTER), origin + width)
+    }
 }
 
 /// The header row of the table that `t` (the grid row at line `row`) belongs

--- a/crates/gpui-editor/src/tables.rs
+++ b/crates/gpui-editor/src/tables.rs
@@ -227,19 +227,24 @@ impl EditorState {
             .unwrap_or_else(|| window.text_style().font());
         let font_size = self.font_size;
         let pad = px(TABLE_CELL_PAD);
-        // Column the click is in, and its left x.
-        let last = t.col_widths.len() - 1;
-        let mut cx = px(0.);
-        let mut cell = 0;
-        for (c, &cw) in t.col_widths.iter().enumerate() {
-            if rel.x < cx + cw || c == last {
+        // Column the click is in, and its left x — through the same mirrored
+        // mapping the cells were painted with, or a click lands in a different
+        // cell than the one under the pointer (on an RTL table the columns run
+        // the other way, so accumulating left-to-right picks the mirror image).
+        let total: Pixels = t.col_widths.iter().copied().sum();
+        // Columns tile the table exactly, so a clamped x always lands in one.
+        let hit_x = rel.x.max(px(0.)).min(total - px(0.01));
+        let mut cell = t.col_widths.len() - 1;
+        for c in 0..t.col_widths.len() {
+            let x = col_offset(&t.col_widths, t.cells.len(), c, t.rtl);
+            if hit_x >= x && hit_x < x + cell_span_width(&t.col_widths, t.cells.len(), c) {
                 cell = c;
                 break;
             }
-            cx += cw;
         }
         // A click in a spanned trailing column lands in the short row's last cell.
         let cell = cell.min(t.cells.len().saturating_sub(1));
+        let cx = col_offset(&t.col_widths, t.cells.len(), cell, t.rtl);
         let content = t.cells.get(cell)?;
         let cw = cell_span_width(&t.col_widths, t.cells.len(), cell);
         let cf = cell_font(&font, t.is_header);
@@ -252,6 +257,9 @@ impl EditorState {
             match t.aligns.get(cell) {
                 Some(markdown_syntax::Align::Center) => (avail - full_w).max(px(0.)) / 2.,
                 Some(markdown_syntax::Align::Right) => (avail - full_w).max(px(0.)),
+                // Unaligned cells follow the table's direction — same rule the
+                // paint uses, so the hit-test matches what's on screen.
+                _ if t.rtl => (avail - full_w).max(px(0.)),
                 _ => px(0.),
             }
         };
@@ -1163,6 +1171,21 @@ fn table_header_row(t: &TableRow, row: usize) -> usize {
 /// The width available to cell `c` of a row with `cells_len` cells: a short
 /// row's LAST cell spans the remaining columns (reader parity — e.g. a
 /// two-cell header over a wider body), otherwise its own column.
+/// Distance from the table's LEFT edge to column `c`'s left edge.
+///
+/// Mirrored for an RTL table, so column 0 sits at the right — matching the
+/// reader's `flex_row_reverse`. Every place that turns a column into an x goes
+/// through this: paint, caret, selection bands, resize grips. They have to
+/// agree, or clicking lands in a different cell than the one drawn there.
+pub(crate) fn col_offset(col_widths: &[Pixels], cells_len: usize, c: usize, rtl: bool) -> Pixels {
+    let before: Pixels = col_widths[..c.min(col_widths.len())].iter().copied().sum();
+    if !rtl {
+        return before;
+    }
+    let total: Pixels = col_widths.iter().copied().sum();
+    total - before - cell_span_width(col_widths, cells_len, c)
+}
+
 pub(crate) fn cell_span_width(col_widths: &[Pixels], cells_len: usize, c: usize) -> Pixels {
     if c + 1 == cells_len && cells_len < col_widths.len() {
         col_widths[c..].iter().copied().sum()
@@ -1226,10 +1249,7 @@ pub(crate) fn table_caret_pos(
     let range = t.cell_ranges.get(cell)?;
     let content = t.cells.get(cell)?;
     let in_cell = col.saturating_sub(range.start).min(content.len());
-    let cell_x = left
-        + t.col_widths[..cell.min(t.col_widths.len())]
-            .iter()
-            .sum::<Pixels>();
+    let cell_x = left + col_offset(&t.col_widths, t.cell_ranges.len(), cell, t.rtl);
     let cw = cell_span_width(&t.col_widths, t.cell_ranges.len(), cell);
     // The header is bold, so shape with the bold font or the caret lands left of
     // the (wider) bold glyphs; position_for_index gives the exact kerned x — and,
@@ -1245,8 +1265,17 @@ pub(crate) fn table_caret_pos(
         Some(avail),
         Hsla::default(),
     )?;
-    let pos = wl.position_for_index(in_cell, line_h).unwrap_or_default();
+    let mut pos = wl.position_for_index(in_cell, line_h).unwrap_or_default();
     let wrapped = !wl.wrap_boundaries().is_empty();
+    // A cell holding right-to-left text needs the same index↔x map the rest of
+    // the editor uses: gpui's `position_for_index` collapses every offset in an
+    // RTL run onto one x, which is a caret that won't move through the word.
+    // Only an unwrapped cell can use it — a map's x's run along the single
+    // pre-wrap line (same limit as elsewhere).
+    if !wrapped && gpui_markdown::syntax::contains_rtl(content) {
+        let map = gpui_bidi::shaped::map_of_wrapped(&wl, content.len());
+        pos.x = px(map.x_for_index(in_cell));
+    }
     let full_w = wl.width();
     // Alignment shifts only unwrapped content (a wrapped cell fills its width).
     let align_off = if wrapped {
@@ -1283,6 +1312,11 @@ fn cell_offset_for_point(
     ) else {
         return 0;
     };
+    if wl.wrap_boundaries().is_empty() && gpui_markdown::syntax::contains_rtl(content) {
+        // Same reason as the caret above, in reverse.
+        let map = gpui_bidi::shaped::map_of_wrapped(&wl, content.len());
+        return map.index_for_x(f32::from(target.x));
+    }
     match wl.closest_index_for_position(
         point(
             target.x,
@@ -1348,14 +1382,17 @@ pub(crate) fn paint_table_row(
     if t.is_header {
         cell_font.weight = gpui::FontWeight::BOLD;
     }
-    let mut x = origin.x;
     for (c, &cw) in t.col_widths.iter().enumerate() {
+        let x = origin.x + col_offset(&t.col_widths, t.cells.len(), c, t.rtl);
         // Inner cell separator at the left of every cell except the first (Grid
         // only; the other styles drop vertical lines). A short row draws no
         // dividers past its last cell — that cell spans the remaining columns.
         if vlines && c > 0 && c < t.cells.len() {
+            // The divider goes on the column's LEADING edge — its right on an
+            // RTL table, where reading starts.
+            let dx = if t.rtl { x + cw - thick } else { x };
             window.paint_quad(fill(
-                Bounds::new(point(x, origin.y), size(thick, row_h)),
+                Bounds::new(point(dx, origin.y), size(thick, row_h)),
                 t.border,
             ));
         }
@@ -1372,6 +1409,9 @@ pub(crate) fn paint_table_row(
                 let align = match t.aligns.get(c) {
                     Some(markdown_syntax::Align::Center) => gpui::TextAlign::Center,
                     Some(markdown_syntax::Align::Right) => gpui::TextAlign::Right,
+                    // No explicit alignment: follow the table's direction, so
+                    // RTL cells start at the right like their text does.
+                    _ if t.rtl => gpui::TextAlign::Right,
                     _ => gpui::TextAlign::Left,
                 };
                 let _ = shaped.paint(
@@ -1387,7 +1427,6 @@ pub(crate) fn paint_table_row(
                 );
             }
         }
-        x += cw;
     }
 }
 

--- a/crates/gpui-markdown/API.md
+++ b/crates/gpui-markdown/API.md
@@ -36,7 +36,9 @@ isn't public. Feature `—` = always compiled (`gpui_markdown::syntax`);
 | [`heading_scale`](#heading_scale) | fn | `fn heading_scale(depth: u8) -> f32` | Font-size multiplier for h1–h6 | — |
 | [`ordered_marker`](#ordered_marker) | fn | `fn ordered_marker(depth: usize, n: u32) -> String` | Word-style list marker (`1.` → `a.` → `i.`) | — |
 | [`LinkHit`](#enum-linkhit) | enum | `Page(String) \| Url(String)` | What a clicked link-like construct targets | — |
-| [`is_safe_external_url`](#is_safe_external_url) | fn | `fn is_safe_external_url(url: &str) -> bool` | May this URL reach the OS opener? (http/https only) | — |
+| [`is_safe_external_url`](#is_safe_external_url) | fn | `fn is_safe_external_url(url: &str) -> bool` | May this URL reach the OS opener? (http/https/mailto only) | — |
+| [`Direction`](#base_direction) | enum | `Ltr \| Rtl` | A block's base writing direction | — |
+| [`base_direction`](#base_direction) | fn | `fn base_direction(text: &str) -> Direction` | First-strong-character direction (UAX #9 P2/P3) | — |
 | [`wiki_target_display`](#wiki_target_display) | fn | `fn wiki_target_display(inner: &str) -> (&str, &str)` | Split `target\|label` into `(target, display)` | — |
 | [`is_tag_char`](#is_tag_char--is_word_char) | fn | `fn is_tag_char(c: u8) -> bool` | Byte valid inside a `#tag` name | — |
 | [`is_word_char`](#is_tag_char--is_word_char) | fn | `fn is_word_char(c: u8) -> bool` | Word byte for boundary checks | — |
@@ -427,6 +429,47 @@ What a click on a link-like construct targets.
 
 ---
 
+## `base_direction`
+
+```rust
+pub enum Direction { Ltr, Rtl }
+impl Direction { pub fn is_rtl(self) -> bool }
+
+pub fn base_direction(text: &str) -> Direction
+```
+
+A block's base writing direction, decided by its first **strong** directional
+character — Unicode UAX #9 rules P2/P3, the same rule browsers' `dir=auto` and
+Logseq use. Hosts apply it per block: the reader right-aligns RTL prose and
+flips the list-marker side.
+
+**Returns** — `Rtl` if the first strong character is Hebrew, Arabic (including
+Persian and Urdu), Syriac, Thaana, N'Ko, Samaritan, Mandaic, or an Arabic
+presentation form; `Ltr` otherwise, including for text with no strong
+character at all.
+
+**Guarantees & edge cases**
+
+- Neutrals are skipped, which is what makes it usable on raw markdown: list
+  markers, heading `#`s, quote `>`s, digits, punctuation, and whitespace all
+  pass through, so `- سلام` and `## سلام` both detect as `Rtl`.
+- The FIRST strong character wins, not the majority — `Rust سلام دنیا` is
+  `Ltr` and `سلام Rust` is `Rtl`. That's the rule that lets a mixed note put
+  each line in its own direction.
+- Empty or neutral-only text (`""`, `"123 — !?"`) is `Ltr`.
+- CJK, Cyrillic, Greek, and Indic scripts are `Ltr` (strong-LTR is
+  "alphabetic and not strong-RTL").
+- Script ranges, not a bidi-class table: the strong-RTL blocks are contiguous
+  and stable, and this predicate isn't worth a Unicode-table dependency.
+
+**Not** a bidi implementation. It gives a *paragraph* direction only. Mixed
+runs inside a line are reordered by the platform shaper (CoreText,
+cosmic-text), which already handles them correctly — but note that gpui's
+`LineLayout` index↔x mapping does not, so this is safe for read-only rendering
+and not sufficient for a text editor's caret.
+
+---
+
 ## `is_safe_external_url`
 
 ```rust
@@ -440,8 +483,11 @@ handler owns the scheme: `file:` launches local content, `smb:` leaks NTLM
 hashes on Windows, `javascript:`/`data:`/app-registered schemes (`ms-msdt:` …)
 run code. So this is an **allowlist**, not a denylist.
 
-**Returns** — `true` only for `http://` and `https://`. The scheme is compared
-case-insensitively (RFC 3986), so `HTTPS://` passes.
+**Returns** — `true` only for `http://`, `https://`, and `mailto:`. The scheme
+is compared case-insensitively (RFC 3986), so `HTTPS://` passes. `mailto:` is
+allowed because `[write us](mailto:x@y.com)` is ordinary markdown and it opens
+a compose window rather than running anything; the mail client owns parsing
+its query.
 
 **Guarantees & edge cases**
 

--- a/crates/gpui-markdown/API.md
+++ b/crates/gpui-markdown/API.md
@@ -39,6 +39,9 @@ isn't public. Feature `—` = always compiled (`gpui_markdown::syntax`);
 | [`is_safe_external_url`](#is_safe_external_url) | fn | `fn is_safe_external_url(url: &str) -> bool` | May this URL reach the OS opener? (http/https/mailto only) | — |
 | [`Direction`](#base_direction) | enum | `Ltr \| Rtl` | A block's base writing direction | — |
 | [`base_direction`](#base_direction) | fn | `fn base_direction(text: &str) -> Direction` | First-strong-character direction (UAX #9 P2/P3) | — |
+| [`content_direction`](#content_direction) | fn | `fn content_direction(line: &str) -> Direction` | Direction of a markdown line's CONTENT, ignoring its markers | — |
+| [`content_direction_opt`](#content_direction) | fn | `fn content_direction_opt(line: &str) -> Option<Direction>` | Same, `None` when the line has no strong character | — |
+| [`contains_rtl`](#contains_rtl) | fn | `fn contains_rtl(text: &str) -> bool` | Does the text hold ANY right-to-left character? | — |
 | [`wiki_target_display`](#wiki_target_display) | fn | `fn wiki_target_display(inner: &str) -> (&str, &str)` | Split `target\|label` into `(target, display)` | — |
 | [`is_tag_char`](#is_tag_char--is_word_char) | fn | `fn is_tag_char(c: u8) -> bool` | Byte valid inside a `#tag` name | — |
 | [`is_word_char`](#is_tag_char--is_word_char) | fn | `fn is_word_char(c: u8) -> bool` | Word byte for boundary checks | — |
@@ -466,9 +469,66 @@ character at all.
 
 **Not** a bidi implementation. It gives a *paragraph* direction only. Mixed
 runs inside a line are reordered by the platform shaper (CoreText,
-cosmic-text), which already handles them correctly — but note that gpui's
-`LineLayout` index↔x mapping does not, so this is safe for read-only rendering
-and not sufficient for a text editor's caret.
+cosmic-text), which already handles them correctly. gpui's `LineLayout`
+index↔x mapping does **not** — that is what the `gpui-bidi` crate exists for,
+and both this renderer and the editor go through it for caret placement,
+selection and hit-testing.
+
+**Use [`content_direction`](#content_direction) for a markdown source line.**
+Neutrals pass through here, but markdown supplies *strong* characters of its
+own: the `x` in `- [x]` and the label in `> [!NOTE]` are strong left-to-right,
+so a completed task and every alert read `Ltr` whatever their prose says.
+
+---
+
+## `content_direction`
+
+```rust
+pub fn content_direction(line: &str) -> Direction
+pub fn content_direction_opt(line: &str) -> Option<Direction>
+```
+
+The direction of a source line's **content**, with its markdown markers
+skipped: blockquote arrows, list bullets, ordered markers, task boxes, heading
+hashes, GitHub alert markers (`[!NOTE]`) and the Obsidian fold char after one.
+
+**Why it isn't [`base_direction`](#base_direction)** — that takes the first
+strong character, and markers can supply one. The `x` in `- [x] یک کار` and the
+`N` in `> [!NOTE]` are both strong left-to-right, so a completed task read
+`Ltr` while the identical unchecked line read `Rtl`, and the two sat on
+opposite sides of the note.
+
+**`_opt` and the `None` case** — a line can have no direction of its own: it is
+blank, or nothing but markers. `> [!NOTE]` strips to nothing. Answering `Ltr`
+there put a callout's title on one side and its body on the other, so callers
+that care take the surrounding text's direction instead. `content_direction`
+flattens `None` to `Ltr` for callers that don't.
+
+**Guarantees & edge cases**
+
+- Markers are stripped repeatedly, so nested forms work: `> - [ ] متن`.
+- Latin content still reads `Ltr`, markers or not.
+- What remains after stripping is passed to [`base_direction`](#base_direction),
+  so all of its rules (first strong wins, neutrals skipped) apply to it.
+
+---
+
+## `contains_rtl`
+
+```rust
+pub fn contains_rtl(text: &str) -> bool
+```
+
+Whether `text` holds **any** right-to-left character.
+
+Distinct from [`base_direction`](#base_direction), which answers which side a
+line starts on. A line can read left-to-right and still hold a Persian name in
+the middle, and that run needs the same logical↔visual mapping an RTL line
+does — the caret misplaces inside it otherwise. Both views use this to decide
+whether a line needs bidi layout at all, while `base_direction` decides which
+way it aligns.
+
+**Cost** — one pass over the chars, early-exit on the first hit; no allocation.
 
 ---
 

--- a/crates/gpui-markdown/Cargo.toml
+++ b/crates/gpui-markdown/Cargo.toml
@@ -9,9 +9,15 @@ license = "GPL-3.0-or-later"
 default = ["view"]
 # The reader view (MarkdownView + renderers). Without it the crate is just
 # `syntax` — the dependency-free construct recognition gpui-editor consumes.
-view = ["dep:gpui", "dep:markdown"]
+view = ["dep:gpui", "dep:markdown", "dep:gpui-bidi"]
 
 [dependencies]
 # Shared workspace spec (the root pins the rev) so Cargo unifies to one gpui.
 gpui = { workspace = true, optional = true }
 markdown = { version = "1", optional = true }
+
+# Logical-order line breaking for RTL paragraphs (#66). gpui wraps by
+# slicing the already-reordered glyph run, which puts an RTL paragraph's
+# last words in its first row; `RtlText` breaks the text instead. A leaf
+# utility crate, depended on by both renderers (see AGENTS.md).
+gpui-bidi = { path = "../gpui-bidi", optional = true }

--- a/crates/gpui-markdown/README.md
+++ b/crates/gpui-markdown/README.md
@@ -35,6 +35,13 @@ This is **the** markdown crate of the Zorite workspace, in two layers:
 - GFM **tables** — content-measured columns, column alignment, plus **per-table
   visual designs** (striped / header-shaded / minimal) chosen by a hidden
   `<!-- table:STYLE -->` marker
+- **Bidirectional text** — a block containing right-to-left prose is broken in
+  *logical* order and laid out row by row via
+  [`gpui-bidi`](../gpui-bidi/README.md), then mirrored: alignment, list markers,
+  quote and callout rules, table column order, property rows. Links keep their
+  colour, hitboxes and hover cursor inside reordered runs, and inline rasters
+  sit on their spacer's real visual box. A left-to-right block containing a
+  Persian phrase gets the mapping but stays left-aligned.
 - **GitHub alerts** — `> [!NOTE]` / `[!TIP]` / `[!IMPORTANT]` / `[!WARNING]` /
   `[!CAUTION]` blockquotes render with a colored bar, bold title, and optional
   host-supplied icons; the natural inline form (`> [!NOTE] like so`) works too.

--- a/crates/gpui-markdown/src/syntax.rs
+++ b/crates/gpui-markdown/src/syntax.rs
@@ -362,6 +362,90 @@ pub fn base_direction(text: &str) -> Direction {
     Direction::Ltr
 }
 
+/// The direction of a source line's CONTENT, ignoring its markdown markers.
+///
+/// [`base_direction`] takes the first strong character, and a marker can supply
+/// one: the `x` in `- [x] یک کار` is strong left-to-right, so a COMPLETED task
+/// read as LTR while the identical unchecked line read as RTL, and the two sat
+/// on opposite sides of the note. Blockquote arrows, list bullets, task boxes
+/// and heading hashes are syntax, not prose, so they are skipped first.
+pub fn content_direction(line: &str) -> Direction {
+    content_direction_opt(line).unwrap_or(Direction::Ltr)
+}
+
+/// [`content_direction`], but `None` when the line has no strong character at
+/// all — it is blank, or nothing but markers.
+///
+/// `> [!NOTE]` is the case that matters: strip the quote arrow and the alert
+/// marker and nothing is left, so the line has no direction of its own and must
+/// take the surrounding text's. Answering `Ltr` there put a Persian callout's
+/// title on one side and its body on the other.
+pub fn content_direction_opt(line: &str) -> Option<Direction> {
+    let mut rest = line.trim_start();
+    loop {
+        let before = rest;
+        // Blockquote markers, however deep.
+        rest = rest.strip_prefix('>').unwrap_or(rest).trim_start();
+        // A bullet, or an ordered marker like `12.` / `3)`.
+        if let Some(r) = rest
+            .strip_prefix("- ")
+            .or_else(|| rest.strip_prefix("* "))
+            .or_else(|| rest.strip_prefix("+ "))
+        {
+            rest = r.trim_start();
+        } else {
+            let digits = rest.chars().take_while(char::is_ascii_digit).count();
+            if digits > 0
+                && let Some(r) = rest[digits..]
+                    .strip_prefix(". ")
+                    .or_else(|| rest[digits..].strip_prefix(") "))
+            {
+                rest = r.trim_start();
+            }
+        }
+        // A GitHub alert marker (`[!NOTE]`, `[!TIP]` …), plus the Obsidian
+        // fold char after it. Its LABEL is Latin, so it decided the direction
+        // of every Persian callout — the same trap the task box set.
+        if let Some(r) = rest.strip_prefix("[!")
+            && let Some(close) = r.find(']')
+        {
+            let after = &r[close + 1..];
+            rest = after
+                .strip_prefix('-')
+                .or_else(|| after.strip_prefix('+'))
+                .unwrap_or(after)
+                .trim_start();
+        }
+        // A task box — the one that started this.
+        if let Some(r) = rest
+            .strip_prefix("[ ] ")
+            .or_else(|| rest.strip_prefix("[x] "))
+            .or_else(|| rest.strip_prefix("[X] "))
+        {
+            rest = r.trim_start();
+        }
+        // Heading hashes.
+        if rest.starts_with('#') {
+            let hashes = rest.chars().take_while(|c| *c == '#').count();
+            if let Some(r) = rest[hashes..].strip_prefix(' ') {
+                rest = r.trim_start();
+            }
+        }
+        if rest == before {
+            break;
+        }
+    }
+    rest.chars().find_map(|c| {
+        if is_strong_rtl(c) {
+            Some(Direction::Rtl)
+        } else if is_strong_ltr(c) {
+            Some(Direction::Ltr)
+        } else {
+            None
+        }
+    })
+}
+
 /// Does `text` contain ANY right-to-left character?
 ///
 /// Distinct from [`base_direction`], which answers which side a line starts on.
@@ -967,6 +1051,29 @@ mod tests {
             normalize_math_fences("$$y$$"),
             std::borrow::Cow::Borrowed(_)
         ));
+    }
+
+    #[test]
+    fn markers_do_not_decide_a_line_s_direction() {
+        // The bug: `x` is strong left-to-right, so a COMPLETED task read LTR
+        // while the same line unchecked read RTL — the two sat on opposite
+        // sides of the note.
+        assert!(content_direction("- [x] یک کار انجام‌شده").is_rtl());
+        assert!(content_direction("- [ ] یک کار انجام‌نشده").is_rtl());
+        assert!(content_direction("- مورد فهرست").is_rtl());
+        assert!(content_direction("1. مورد شماره‌دار").is_rtl());
+        assert!(content_direction("## سلام دنیا").is_rtl());
+        assert!(content_direction("> یک نقل‌قول").is_rtl());
+        // An alert's label is Latin whatever the prose is.
+        assert!(content_direction("> [!NOTE]\n> یک هشدار فارسی").is_rtl());
+        assert!(content_direction("> [!WARNING]- یک هشدار").is_rtl());
+        assert!(!content_direction("> [!NOTE]\n> an english callout").is_rtl());
+        assert!(!content_direction("> > [!NOTE]\n").is_rtl(), "no content");
+        // Latin content still reads left-to-right, markers or not.
+        assert!(!content_direction("- [x] a done task").is_rtl());
+        assert!(!content_direction("## English heading").is_rtl());
+        // A line that is only markers has no direction of its own.
+        assert!(!content_direction("- [ ] ").is_rtl());
     }
 
     #[test]

--- a/crates/gpui-markdown/src/syntax.rs
+++ b/crates/gpui-markdown/src/syntax.rs
@@ -326,6 +326,67 @@ pub fn is_safe_external_url(url: &str) -> bool {
         })
 }
 
+/// A block's base writing direction.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum Direction {
+    #[default]
+    Ltr,
+    Rtl,
+}
+
+impl Direction {
+    pub fn is_rtl(self) -> bool {
+        self == Direction::Rtl
+    }
+}
+
+/// The base direction of `text`, by the first *strong* directional character
+/// (Unicode UAX #9 rules P2/P3 — the same rule Logseq and browsers' `dir=auto`
+/// use). Neutral characters (digits, punctuation, whitespace, markdown
+/// markers) are skipped, so `- سلام` and `## سلام` detect as RTL; text with no
+/// strong character at all is LTR.
+///
+/// Ranges rather than a full Unicode table: the strong-RTL blocks are
+/// contiguous and stable (Hebrew, Arabic and its supplements, Syriac, Thaana,
+/// N'Ko, Samaritan, Mandaic, plus the Arabic presentation forms), and pulling
+/// a bidi-class table in for one predicate isn't worth the dependency.
+pub fn base_direction(text: &str) -> Direction {
+    for c in text.chars() {
+        if is_strong_rtl(c) {
+            return Direction::Rtl;
+        }
+        if is_strong_ltr(c) {
+            return Direction::Ltr;
+        }
+    }
+    Direction::Ltr
+}
+
+/// Strong right-to-left: Hebrew through Arabic-script languages.
+fn is_strong_rtl(c: char) -> bool {
+    matches!(c,
+        '\u{0590}'..='\u{05FF}'   // Hebrew
+        | '\u{0600}'..='\u{06FF}' // Arabic (incl. Persian, Urdu)
+        | '\u{0700}'..='\u{074F}' // Syriac
+        | '\u{0750}'..='\u{077F}' // Arabic Supplement
+        | '\u{0780}'..='\u{07BF}' // Thaana
+        | '\u{07C0}'..='\u{07FF}' // N'Ko
+        | '\u{0800}'..='\u{083F}' // Samaritan
+        | '\u{0840}'..='\u{085F}' // Mandaic
+        | '\u{08A0}'..='\u{08FF}' // Arabic Extended-A
+        | '\u{FB1D}'..='\u{FDFF}' // Hebrew/Arabic presentation forms
+        | '\u{FE70}'..='\u{FEFF}' // Arabic presentation forms-B
+    )
+}
+
+/// Strong left-to-right — Latin/Greek/Cyrillic and the CJK/Indic scripts.
+/// Deliberately approximate in the same direction as [`is_strong_rtl`]: what
+/// matters is that a strong LTR character stops the scan, and every alphabetic
+/// character that isn't strong-RTL does.
+fn is_strong_ltr(c: char) -> bool {
+    c.is_alphabetic() && !is_strong_rtl(c)
+}
+
 /// Split a wiki-link's inner text into `(target, display)`:
 /// `target|label` shows `label` (falling back to the target when the label is
 /// empty); `name` shows itself. Both sides trimmed.
@@ -896,6 +957,33 @@ mod tests {
             normalize_math_fences("$$y$$"),
             std::borrow::Cow::Borrowed(_)
         ));
+    }
+
+    #[test]
+    fn base_direction_follows_the_first_strong_character() {
+        use Direction::*;
+        // Plain cases.
+        assert_eq!(base_direction("hello"), Ltr);
+        assert_eq!(base_direction("سلام دنیا"), Rtl); // Persian
+        assert_eq!(base_direction("שלום עולם"), Rtl); // Hebrew
+        // Neutrals lead — markdown markers, digits, punctuation, whitespace
+        // are all skipped, which is what makes list items and headings work.
+        assert_eq!(base_direction("- سلام"), Rtl);
+        assert_eq!(base_direction("## سلام"), Rtl);
+        assert_eq!(base_direction("> «سلام»"), Rtl);
+        assert_eq!(base_direction("  \t123 — سلام"), Rtl);
+        assert_eq!(base_direction("- hello"), Ltr);
+        // The FIRST strong character decides, not the majority: a line opening
+        // in English stays LTR however much Persian follows (and vice versa).
+        assert_eq!(base_direction("Rust سلام دنیا و بیشتر"), Ltr);
+        assert_eq!(base_direction("سلام Rust and more English"), Rtl);
+        // No strong character anywhere → LTR.
+        assert_eq!(base_direction(""), Ltr);
+        assert_eq!(base_direction("123 — !?"), Ltr);
+        // Other scripts are LTR.
+        assert_eq!(base_direction("日本語"), Ltr);
+        assert_eq!(base_direction("Привет"), Ltr);
+        assert!(Direction::Rtl.is_rtl() && !Direction::Ltr.is_rtl());
     }
 
     #[test]

--- a/crates/gpui-markdown/src/syntax.rs
+++ b/crates/gpui-markdown/src/syntax.rs
@@ -362,6 +362,16 @@ pub fn base_direction(text: &str) -> Direction {
     Direction::Ltr
 }
 
+/// Does `text` contain ANY right-to-left character?
+///
+/// Distinct from [`base_direction`], which answers which side a line starts on.
+/// A line can read left-to-right and still hold a Persian name in the middle,
+/// and that run needs the same logical↔visual mapping an RTL line does — the
+/// caret misplaces inside it otherwise.
+pub fn contains_rtl(text: &str) -> bool {
+    text.chars().any(is_strong_rtl)
+}
+
 /// Strong right-to-left: Hebrew through Arabic-script languages.
 fn is_strong_rtl(c: char) -> bool {
     matches!(c,

--- a/crates/gpui-markdown/src/syntax.rs
+++ b/crates/gpui-markdown/src/syntax.rs
@@ -1068,6 +1068,11 @@ mod tests {
         assert!(content_direction("> [!NOTE]\n> یک هشدار فارسی").is_rtl());
         assert!(content_direction("> [!WARNING]- یک هشدار").is_rtl());
         assert!(!content_direction("> [!NOTE]\n> an english callout").is_rtl());
+        // A marker-only line has NO direction of its own — the caller decides
+        // whether that means the line above or the content below.
+        assert_eq!(content_direction_opt("> [!NOTE]"), None);
+        assert_eq!(content_direction_opt("- "), None);
+        assert_eq!(content_direction_opt(""), None);
         assert!(!content_direction("> > [!NOTE]\n").is_rtl(), "no content");
         // Latin content still reads left-to-right, markers or not.
         assert!(!content_direction("- [x] a done task").is_rtl());

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -1191,7 +1191,7 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
                 .position
                 .as_ref()
                 .and_then(|p| ctx.source.get(p.start.offset..p.end.offset))
-                .is_some_and(|s| crate::syntax::base_direction(s).is_rtl());
+                .is_some_and(|s| crate::syntax::content_direction(s).is_rtl());
             let text = div()
                 // Full width, else `inline_element`'s right-alignment has
                 // nothing to align WITHIN: a content-sized div sits left
@@ -1400,11 +1400,21 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
             // a chevron joins the title, clicking flips the `-`/`+` in the
             // source (via the host's handler), and a folded callout shows only
             // its title.
+            // Direction from the quote's source, so the `>` markers and
+            // whitespace (neutral under UAX #9) don't skew it. Shared by the
+            // alert branch and the plain quote below.
+            let rtl = b
+                .position
+                .as_ref()
+                .and_then(|p| ctx.source.get(p.start.offset..p.end.offset))
+                .is_some_and(|s| crate::syntax::content_direction(s).is_rtl());
             if let Some((kind, fold, marker_offset, children)) = alert_parts(b) {
                 let color = kind.color(&ctx.style.alerts);
                 let mut title = div()
                     .flex()
-                    .flex_row()
+                    // The icon leads the label, so it swaps sides with the text.
+                    .when(rtl, |d| d.flex_row_reverse())
+                    .when(!rtl, |d| d.flex_row())
                     .items_center()
                     .gap(px(6.0))
                     .font_weight(FontWeight::BOLD)
@@ -1431,7 +1441,8 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
                             format!("{}-fold-{}", ctx.id_base, ctx.counter).into(),
                         ))
                         .flex()
-                        .flex_row()
+                        .when(rtl, |d| d.flex_row_reverse())
+                        .when(!rtl, |d| d.flex_row())
                         .items_center()
                         .gap(px(6.0))
                         .child(title)
@@ -1448,9 +1459,10 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
                     title = row.into_any_element();
                 }
                 let mut q = div()
-                    .border_l_2()
                     .border_color(color)
-                    .pl(px(12.0))
+                    // The rule goes on the side the text starts from.
+                    .when(rtl, |d| d.border_r_2().pr(px(12.0)))
+                    .when(!rtl, |d| d.border_l_2().pl(px(12.0)))
                     .flex()
                     .flex_col()
                     .gap(px(6.0))
@@ -1465,14 +1477,7 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
                 return Some(q.into_any_element());
             }
             let muted = ctx.style.muted_color;
-            // An RTL quote's rule belongs on the right, where the text starts
-            // (#66) — direction from the quote's source, so the `>` markers
-            // and whitespace (neutral under UAX #9) don't skew it.
-            let rtl = b
-                .position
-                .as_ref()
-                .and_then(|p| ctx.source.get(p.start.offset..p.end.offset))
-                .is_some_and(|s| crate::syntax::base_direction(s).is_rtl());
+            // An RTL quote's rule belongs on the right, where the text starts.
             let mut q = div()
                 .border_color(muted)
                 .when(rtl, |d| d.border_r_2().pr(px(12.0)))
@@ -1828,7 +1833,7 @@ fn render_list(list: &mdast::List, ctx: &mut Ctx, depth: usize, window: &mut Win
             .position
             .as_ref()
             .and_then(|p| ctx.source.get(p.start.offset..p.end.offset))
-            .is_some_and(|s| crate::syntax::base_direction(s).is_rtl());
+            .is_some_and(|s| crate::syntax::content_direction(s).is_rtl());
         col = col.child(
             div()
                 .flex()
@@ -2927,6 +2932,13 @@ fn render_property_table(
         0.0
     };
     let key_cell_w = key_w + px(icon_indent + 20.0);
+    // The panel follows its VALUES, not its keys: a Persian note's property
+    // keys are usually Latin (`tags`, `key`), so keying off the line would leave
+    // an RTL note's properties reading the wrong way — and deciding per ROW
+    // would stagger the fixed-width key column.
+    let rtl = rows
+        .iter()
+        .any(|(_, v, _)| crate::syntax::content_direction(v).is_rtl());
     let key_col = ctx.style.muted_color;
     let tag_c = ctx.style.tag_color;
     let link_c = ctx.style.link_color;
@@ -2940,9 +2952,15 @@ fn render_property_table(
         let mut val = div()
             .flex()
             .flex_wrap()
+            // Segments read right-to-left. The cell does NOT grow in that case:
+            // the reversed row puts the key at the right edge and the value
+            // immediately beside it, whereas a growing cell would stretch to the
+            // far margin and strand the value there — which is not a `justify`
+            // that can be relied on to mean the same thing under row-reverse.
+            .when(rtl, |d| d.flex_row_reverse())
+            .when(!rtl, |d| d.flex_1())
             .items_center()
             .gap(px(5.0))
-            .flex_1()
             .px(px(8.0))
             .py(px(3.0));
         for seg in crate::syntax::property_value_segments(&value) {
@@ -3006,6 +3024,8 @@ fn render_property_table(
             .w(key_cell_w)
             .flex_shrink_0()
             .flex()
+            // The icon leads the key name, so it swaps sides too.
+            .when(rtl, |d| d.flex_row_reverse())
             .items_center()
             .gap(px(6.0))
             .px(px(8.0))
@@ -3033,6 +3053,8 @@ fn render_property_table(
         panel = panel.child(
             div()
                 .flex()
+                // Key on the right, value to its left.
+                .when(rtl, |d| d.flex_row_reverse())
                 .items_center()
                 .rounded(px(6.0))
                 .border_1()
@@ -3078,7 +3100,7 @@ fn render_table(
         .position
         .as_ref()
         .and_then(|p| ctx.source.get(p.start.offset..p.end.offset))
-        .is_some_and(|s| crate::syntax::base_direction(s).is_rtl());
+        .is_some_and(|s| crate::syntax::content_direction(s).is_rtl());
     let base_font = window.text_style().font();
     let mut widths = vec![px(0.0); ncols];
     for (ri, row) in table.children.iter().enumerate() {

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -13,9 +13,10 @@ use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 use gpui::{
     AnyElement, App, Bounds, ClipboardItem, Corners, ElementId, FontStyle, FontWeight,
     HighlightStyle, Hsla, InteractiveElement, InteractiveText, IntoElement, MouseButton,
-    MouseDownEvent, ParentElement, Pixels, RenderImage, RenderOnce, ScrollHandle, SharedString,
-    StatefulInteractiveElement, StrikethroughStyle, Styled, StyledText, TextRun, Window, canvas,
-    div, point, prelude::FluentBuilder, px, relative, rgb, rgba, size, svg,
+    MouseDownEvent, ParentElement, Pixels, Point, RenderImage, RenderOnce, ScrollHandle,
+    SharedString, StatefulInteractiveElement, StrikethroughStyle, Styled, StyledText, TextLayout,
+    TextRun, Window, canvas, div, point, prelude::FluentBuilder, px, relative, rgb, rgba, size,
+    svg,
 };
 use markdown::mdast;
 
@@ -1843,15 +1844,93 @@ fn render_list(list: &mdast::List, ctx: &mut Ctx, depth: usize, window: &mut Win
 
 // --- Inline rendering ---
 
+#[derive(Clone)]
 enum LinkTarget {
     Wiki(SharedString),
     Url(SharedString),
 }
 
+/// The text layout of whichever paragraph element got built.
+///
+/// RTL blocks lay themselves out (`gpui_bidi::paragraph`), because gpui wraps
+/// by slicing the reordered glyph run and gets the rows backwards — so the two
+/// directions carry different layouts. Everything downstream (link
+/// hit-testing, click-to-caret, seating an inline formula over its spacer)
+/// only ever asks these three questions, so it asks them here.
+enum TextHandle {
+    Ltr(TextLayout),
+    Rtl(gpui_bidi::paragraph::RtlLayout),
+}
+
+impl TextHandle {
+    fn index_for_position(&self, position: Point<Pixels>) -> Result<usize, usize> {
+        match self {
+            Self::Ltr(l) => l.index_for_position(position),
+            Self::Rtl(l) => l.index_for_position(position),
+        }
+    }
+
+    fn line_height(&self) -> Pixels {
+        match self {
+            Self::Ltr(l) => l.line_height(),
+            Self::Rtl(l) => l.line_height(),
+        }
+    }
+
+    /// Top-left corner of the spacer occupying `range`, where an inline raster
+    /// gets painted.
+    ///
+    /// In an LTR line that's just the start offset's position. In an RTL line
+    /// the start offset is the spacer's RIGHT edge — painting from there would
+    /// cover the words beside it — so the whole range's visual box is measured
+    /// and its left edge used.
+    fn raster_origin(&self, range: Range<usize>) -> Option<Point<Pixels>> {
+        match self {
+            Self::Ltr(l) => l.position_for_index(range.start),
+            Self::Rtl(l) => l.left_edge_of(range),
+        }
+    }
+}
+
+/// Open a link target. Shared by both directions: LTR goes through
+/// `InteractiveText`, RTL hit-tests through its own layout, but what a click
+/// DOES must not depend on which.
+fn follow_link(
+    target: Option<&LinkTarget>,
+    on_wiki: &Option<WikiLinkHandler>,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    match target {
+        Some(LinkTarget::Wiki(title)) => {
+            if let Some(handler) = on_wiki {
+                handler(title.clone(), window, cx);
+            }
+        }
+        // Only http(s) reaches the OS opener — the markdown is untrusted, and
+        // `open_url` runs the scheme's handler.
+        Some(LinkTarget::Url(url)) if crate::syntax::is_safe_external_url(url) => cx.open_url(url),
+        Some(LinkTarget::Url(_)) | None => {}
+    }
+}
+
 /// An inline raster spliced into a paragraph's text: `(display byte offset of
-/// the spacer, raster, logical w, h, image src)`. `src` is `Some` for an
-/// image (clickable → preview), `None` for a `$…$` formula.
-type InlineRaster = (usize, Arc<RenderImage>, f32, f32, Option<SharedString>);
+/// the spacer, spacer byte length, raster, logical w, h, image src)`. `src` is
+/// `Some` for an image (clickable → preview), `None` for a `$…$` formula.
+///
+/// The spacer's LENGTH is carried, not just where it starts, because an RTL
+/// line runs the other way: the first byte of the spacer sits at its RIGHT
+/// edge, and a raster painted from there covers the text beside it instead of
+/// the gap. With the range, the raster is placed by the spacer's actual
+/// visual box, which is correct whichever way the line runs.
+type InlineRaster = (
+    usize,
+    usize,
+    Arc<RenderImage>,
+    f32,
+    f32,
+    Option<SharedString>,
+);
 
 /// Window-space bounds of each painted inline image + its src, for click
 /// hit-testing (image click → preview).
@@ -1946,62 +2025,79 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
 
     let math = std::mem::take(&mut inl.math);
 
+    // Rendered-text ranges of this block's links, so the click-to-caret handler
+    // below can ignore a click that lands on a link. A link's own `on_click`
+    // fires on mouse-*up*; the caret handler fires on mouse-*down*, so without
+    // this it would enter the editor first and swallow the link click.
+    let link_ranges: Vec<Range<usize>> = inl.links.iter().map(|(r, _)| r.clone()).collect();
+    let targets: Vec<LinkTarget> = inl.links.iter().map(|(_, t)| t.clone()).collect();
+
     // #66: an RTL paragraph cannot use gpui's wrapping. gpui shapes the whole
     // paragraph as one line and slices it into rows by ascending x, and glyph
     // order is visual — so the first row gets the paragraph's LAST words and a
     // wrapped Persian note reads bottom-to-top. `RtlText` breaks in logical
     // order first (UAX #9) and paints the rows itself.
     //
-    // Links and inline math still take the `StyledText` route: both hit-test
-    // through the text layout this path doesn't populate, so they need the
-    // per-line mapping ported before they can move over.
-    if dir.is_rtl() && inl.links.is_empty() && math.is_empty() {
-        return div()
-            .w_full()
-            .child(gpui_bidi::paragraph::RtlText::new(inl.text).with_highlights(highlights))
-            .into_any_element();
-    }
-
-    let styled = StyledText::new(inl.text).with_highlights(highlights);
-    // Capture the text layout (a shared handle, populated on paint) so a click can
-    // be mapped to a rendered byte index, then to a source offset (and so a canvas can paint
-    // inline formulas over their spacers).
-    let layout = styled.layout().clone();
-    // Rendered-text ranges of this block's links, so the click-to-caret handler
-    // below can ignore a click that lands on a link. A link's own `on_click`
-    // fires on mouse-*up*; the caret handler fires on mouse-*down*, so without
-    // this it would enter the editor first and swallow the link click.
-    let link_ranges: Vec<Range<usize>> = inl.links.iter().map(|(r, _)| r.clone()).collect();
-
-    let inner = if inl.links.is_empty() {
-        styled.into_any_element()
+    // Everything past this point is direction-agnostic: it works off
+    // `TextHandle`, so links, click-to-caret and inline math behave the same
+    // either way.
+    let (inner, layout) = if dir.is_rtl() {
+        let rtl = gpui_bidi::paragraph::RtlText::new(inl.text)
+            .with_highlights(highlights)
+            .with_pointer_ranges(link_ranges.clone());
+        let layout = TextHandle::Rtl(rtl.layout().clone());
+        let inner = if link_ranges.is_empty() {
+            rtl.into_any_element()
+        } else {
+            // `InteractiveText` hit-tests through gpui's own layout, which is
+            // the thing that's wrong for RTL — so the click lands via the same
+            // handle that painted the rows. Mouse-DOWN, and consumed, so the
+            // click-to-caret wrapper below doesn't also fire.
+            let TextHandle::Rtl(hit) = &layout else {
+                unreachable!("just built as Rtl")
+            };
+            let hit = hit.clone();
+            let ranges = link_ranges.clone();
+            let targets = targets.clone();
+            let on_wiki = ctx.on_wiki_link.clone();
+            div()
+                .child(rtl)
+                .on_mouse_down(MouseButton::Left, move |ev: &MouseDownEvent, window, cx| {
+                    let Ok(ix) = hit.index_for_position(ev.position) else {
+                        return;
+                    };
+                    if let Some(k) = ranges.iter().position(|r| r.contains(&ix)) {
+                        cx.stop_propagation();
+                        follow_link(targets.get(k), &on_wiki, window, cx);
+                    }
+                })
+                .into_any_element()
+        };
+        (inner, layout)
     } else {
-        ctx.counter += 1;
-        let id = ElementId::Name(format!("{}-{}", ctx.id_base, ctx.counter).into());
-        let targets: Vec<LinkTarget> = inl.links.into_iter().map(|(_, t)| t).collect();
-        let on_wiki = ctx.on_wiki_link.clone();
-        InteractiveText::new(id, styled)
-            .on_click(link_ranges.clone(), move |ix, window, cx| {
-                // The click was on a link range; consume it so it doesn't also reach
-                // a surrounding host handler (e.g. the click-to-caret below).
-                cx.stop_propagation();
-                match targets.get(ix) {
-                    Some(LinkTarget::Wiki(title)) => {
-                        if let Some(handler) = &on_wiki {
-                            handler(title.clone(), window, cx);
-                        }
-                    }
-                    // Only http(s) reaches the OS opener — the markdown is
-                    // untrusted, and `open_url` runs the scheme's handler.
-                    Some(LinkTarget::Url(url)) if crate::syntax::is_safe_external_url(url) => {
-                        cx.open_url(url)
-                    }
-                    Some(LinkTarget::Url(_)) => {}
-                    None => {}
-                }
-            })
-            .into_any_element()
+        let styled = StyledText::new(inl.text).with_highlights(highlights);
+        // Capture the text layout (a shared handle, populated on paint) so a click can
+        // be mapped to a rendered byte index, then to a source offset (and so a canvas can paint
+        // inline formulas over their spacers).
+        let layout = TextHandle::Ltr(styled.layout().clone());
+        let inner = if link_ranges.is_empty() {
+            styled.into_any_element()
+        } else {
+            ctx.counter += 1;
+            let id = ElementId::Name(format!("{}-{}", ctx.id_base, ctx.counter).into());
+            let on_wiki = ctx.on_wiki_link.clone();
+            InteractiveText::new(id, styled)
+                .on_click(link_ranges.clone(), move |ix, window, cx| {
+                    // The click was on a link range; consume it so it doesn't also reach
+                    // a surrounding host handler (e.g. the click-to-caret below).
+                    cx.stop_propagation();
+                    follow_link(targets.get(ix), &on_wiki, window, cx);
+                })
+                .into_any_element()
+        };
+        (inner, layout)
     };
+    let layout = Rc::new(layout);
 
     // Click-to-caret: outside a link (link clicks `stop_propagation` above), map the
     // click to a source offset and report it so the host can place its editor caret
@@ -2053,7 +2149,7 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
     // A paragraph with inline formulas: paint each raster over its spacer via a canvas painted
     // AFTER the text (so the text layout is populated + gives the spacer's window position), and
     // grow the line height so a tall formula (a fraction) doesn't overlap the neighbouring line.
-    let tallest = math.iter().fold(0f32, |a, &(_, _, _, h, _)| a.max(h));
+    let tallest = math.iter().fold(0f32, |a, &(_, _, _, _, h, _)| a.max(h));
     let line_h = px((f32::from(ctx.style.text_size) * 1.4).max(tallest + 6.0));
     let with_math = div()
         .relative()
@@ -2066,8 +2162,8 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
                     let row_h = layout.line_height();
                     let mut hits = image_hits.borrow_mut();
                     hits.clear();
-                    for (off, img, w, h, src) in &math {
-                        if let Some(p) = layout.position_for_index(*off) {
+                    for (off, len, img, w, h, src) in &math {
+                        if let Some(p) = layout.raster_origin(*off..*off + *len) {
                             let y = p.y + (row_h - px(*h)) / 2.0;
                             let b = Bounds::new(point(p.x, y), size(px(*w), px(*h)));
                             let _ =
@@ -2130,7 +2226,8 @@ fn build_inline(
                     Some((img, w, h)) => {
                         let space_w = (f32::from(style.text_size) * 0.26).max(1.0);
                         let n = ((w / space_w).ceil() as usize).max(1);
-                        out.math.push((out.text.len(), img, w, h, None));
+                        out.math
+                            .push((out.text.len(), n * '\u{00A0}'.len_utf8(), img, w, h, None));
                         out.text.extend(std::iter::repeat_n('\u{00A0}', n));
                     }
                     None => push_run(&format!("${}$", m.value), cur, out),
@@ -2166,8 +2263,14 @@ fn build_inline(
                     Some((raster, w, h)) => {
                         let space_w = (f32::from(style.text_size) * 0.26).max(1.0);
                         let n = ((w / space_w).ceil() as usize).max(1);
-                        out.math
-                            .push((out.text.len(), raster, w, h, Some(img.url.clone().into())));
+                        out.math.push((
+                            out.text.len(),
+                            n * '\u{00A0}'.len_utf8(),
+                            raster,
+                            w,
+                            h,
+                            Some(img.url.clone().into()),
+                        ));
                         out.text.extend(std::iter::repeat_n('\u{00A0}', n));
                     }
                     None => {

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -1945,6 +1945,23 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
     };
 
     let math = std::mem::take(&mut inl.math);
+
+    // #66: an RTL paragraph cannot use gpui's wrapping. gpui shapes the whole
+    // paragraph as one line and slices it into rows by ascending x, and glyph
+    // order is visual — so the first row gets the paragraph's LAST words and a
+    // wrapped Persian note reads bottom-to-top. `RtlText` breaks in logical
+    // order first (UAX #9) and paints the rows itself.
+    //
+    // Links and inline math still take the `StyledText` route: both hit-test
+    // through the text layout this path doesn't populate, so they need the
+    // per-line mapping ported before they can move over.
+    if dir.is_rtl() && inl.links.is_empty() && math.is_empty() {
+        return div()
+            .w_full()
+            .child(gpui_bidi::paragraph::RtlText::new(inl.text).with_highlights(highlights))
+            .into_any_element();
+    }
+
     let styled = StyledText::new(inl.text).with_highlights(highlights);
     // Capture the text layout (a shared handle, populated on paint) so a click can
     // be mapped to a rendered byte index, then to a source offset (and so a canvas can paint

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -1647,10 +1647,20 @@ fn render_list(list: &mdast::List, ctx: &mut Ctx, depth: usize, window: &mut Win
         } else {
             marker_el.into_any_element()
         };
+        // An RTL item puts its bullet/number on the right (#66). Direction
+        // comes from the item's SOURCE slice — the list marker, digits and
+        // whitespace are all neutral under UAX #9, so `- سلام` reads RTL and
+        // `- hello` reads LTR.
+        let item_rtl = li
+            .position
+            .as_ref()
+            .and_then(|p| ctx.source.get(p.start.offset..p.end.offset))
+            .is_some_and(|s| crate::syntax::base_direction(s).is_rtl());
         col = col.child(
             div()
                 .flex()
-                .flex_row()
+                .when(item_rtl, |d| d.flex_row_reverse())
+                .when(!item_rtl, |d| d.flex_row())
                 .gap(px(8.0))
                 .child(marker_col)
                 .child(div().flex_1().min_w_0().child(content)),
@@ -1741,6 +1751,27 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
         inl.highlights
     };
 
+    // Writing direction for this block (#66). Detected from the RENDERED text
+    // — what the reader actually sees, markers already stripped — so a
+    // `- سلام` item and a `## سلام` heading both come out RTL. Every block
+    // that shows prose funnels through here (paragraphs, headings, list-item
+    // content, quotes, table cells), so this is the one place it's decided.
+    //
+    // Reader-only by design: the platform shapers already reorder RTL glyphs
+    // correctly, so alignment is all that's missing here. The EDITOR needs a
+    // logical↔visual index map before it can do the same — gpui's
+    // `x_for_index` collapses every caret offset in an RTL line onto x=0 (see
+    // the bidi note in TODO.md), and a right-aligned line with a broken caret
+    // would be worse than none.
+    let dir = crate::syntax::base_direction(&inl.text);
+    let align = move |el: AnyElement| -> AnyElement {
+        if dir.is_rtl() {
+            div().w_full().text_right().child(el).into_any_element()
+        } else {
+            el
+        }
+    };
+
     let math = std::mem::take(&mut inl.math);
     let styled = StyledText::new(inl.text).with_highlights(highlights);
     // Capture the text layout (a shared handle, populated on paint) so a click can
@@ -1828,14 +1859,14 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
         }
     };
     if math.is_empty() {
-        return el;
+        return align(el);
     }
     // A paragraph with inline formulas: paint each raster over its spacer via a canvas painted
     // AFTER the text (so the text layout is populated + gives the spacer's window position), and
     // grow the line height so a tall formula (a fraction) doesn't overlap the neighbouring line.
     let tallest = math.iter().fold(0f32, |a, &(_, _, _, h, _)| a.max(h));
     let line_h = px((f32::from(ctx.style.text_size) * 1.4).max(tallest + 6.0));
-    div()
+    let with_math = div()
         .relative()
         .line_height(line_h)
         .child(el)
@@ -1862,7 +1893,8 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
             .absolute()
             .inset_0(),
         )
-        .into_any_element()
+        .into_any_element();
+    align(with_math)
 }
 
 fn build_inline(

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -1034,7 +1034,21 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
                     _ => 6.0,
                 })
             };
+            // An RTL heading right-aligns like any other block (#66), and its
+            // fold chevron moves to the left so it stays on the text's
+            // trailing edge.
+            let h_rtl = h
+                .position
+                .as_ref()
+                .and_then(|p| ctx.source.get(p.start.offset..p.end.offset))
+                .is_some_and(|s| crate::syntax::base_direction(s).is_rtl());
             let text = div()
+                // Full width, else `inline_element`'s right-alignment has
+                // nothing to align WITHIN: a content-sized div sits left
+                // whatever its text alignment says.
+                .w_full()
+                .flex_1()
+                .min_w_0()
                 .text_size(size)
                 .text_color(color)
                 .font_weight(FontWeight::BOLD)
@@ -1071,7 +1085,8 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
                         .group(group)
                         .mt(top)
                         .flex()
-                        .flex_row()
+                        .when(h_rtl, |d| d.flex_row_reverse())
+                        .when(!h_rtl, |d| d.flex_row())
                         .items_center()
                         .gap(px(8.0))
                         .child(text)
@@ -1300,10 +1315,18 @@ fn render_block(node: &mdast::Node, ctx: &mut Ctx, window: &mut Window) -> Optio
                 return Some(q.into_any_element());
             }
             let muted = ctx.style.muted_color;
+            // An RTL quote's rule belongs on the right, where the text starts
+            // (#66) — direction from the quote's source, so the `>` markers
+            // and whitespace (neutral under UAX #9) don't skew it.
+            let rtl = b
+                .position
+                .as_ref()
+                .and_then(|p| ctx.source.get(p.start.offset..p.end.offset))
+                .is_some_and(|s| crate::syntax::base_direction(s).is_rtl());
             let mut q = div()
-                .border_l_2()
                 .border_color(muted)
-                .pl(px(12.0))
+                .when(rtl, |d| d.border_r_2().pr(px(12.0)))
+                .when(!rtl, |d| d.border_l_2().pl(px(12.0)))
                 .flex()
                 .flex_col()
                 .gap(px(6.0))
@@ -2770,6 +2793,14 @@ fn render_table(
         .max()
         .unwrap_or(1)
         .max(1);
+    // An RTL table reads right-to-left: the first column sits on the RIGHT
+    // (#66). Direction from the table's source — pipes, dashes and digits are
+    // neutral under UAX #9, so the first strong character in a cell decides.
+    let rtl = table
+        .position
+        .as_ref()
+        .and_then(|p| ctx.source.get(p.start.offset..p.end.offset))
+        .is_some_and(|s| crate::syntax::base_direction(s).is_rtl());
     let base_font = window.text_style().font();
     let mut widths = vec![px(0.0); ncols];
     for (ri, row) in table.children.iter().enumerate() {
@@ -2840,7 +2871,12 @@ fn render_table(
         // The mdast table has no separator child: row 0 is the header, row 1 the
         // first body row (body_index 0).
         let body_index = ri.checked_sub(1);
-        let mut row_el = div().flex().flex_row();
+        // Reversing the row lays column 0 at the right without touching the
+        // width/alignment bookkeeping, which stays keyed by logical index.
+        let mut row_el = div()
+            .flex()
+            .when(rtl, |d| d.flex_row_reverse())
+            .when(!rtl, |d| d.flex_row());
         // Top divider: under every row (Grid), just under the header
         // (Striped/Minimal → the first body row's top), or never (Header).
         let top_divider = if row_lines {
@@ -2872,7 +2908,16 @@ fn render_table(
                 .min_h(px(f32::from(ctx.style.text_size) * 1.45 + 12.0))
                 .flex()
                 .items_center();
-            if vlines && ci + 1 < r.children.len() {
+            // Column separators sit between adjacent cells. Reversed, cell `i`
+            // is drawn LEFT of cell `i-1`, so the divider belongs on every
+            // cell except index 0 (the rightmost) — mirroring the LTR rule of
+            // "every cell except the last".
+            let needs_divider = if rtl {
+                ci > 0
+            } else {
+                ci + 1 < r.children.len()
+            };
+            if vlines && needs_divider {
                 cell_el = cell_el.border_r_1().border_color(border);
             }
             // Honor the column's GFM alignment (`:---:` / `---:`).
@@ -2896,7 +2941,10 @@ fn render_table(
         .id(("md-table", ctx.counter))
         // WYSIWYG indents tables into a 22px gutter (its row handles live
         // there); mirror it so the grid sits at the same x in both views.
-        .ml(px(22.0))
+        // An RTL table takes that gutter on its other side and hugs the right
+        // edge, where the rest of an RTL block starts.
+        .when(rtl, |d| d.mr(px(22.0)).ml_auto())
+        .when(!rtl, |d| d.ml(px(22.0)))
         .max_w_full()
         .overflow_x_scroll()
         .child(grid)

--- a/crates/gpui-markdown/src/view.rs
+++ b/crates/gpui-markdown/src/view.rs
@@ -2046,8 +2046,13 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
     // Everything past this point is direction-agnostic: it works off
     // `TextHandle`, so links, click-to-caret and inline math behave the same
     // either way.
-    let (inner, layout) = if dir.is_rtl() {
+    // Any paragraph CONTAINING right-to-left text needs the mapping, not just
+    // one that reads that way: an English sentence quoting a Persian name
+    // misplaces the caret and its link hitboxes inside that phrase otherwise.
+    // `with_base_rtl` keeps such a paragraph left-aligned (#66).
+    let (inner, layout) = if crate::syntax::contains_rtl(&inl.text) {
         let rtl = gpui_bidi::paragraph::RtlText::new(inl.text)
+            .with_base_rtl(dir.is_rtl())
             .with_highlights(highlights)
             .with_pointer_ranges(link_ranges.clone());
         let layout = TextHandle::Rtl(rtl.layout().clone());

--- a/docs/scripts/sync-crate-readmes.mjs
+++ b/docs/scripts/sync-crate-readmes.mjs
@@ -29,6 +29,11 @@ const DOCS = '/zorite/reference/crates';
 
 const crates = [
 	{
+		name: 'gpui-bidi',
+		description:
+			"Bidirectional text for GPUI: index↔x over reordered glyphs, logical-order row layout, and a row painter that keeps a styled line's colours.",
+	},
+	{
 		name: 'gpui-editor',
 		description:
 			"A from-scratch multi-line text editor for GPUI — the engine behind Zorite's Word-like note editor.",

--- a/src/app.rs
+++ b/src/app.rs
@@ -5382,7 +5382,7 @@ impl AppView {
 
     /// Resolve the active skin + mode (+ OS appearance for Auto) to a
     /// palette and push it live to every window.
-    fn apply_theme(&self, window: &mut Window, cx: &mut Context<Self>) {
+    fn apply_theme(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let skin = self.current_skin();
         // A dark-only theme ignores the Light/Dark/Auto setting and forces dark,
         // so the window chrome / titlebar matches its always-dark content.
@@ -5411,8 +5411,34 @@ impl AppView {
         theme::apply(palette, is_dark, window, cx);
         theme::set_ui_font(&font, cx);
         // Diagrams are themed at render time — drop the cache so they re-render
-        // with the new palette (Rc<RefCell>, so this is fine from `&self`).
+        // with the new palette.
         self.mermaid_store.borrow_mut().clear();
+        // Formulas are tinted at render time too, and were being missed here: a
+        // raster rendered for the dark palette is white, so after one visit to a
+        // dark theme every light theme showed an invisible formula over the
+        // spacer it had reserved. `set_color` drops them only when the tint
+        // actually changed. Block math re-renders itself on a cache miss, but
+        // INLINE math deliberately doesn't (it relies on content having been
+        // pre-warmed), so the loaded content is re-warmed here.
+        let retint = self
+            .math_store
+            .borrow_mut()
+            .set_color(theme::text_primary());
+        if retint {
+            let contents: Vec<String> = self
+                .day_editors
+                .values()
+                .map(|de| de.state.read(cx).value().to_string())
+                .chain(
+                    self.page_editor
+                        .as_ref()
+                        .map(|pe| pe.state.read(cx).value().to_string()),
+                )
+                .collect();
+            for content in contents {
+                self.ensure_content_math(&content, cx);
+            }
+        }
         // Open editors hold a SyntaxStyle cloned at creation — re-push it so the
         // inline tag/code/link colors track the new palette live, instead of
         // keeping the old theme's until a restart or a WYSIWYG toggle.

--- a/src/app/math.rs
+++ b/src/app/math.rs
@@ -417,6 +417,20 @@ impl AppView {
     fn exit_math_edit(&mut self, after: bool, window: &mut Window, cx: &mut Context<Self>) {
         let inline = self.math_edit.as_ref().is_some_and(|m| m.inline);
         if let Some((source, block)) = self.commit_math_edit(cx) {
+            // ratex-gpui reports the arrow it was handed — left/up = before the
+            // span, right/down = after — which is the left-to-right reading. On
+            // an RTL line the text continues LEFTWARD, so exiting left means
+            // landing AFTER the span; without this the caret leaves a formula
+            // on the wrong side and appears not to exit at all (#66). The crate
+            // stays host-agnostic, so direction is decided here.
+            let after = {
+                let text = source.read(cx).value();
+                if line_is_rtl(&text, block.start) {
+                    !after
+                } else {
+                    after
+                }
+            };
             source.update(cx, |e, cx| {
                 if inline {
                     e.focus(window, cx);
@@ -442,4 +456,13 @@ impl AppView {
             self.ensure_math_loaded(source, cx);
         }
     }
+}
+
+/// Does the line containing byte `at` read right-to-left? Same rule the editor
+/// and reader use — the line's first strong character.
+fn line_is_rtl(text: &str, at: usize) -> bool {
+    let at = at.min(text.len());
+    let start = text[..at].rfind('\n').map_or(0, |i| i + 1);
+    let end = text[at..].find('\n').map_or(text.len(), |i| at + i);
+    gpui_markdown::syntax::base_direction(&text[start..end]).is_rtl()
 }

--- a/src/app/math.rs
+++ b/src/app/math.rs
@@ -464,5 +464,5 @@ fn line_is_rtl(text: &str, at: usize) -> bool {
     let at = at.min(text.len());
     let start = text[..at].rfind('\n').map_or(0, |i| i + 1);
     let end = text[at..].find('\n').map_or(text.len(), |i| at + i);
-    gpui_markdown::syntax::base_direction(&text[start..end]).is_rtl()
+    gpui_markdown::syntax::content_direction(&text[start..end]).is_rtl()
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1788,6 +1788,53 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Does an abrupt termination with an uncheckpointed WAL lose data? The
+    /// sandbox DB emptied out after a SIGTERM + external sqlite3 open, and
+    /// v0.10.1 newly chmods the -wal/-shm siblings — so pin both here.
+    #[test]
+    fn wal_survives_an_unclean_close() {
+        let dir = std::env::temp_dir().join(format!("zorite-wal-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("wal.db");
+        let _ = std::fs::remove_file(&path);
+
+        let db = Db::open_file(&path, None).unwrap();
+        let mut ids = Vec::new();
+        for i in 0..25 {
+            let p = db.get_or_create_page(&format!("Page {i}")).unwrap();
+            db.set_page_content(p.id, &format!("body {i}")).unwrap();
+            ids.push(p.id);
+        }
+        // Mimic v0.10.1's new permission tightening on the live siblings.
+        restrict_to_owner(&path, 0o600);
+        for ext in ["db-wal", "db-shm"] {
+            restrict_to_owner(&path.with_extension(ext), 0o600);
+        }
+        let wal = path.with_extension("db-wal");
+        let wal_len = std::fs::metadata(&wal).map(|m| m.len()).unwrap_or(0);
+        eprintln!("WALREPRO: wal bytes before unclean close = {wal_len}");
+
+        // No clean close: leak the handle so nothing checkpoints or unlinks,
+        // the way a killed process leaves it.
+        std::mem::forget(db);
+
+        let db2 = Db::open_file(&path, None).unwrap();
+        let n: i64 = db2
+            .conn
+            .query_row("SELECT count(*) FROM pages", [], |r| r.get(0))
+            .unwrap();
+        eprintln!("WALREPRO: pages after reopen = {n} (expected 25)");
+        assert_eq!(n, 25, "pages lost across an unclean close");
+        for (i, id) in ids.iter().enumerate() {
+            assert_eq!(
+                db2.get_page(*id).unwrap().unwrap().content,
+                format!("body {i}")
+            );
+        }
+        drop(db2);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn encryption_round_trip() {
         let dir = std::env::temp_dir().join(format!("zorite-enc-test-{}", std::process::id()));

--- a/src/math.rs
+++ b/src/math.rs
@@ -47,11 +47,17 @@ impl MathStore {
 
     /// Set the text color formulas are tinted for. If it changed (a theme switch), drop the
     /// cached rasters so they re-render in the new color. Call before kicking off renders.
-    pub fn set_color(&mut self, color: Hsla) {
+    ///
+    /// Returns whether anything was dropped, so a caller that has to re-warm
+    /// the rasters itself (inline formulas don't re-render on a cache miss)
+    /// can skip that work when the tint is unchanged.
+    pub fn set_color(&mut self, color: Hsla) -> bool {
         if self.color != Some(color) {
             self.color = Some(color);
             self.slots.clear();
+            return true;
         }
+        false
     }
 
     /// Claim `source` for rendering. Returns `false` if it already has a slot, so the

--- a/src/ui/property_editor.rs
+++ b/src/ui/property_editor.rs
@@ -17,7 +17,8 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 use gpui::{
     App, Bounds, Context, FocusHandle, Focusable, InteractiveElement, IntoElement, KeyDownEvent,
     MouseButton, MouseDownEvent, ParentElement, Pixels, Render, SharedString,
-    StatefulInteractiveElement, Styled, Window, canvas, deferred, div, px, svg,
+    StatefulInteractiveElement, Styled, Window, canvas, deferred, div, prelude::FluentBuilder, px,
+    svg,
 };
 
 use crate::theme;
@@ -340,24 +341,31 @@ impl PropertyEditor {
         let n = self.rows.len();
         let m = &ev.keystroke.modifiers;
         match ev.keystroke.key.as_str() {
-            "left" => {
-                let moved = self.field_mut(row, is_key).is_some_and(Field::left);
+            // Arrows move VISUALLY, as everywhere else: on an RTL field the
+            // character to the right is the logically previous one, and the
+            // field to the visual left is the one that comes NEXT (the key sits
+            // on the right there). Direction is decided once, from the field's
+            // own text, so a Latin key beside a Persian value keeps its own.
+            key @ ("left" | "right") => {
+                let rtl = self
+                    .field(row, is_key)
+                    .is_some_and(|f| gpui_markdown::syntax::content_direction(&f.text).is_rtl());
+                let forward = (key == "right") != rtl;
+                let moved = self
+                    .field_mut(row, is_key)
+                    .is_some_and(|f| if forward { f.right() } else { f.left() });
                 if !moved {
-                    // Hop to the field on the left, caret at its end.
-                    if !is_key {
+                    if forward {
+                        if is_key {
+                            self.go(row, false, false);
+                        } else if row + 1 < n {
+                            self.go(row + 1, true, false);
+                        }
+                    } else if !is_key {
+                        // Hop to the preceding field, caret at its end.
                         self.go(row, true, true);
                     } else if row > 0 {
                         self.go(row - 1, false, true);
-                    }
-                }
-            }
-            "right" => {
-                let moved = self.field_mut(row, is_key).is_some_and(Field::right);
-                if !moved {
-                    if is_key {
-                        self.go(row, false, false);
-                    } else if row + 1 < n {
-                        self.go(row + 1, true, false);
                     }
                 }
             }
@@ -448,8 +456,16 @@ impl Render for PropertyEditor {
         }
         // icon + gap(6) + widest key + a small trailing gap before the value.
         let key_col = px(self.text_size * 0.95 + 6.0 + max_key + 14.0);
+        // Follow the note, like the rendered panel does: keyed off the VALUES,
+        // since a Persian note's property keys are usually Latin (`tags`). The
+        // panel is what the rendered one turns into on click, so it has to sit
+        // on the same side — otherwise it jumps across the note as you edit it.
+        let rtl = self
+            .rows
+            .iter()
+            .any(|r| gpui_markdown::syntax::content_direction(&r.value.text).is_rtl());
         let rows: Vec<_> = (0..self.rows.len())
-            .map(|i| self.render_row(i, key_col, cx))
+            .map(|i| self.render_row(i, key_col, rtl, cx))
             .collect();
         div()
             .track_focus(&self.focus)
@@ -472,7 +488,12 @@ impl Render for PropertyEditor {
             // Match the rendered panel: the note's text size, rows stacked with
             // no gap (the row height carries the spacing).
             .text_size(px(self.text_size))
-            .max_w(px(480.0))
+            // The 480px cap keeps a left-to-right panel from stretching across
+            // the note. An RTL panel has to span so its rows can sit against
+            // the right edge, where the rendered panel puts them — capped, it
+            // right-aligns inside its own 480px and lands mid-note.
+            .when(!rtl, |d| d.max_w(px(480.0)))
+            .when(rtl, |d| d.w_full().items_end())
             .children(rows)
             .child(
                 div()
@@ -496,7 +517,13 @@ impl Render for PropertyEditor {
 }
 
 impl PropertyEditor {
-    fn render_row(&self, i: usize, key_col: Pixels, cx: &mut Context<Self>) -> gpui::AnyElement {
+    fn render_row(
+        &self,
+        i: usize,
+        key_col: Pixels,
+        rtl: bool,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
         let r = &self.rows[i];
         let key_active = self.active == Some((i, true));
         let value_active = self.active == Some((i, false));
@@ -509,6 +536,9 @@ impl PropertyEditor {
 
         div()
             .flex()
+            // Key (and its icon) lead from the right, value beside it, the
+            // remove affordance at the row's trailing end either way.
+            .when(rtl, |d| d.flex_row_reverse())
             .items_center()
             .h(row_h)
             .gap(px(6.0))
@@ -518,6 +548,7 @@ impl PropertyEditor {
                     .w(key_col)
                     .flex_shrink_0()
                     .flex()
+                    .when(rtl, |d| d.flex_row_reverse())
                     .items_center()
                     .gap(px(6.0))
                     .children(icon.map(|p| {
@@ -600,16 +631,20 @@ impl PropertyEditor {
         } else {
             cell = cell.flex_1();
         }
+        // The field's OWN text decides here, not the panel: a Latin key next
+        // to a Persian value must not be reversed along with it.
+        let f_rtl = gpui_markdown::syntax::content_direction(&f.text).is_rtl();
         if active && is_key {
             // Key: plain text split at the caret (keys aren't pills).
             let (before, after) = f.text.split_at(f.caret);
-            cell.child(before.to_string())
+            cell.when(f_rtl, |d| d.flex_row_reverse())
+                .child(before.to_string())
                 .child(caret_bar(sz))
                 .child(after.to_string())
                 .into_any_element()
         } else if active {
             // Value: pills, revealing the segment under the caret as raw text.
-            cell.child(active_value(f, sz)).into_any_element()
+            cell.child(active_value(f, sz, f_rtl)).into_any_element()
         } else if is_key {
             let label = if f.text.is_empty() {
                 "key".to_string()
@@ -738,7 +773,7 @@ fn caret_bar(text_size: f32) -> impl IntoElement {
 /// The focused value, rendered like the panel (tags/wiki-links as pills) except
 /// the segment the caret sits in, which shows raw text + the caret so it can be
 /// edited — reveal-on-caret, within the field.
-fn active_value(f: &Field, text_size: f32) -> impl IntoElement {
+fn active_value(f: &Field, text_size: f32, rtl: bool) -> impl IntoElement {
     let value = f.text.as_str();
     let caret = f.caret;
     let mut kids: Vec<gpui::AnyElement> = Vec::new();
@@ -788,7 +823,15 @@ fn active_value(f: &Field, text_size: f32) -> impl IntoElement {
     if !placed {
         kids.push(caret_bar(text_size).into_any_element());
     }
-    div().flex().items_center().children(kids)
+    // An active field is a SEQUENCE of children — text before the caret, the
+    // caret bar, text after it, pills — so the row's direction is what puts
+    // them in reading order. Laid out left-to-right, an RTL value comes apart:
+    // `#فارسی #آزمایش` renders as `سی #آزمایش#فار`.
+    div()
+        .flex()
+        .when(rtl, |d| d.flex_row_reverse())
+        .items_center()
+        .children(kids)
 }
 
 /// Push a plain-text run, splitting it at the caret (once) with a caret bar.


### PR DESCRIPTION
Closes #66.

Persian and Hebrew notes now read, wrap, and edit correctly in the reader
and in WYSIWYG. The two views are meant to be indistinguishable when you
switch, so every fix here landed in both.

## The core problem

The platform shapers already do bidi correctly — glyphs come back in
visual order carrying logical byte indices. What is wrong is how gpui
reads them back:

- `LineLayout::x_for_index` returns the first glyph whose `index >=
  target`. In an RTL line the first glyph carries the HIGHEST index, so
  every offset collapses onto x = 0 — a caret that will not move and
  zero-width selection quads.
- `compute_wrap_boundaries` slices the already-reordered glyph run by
  ascending x, so a wrapped RTL paragraph reads **bottom-to-top**, and
  its break candidates come from an `is_word_char` that does not know
  Arabic, so words split mid-word.
- `paint_line` pulls decorations from a forward-only iterator keyed on
  `glyph.index >= run_end`, so a bidi row paints entirely in the colour
  of whichever run covers its logically-last character — a link inside
  Persian text came out body-coloured.

Upstream gpui is not taking modifications, so the fix is ours.

## Approach

`crates/gpui-bidi` (new, a leaf both renderers depend on):

- `VisualMap` — index↔x over a reordered glyph table, plus visual caret
  stepping and rect-for-range. Built from plain `(index, x)` pairs, so
  every rule is unit-testable without a window or a GPU.
- Glyph direction comes from the UAX #9 embedding levels (`unicode-bidi`,
  already in the tree via lopdf/usvg). It cannot be inferred from
  geometry: at the EDGE of an embedded run the glyph beside it belongs to
  the other run and carries a misleading index.
- `layout_rows` breaks a paragraph in LOGICAL order at word boundaries,
  then shapes each row on its own — the sequence gpui gets backwards.
- `paint_row` paints a styled row once per style, uniformly coloured and
  clipped to that style's boxes, which sidesteps the decoration collapse
  while keeping the row's own shaping (so cursive joining survives a
  style boundary inside a word).

Both engines consume it. In the editor the RTL layout happens during
shaping, because our break points give a different row COUNT and the row
span and height are decided there.

## What works

Logical wrapping, caret and selection in prose, tables, cells and
property fields. Visual arrow movement. Links (colour, hit-testing, hover
cursor), inline and block math, images. Tables mirror their columns,
clicks, caret, resize grips and add/remove affordances through one shared
mapping. Lists, tasks, quotes, callouts and property panels mirror in
both views. A left-to-right paragraph containing a Persian phrase gets
the mapping but stays left-aligned.

Markers no longer decide direction: the `x` in `- [x]` and the label in
`> [!NOTE]` are strong left-to-right characters, so a completed task and
every Persian callout read LTR. Direction comes from the line's content,
and a line that is nothing but markers takes the direction of the content
it titles.

## Known limitation

Word breaking for RTL rows is space-based, so a line mixing RTL with
unspaced CJK would wrap poorly. Lines with no RTL keep gpui's wrapping,
so plain CJK is untouched.

## Testing

`fmt` / `clippy -D warnings` / `cargo test --workspace` green. The bidi
rules are unit-tested without a GPU; layout and interaction were verified
by hand in both views against a note covering headings, mixed-direction
paragraphs, lists, tasks, quotes, callouts, tables, block and inline
math, properties, links and an English control — synthetic keyboard input
does not reach a GPUI window, so caret and selection needed real
keypresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)