### PR TITLE
feat(release): AppImage update information + .zsync assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -506,6 +506,33 @@ jobs:
       - name: Build .deb + .AppImage
         run: cargo packager --release -f deb -f appimage
 
+      # Delta updates (#74): cargo-packager has no update-information
+      # support, so re-pack the AppImage with appimagetool. `-u` embeds
+      # the update info in the `.upd_info` ELF section (recognized by
+      # AppImageUpdate / AppImageLauncher / AM) and writes the matching
+      # `.zsync` next to the output; running it against the FINAL asset
+      # filename keeps the zsync's `Filename:` header correct. The
+      # `gh-releases-zsync` transport resolves `latest` via the GitHub
+      # API, so the version part of the glob stays a wildcard.
+      # appimagetool only publishes a `continuous` tag — no version to
+      # pin; it runs on the extracted AppDir linuxdeploy already built.
+      - name: Embed AppImage update information + .zsync
+        run: |
+          VERSION="${EFFECTIVE_VERSION#v}"
+          ARCH="${{ matrix.rpm_arch }}"
+          NAME="zorite_${VERSION}_${ARCH}.AppImage"
+
+          curl -fsSL -o appimagetool \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage"
+          chmod +x appimagetool
+          TOOL="$PWD/appimagetool"
+
+          cd target/release
+          "./$NAME" --appimage-extract >/dev/null
+          UPDINFO="gh-releases-zsync|packetThrower|zorite|latest|zorite_*_${ARCH}.AppImage.zsync"
+          ARCH="$ARCH" "$TOOL" -u "$UPDINFO" squashfs-root "$NAME"
+          test -f "${NAME}.zsync"
+
       - name: Build .rpm via fpm
         run: |
           VERSION="${EFFECTIVE_VERSION#v}"
@@ -593,6 +620,7 @@ jobs:
           # Zorite_<version>_<arch>.<format>.
           cp "$BUNDLE"/*.deb release-artifacts/ 2>/dev/null || true
           cp "$BUNDLE"/*.AppImage release-artifacts/ 2>/dev/null || true
+          cp "$BUNDLE"/*.AppImage.zsync release-artifacts/ 2>/dev/null || true
 
           echo "--- staged ---"
           ls -la release-artifacts/


### PR DESCRIPTION
Implements #74: after `cargo packager` builds the AppImage, re-pack the extracted AppDir with appimagetool `-u "gh-releases-zsync|packetThrower|zorite|latest|zorite_*_<arch>.AppImage.zsync"`. That embeds the update information in the `.upd_info` ELF section and writes the matching `.zsync` next to the final asset name (so its `Filename:` header is correct), per arch (x86_64 / aarch64). Staging picks up `*.AppImage.zsync`; SHA256SUMS already hashes everything in the artifact dirs.

Notes:
- appimagetool only publishes a `continuous` tag, so there is no version to pin.
- Older releases can't delta-update retroactively — the first release carrying this becomes the baseline.

Verification: `workflow_dispatch` run of release.yml on this branch (the workflow's documented ad-hoc test path).

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)