### PR TITLE
fix(math): accents, braces, and structural-editor UX (#77)

### DIFF
--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -1404,6 +1404,13 @@ impl EditorState {
         cx.notify();
     }
 
+    /// The byte range of the block currently being structurally edited (the range handed
+    /// to [`Self::set_editing_block`] — the source text is untouched while the edit is
+    /// open, so it stays valid). `None` when no block edit is open.
+    pub fn editing_block_range(&self) -> Option<Range<usize>> {
+        self.editing_block.as_ref().map(|eb| eb.range.clone())
+    }
+
     /// End an in-line math edit (the host has committed / cancelled). Returns the block's
     /// byte range, so the host can overwrite it.
     pub fn end_editing_block(&mut self, cx: &mut Context<Self>) -> Option<Range<usize>> {
@@ -2746,10 +2753,24 @@ impl EditorState {
         // report no math block here — clicks / arrows / `/math` stay in the text editor.
         self.markdown_style.as_ref()?;
         let starts = self.line_starts();
-        markdown_syntax::math_blocks(&self.content)
-            .into_iter()
+        let blocks = markdown_syntax::math_blocks(&self.content);
+        blocks
+            .iter()
             .find(|(r, _)| r.contains(&row))
-            .map(|(r, source)| (starts[r.start]..self.line_end(r.end - 1), source.into()))
+            .or_else(|| {
+                // A `<!-- math:ALIGN -->` marker row belongs to the block directly
+                // below it: it's invisible in WYSIWYG, so a caret seated there —
+                // e.g. arrow-up returns offset 0 when the block opens the document
+                // (#77) — would reveal the raw rows instead of opening the editor.
+                markdown_syntax::math_align_marker(self.line_str(row))?;
+                blocks.iter().find(|(r, _)| r.start == row + 1)
+            })
+            .map(|(r, source)| {
+                (
+                    starts[r.start]..self.line_end(r.end - 1),
+                    source.clone().into(),
+                )
+            })
     }
 
     /// A `$$` block's byte range grown for deletion: takes in the
@@ -4091,11 +4112,13 @@ impl EditorState {
             }
         } else {
             let (start_row, _) = self.row_col(block.start);
-            if start_row > 0 {
-                self.line_end(start_row - 1)
-            } else {
-                0
+            // An alignment marker directly above belongs to the block — resting
+            // on it reveals the region, so step past it too.
+            let mut row = start_row;
+            if row > 0 && markdown_syntax::math_align_marker(self.line_str(row - 1)).is_some() {
+                row -= 1;
             }
+            if row > 0 { self.line_end(row - 1) } else { 0 }
         };
         self.move_to(target, cx);
     }

--- a/crates/gpui-editor/src/lib.rs
+++ b/crates/gpui-editor/src/lib.rs
@@ -994,6 +994,11 @@ struct EditingBlock {
 struct EditingInline {
     range: Range<usize>,
     view: gpui::AnyView,
+    /// Where the view's top-left sits relative to the formula raster's top-left. The
+    /// host's editor view pads its raster differently than the display raster (whose
+    /// padding was baked at the block em and scaled down), so a zero offset shifts
+    /// the glyphs visibly on entering edit.
+    offset: Point<Pixels>,
 }
 
 impl EditorState {
@@ -1409,13 +1414,20 @@ impl EditorState {
 
     /// Begin a structural edit of the inline `$…$` span at `range` (absolute bytes): overlay
     /// `view` (the host's editor) at the formula's painted spot. The host focuses `view`.
+    /// `offset` places the view relative to the raster's top-left, letting the host
+    /// align the view's glyphs with the displayed formula's (their paddings differ).
     pub fn set_editing_inline(
         &mut self,
         range: Range<usize>,
         view: gpui::AnyView,
+        offset: Point<Pixels>,
         cx: &mut Context<Self>,
     ) {
-        self.editing_inline = Some(EditingInline { range, view });
+        self.editing_inline = Some(EditingInline {
+            range,
+            view,
+            offset,
+        });
         cx.notify();
     }
 
@@ -1615,8 +1627,8 @@ impl EditorState {
         Some(
             div()
                 .absolute()
-                .top(rect.origin.y - origin.y)
-                .left(rect.origin.x - origin.x)
+                .top(rect.origin.y - origin.y + ei.offset.y)
+                .left(rect.origin.x - origin.x + ei.offset.x)
                 .occlude()
                 .child(ei.view.clone()),
         )
@@ -1816,7 +1828,22 @@ impl EditorState {
         if visual_right {
             self.next_visible_boundary(off)
         } else {
-            self.prev_visible_boundary(off)
+            let target = self.prev_visible_boundary(off);
+            // Same nudge as the bidi branch above: a leftward step over a formula's
+            // spacer resolves to the span's START, which fails `left()`'s strictly-
+            // inside test — so on plain LTR rows the editor never opened from the
+            // right and the caret just seated at the formula's start (#77).
+            let (trow, _) = self.row_col(target);
+            let line_start = self.line_starts()[trow];
+            let here = off.saturating_sub(line_start);
+            let lands_on_a_formula = markdown_syntax::inline_math_spans(self.line_str(trow))
+                .into_iter()
+                .any(|s| line_start + s.start == target && !(s.start < here && here < s.end));
+            if lands_on_a_formula {
+                target + 1
+            } else {
+                target
+            }
         }
     }
 

--- a/crates/ratex-gpui/API.md
+++ b/crates/ratex-gpui/API.md
@@ -66,6 +66,7 @@ The surface splits into three layers, documented in this order:
 | [`Cursor::matrix_remove_col`](#matrix-row--column-editing) | method | `editor` | `fn matrix_remove_col(&mut self, top: &mut Row)` | Remove the caret's matrix column (last column is kept) |
 | [`Cursor::delete_range`](#cursordelete_range) | method | `editor` | `fn delete_range(&mut self, top: &mut Row, lo: usize, hi: usize)` | Delete a selection (atom range) in the cursor's row |
 | [`Cursor::wrap_delim`](#the-wrap_-methods) | method | `editor` | `fn wrap_delim(&mut self, top: &mut Row, lo: usize, hi: usize, open: &str, close: &str)` | Wrap a selection in `\left…\right` delimiters |
+| [`Cursor::wrap_accent`](#the-wrap_-methods) | method | `editor` | `fn wrap_accent(&mut self, top: &mut Row, lo: usize, hi: usize, accent: &str)` | Wrap a selection under an accent (`\hat`, `\bar`, …) |
 | [`Cursor::wrap_sqrt`](#the-wrap_-methods) | method | `editor` | `fn wrap_sqrt(&mut self, top: &mut Row, lo: usize, hi: usize)` | Wrap a selection under a square root |
 | [`Cursor::wrap_nth_root`](#the-wrap_-methods) | method | `editor` | `fn wrap_nth_root(&mut self, top: &mut Row, lo: usize, hi: usize)` | Wrap under an nth-root; caret into the degree box |
 | [`Cursor::wrap_fraction`](#the-wrap_-methods) | method | `editor` | `fn wrap_fraction(&mut self, top: &mut Row, lo: usize, hi: usize)` | Selection → numerator; caret into the denominator |
@@ -347,6 +348,8 @@ pub enum Atom {
     SupSub { sup: Option<Row>, sub: Option<Row> },
     /// \sqrt{radicand} or \sqrt[index]{radicand}.
     Sqrt { radicand: Row, index: Option<Row> },
+    /// An accent over an editable base: \hat{base}, \bar{base}, \vec{base}, ….
+    Accent { accent: String, base: Row },
     /// Auto-growing delimiters: \left<open> body \right<close>.
     Delim { open: String, body: Row, close: String },
     /// A matrix: a rectangular grid of cells (rows[r][c]), rendered with parentheses.
@@ -446,6 +449,7 @@ pub enum Slot {
     Radicand,          // root body
     Index,             // nth-root degree
     Body,              // delimiter body
+    Base,              // accent base
     Sup,               // superscript
     Sub,               // subscript
     Cell(usize, usize) // matrix cell at (row, column)
@@ -623,6 +627,7 @@ at `lo`.
 
 ```rust
 pub fn wrap_delim(&mut self, top: &mut Row, lo: usize, hi: usize, open: &str, close: &str)
+pub fn wrap_accent(&mut self, top: &mut Row, lo: usize, hi: usize, accent: &str)
 pub fn wrap_sqrt(&mut self, top: &mut Row, lo: usize, hi: usize)
 pub fn wrap_nth_root(&mut self, top: &mut Row, lo: usize, hi: usize)
 pub fn wrap_fraction(&mut self, top: &mut Row, lo: usize, hi: usize)
@@ -633,6 +638,7 @@ Replace atoms `lo..hi` of the cursor's row with **one structure containing them*
 | Method | Selection becomes | Caret lands |
 | --- | --- | --- |
 | `wrap_delim` | the delimiter's body (`\left<open> … \right<close>`) | just **after** the delimiter |
+| `wrap_accent` | the accent's base (`accent` is the command, e.g. `r"\hat"`) | just **after** the accent |
 | `wrap_sqrt` | the radicand | just **after** the root |
 | `wrap_nth_root` | the radicand (an empty degree box is added) | **inside the degree**, ready to type e.g. `3` |
 | `wrap_fraction` | the numerator (denominator starts empty) | **inside the denominator** |
@@ -910,7 +916,7 @@ commit the view actually calls.
 
 - With a selection, a **wrap-capable** command wraps it instead of inserting empty:
   `frac` → [`wrap_fraction`](#the-wrap_-methods), `sqrt` → `wrap_sqrt`, `nthroot` →
-  `wrap_nth_root`, any delimiter → `wrap_delim`. (Returns `true` even if the range was
+  `wrap_nth_root`, any delimiter → `wrap_delim`, any accent → `wrap_accent`. (Returns `true` even if the range was
   empty/out-of-bounds and the wrap no-opped.)
 - Every other command — and any command with `sel: None` — is plain
   `commit_command`: it inserts at the caret, leaving the selection's atoms in place

--- a/crates/ratex-gpui/API.md
+++ b/crates/ratex-gpui/API.md
@@ -82,7 +82,7 @@ The surface splits into three layers, documented in this order:
 | [`editor::input::commit_command_selecting`](#commit_command_selecting) | fn | `editor` | `fn commit_command_selecting(top: &mut Row, cursor: &mut Cursor, name: &str, sel: Option<(usize, usize)>) -> bool` | Same, wrapping a selection when the command can |
 | [`editor::input::delim_pair`](#delim_pair) | fn | `editor` | `fn delim_pair(c: char) -> Option<(&'static str, &'static str)>` | The `(open, close)` pair a typed bracket wraps with |
 | [`editor::input::command_matches`](#command_matches) | fn | `editor` | `fn command_matches(prefix: &str) -> Vec<&'static str>` | Autocomplete: command names starting with a prefix |
-| [`editor::input::PALETTE`](#const-palette) | const | `editor` | `const PALETTE: &[(&str, &str)]` | The 40-button click-to-insert palette (glyph, command) |
+| [`editor::input::PALETTE`](#const-palette) | const | `editor` | `const PALETTE: &[(&str, &str)]` | The 45-button click-to-insert palette (glyph, command) |
 | [`MathEditor`](#struct-matheditor) | struct | `editor` | — | The interactive gpui editor view. Re-exported at the crate root; lives in `editor::view` |
 | [`MathEditor::new`](#matheditornew) | constructor | `editor` | `fn new(cx: &mut Context<Self>) -> Self` | An empty standalone editor (48 px/em, floating palette) |
 | [`MathEditor::from_latex`](#matheditorfrom_latex) | constructor | `editor` | `fn from_latex(latex: &str, font_size: f32, at_end: bool, align: MathAlign, theme: MathTheme, cx: &mut Context<Self>) -> Self` | An in-line editor seeded from LaTeX |

--- a/crates/ratex-gpui/src/editor/cursor.rs
+++ b/crates/ratex-gpui/src/editor/cursor.rs
@@ -147,12 +147,23 @@ impl Cursor {
         }
     }
 
-    /// Delete the atom before the cursor. At a slot start, ascend out to before the
-    /// structure (deleting an empty structure outright is a later refinement).
+    /// Delete the atom before the cursor. An accent peels — the wrapper goes, its base
+    /// stays in place (`\hat{x}` → `x`, MathQuill's convention) — since the base is
+    /// user content a plain remove would silently destroy. At a slot start, ascend out
+    /// to before the structure (deleting an empty structure outright is a later
+    /// refinement).
     pub fn backspace(&mut self, top: &mut Row) {
         if self.index > 0 {
-            resolve_mut(top, &self.path).atoms.remove(self.index - 1);
-            self.index -= 1;
+            let row = resolve_mut(top, &self.path);
+            let at = self.index - 1;
+            if let Atom::Accent { base, .. } = &mut row.atoms[at] {
+                let inner = std::mem::take(&mut base.atoms);
+                self.index = at + inner.len();
+                row.atoms.splice(at..=at, inner);
+            } else {
+                row.atoms.remove(at);
+                self.index = at;
+            }
         } else if let Some(step) = self.path.pop() {
             self.index = step.atom;
         }
@@ -676,6 +687,29 @@ mod tests {
         cur.move_right(&top); // base end -> out after the accent
         assert_eq!(cur.path, vec![]);
         assert_eq!(cur.index, 1);
+    }
+
+    #[test]
+    fn backspace_after_accent_peels_the_wrapper() {
+        let mut top = Row::new();
+        let mut cur = Cursor::start();
+        cur.insert(
+            &mut top,
+            Atom::Accent {
+                accent: r"\hat".into(),
+                base: Row::new(),
+            },
+        ); // descends into the base
+        cur.insert(&mut top, sym("x"));
+        cur.insert(&mut top, sym("y"));
+        cur.move_right(&top); // base end -> out, after the accent
+        assert_eq!(top.to_latex(), r"\hat{x y}");
+        assert_eq!((cur.path.clone(), cur.index), (vec![], 1));
+        cur.backspace(&mut top); // peel: the base stays, the hat goes
+        assert_eq!(top.to_latex(), "x y");
+        assert_eq!(cur.index, 2);
+        cur.backspace(&mut top); // plain delete resumes
+        assert_eq!(top.to_latex(), "x");
     }
 
     #[test]

--- a/crates/ratex-gpui/src/editor/cursor.rs
+++ b/crates/ratex-gpui/src/editor/cursor.rs
@@ -20,6 +20,8 @@ pub enum Slot {
     Radicand,
     Index,
     Body,
+    /// An accent's base row.
+    Base,
     Sup,
     Sub,
     /// A matrix cell at (row, column).
@@ -52,6 +54,7 @@ pub(crate) fn nav_slots(atom: &Atom) -> Vec<Slot> {
             }
         }
         Atom::Delim { .. } => vec![Slot::Body],
+        Atom::Accent { .. } => vec![Slot::Base],
         Atom::Matrix { rows } => (0..rows.len())
             .flat_map(|r| (0..rows[r].len()).map(move |c| Slot::Cell(r, c)))
             .collect(),
@@ -77,6 +80,7 @@ fn slot_row(atom: &Atom, slot: Slot) -> &Row {
         (Atom::Sqrt { radicand, .. }, Slot::Radicand) => radicand,
         (Atom::Sqrt { index: Some(i), .. }, Slot::Index) => i,
         (Atom::Delim { body, .. }, Slot::Body) => body,
+        (Atom::Accent { base, .. }, Slot::Base) => base,
         (Atom::SupSub { sub: Some(r), .. }, Slot::Sub) => r,
         (Atom::SupSub { sup: Some(r), .. }, Slot::Sup) => r,
         (Atom::Matrix { rows }, Slot::Cell(r, c)) => &rows[r][c],
@@ -91,6 +95,7 @@ fn slot_row_mut(atom: &mut Atom, slot: Slot) -> &mut Row {
         (Atom::Sqrt { radicand, .. }, Slot::Radicand) => radicand,
         (Atom::Sqrt { index: Some(i), .. }, Slot::Index) => i,
         (Atom::Delim { body, .. }, Slot::Body) => body,
+        (Atom::Accent { base, .. }, Slot::Base) => base,
         (Atom::SupSub { sub: Some(r), .. }, Slot::Sub) => r,
         (Atom::SupSub { sup: Some(r), .. }, Slot::Sup) => r,
         (Atom::Matrix { rows }, Slot::Cell(r, c)) => &mut rows[r][c],
@@ -384,6 +389,17 @@ impl Cursor {
         }
     }
 
+    /// Wrap a selection (`lo..hi`) under an accent (`\hat`, `\bar`, …) — the selection
+    /// becomes the base. Caret lands just after the accent.
+    pub fn wrap_accent(&mut self, top: &mut Row, lo: usize, hi: usize, accent: &str) {
+        if let Some(at) = self.wrap_range(top, lo, hi, |base| Atom::Accent {
+            accent: accent.to_string(),
+            base,
+        }) {
+            self.index = at + 1;
+        }
+    }
+
     /// Wrap a selection (`lo..hi`) under a square root. Caret lands just after the root.
     pub fn wrap_sqrt(&mut self, top: &mut Row, lo: usize, hi: usize) {
         if let Some(at) = self.wrap_range(top, lo, hi, |radicand| Atom::Sqrt {
@@ -634,6 +650,44 @@ mod tests {
         cur.move_right(&top); // sup end -> out after the script
         assert_eq!(cur.path, vec![]);
         assert_eq!(cur.index, 2);
+    }
+
+    #[test]
+    fn accent_descend_type_and_exit() {
+        let mut top = Row::new();
+        let mut cur = Cursor::start();
+        cur.insert(
+            &mut top,
+            Atom::Accent {
+                accent: r"\hat".into(),
+                base: Row::new(),
+            },
+        );
+        // insert descends into the base slot
+        assert_eq!(
+            cur.path,
+            vec![Step {
+                atom: 0,
+                slot: Slot::Base
+            }]
+        );
+        cur.insert(&mut top, sym("X"));
+        assert_eq!(top.to_latex(), r"\hat{X}");
+        cur.move_right(&top); // base end -> out after the accent
+        assert_eq!(cur.path, vec![]);
+        assert_eq!(cur.index, 1);
+    }
+
+    #[test]
+    fn wrap_accent_wraps_a_range_caret_after() {
+        let mut top = Row::new();
+        let mut cur = Cursor::start();
+        for c in ["x", "y"] {
+            cur.insert(&mut top, sym(c));
+        }
+        cur.wrap_accent(&mut top, 0, 2, r"\bar");
+        assert_eq!(top.to_latex(), r"\bar{x y}");
+        assert_eq!(cur.index, 1);
     }
 
     #[test]

--- a/crates/ratex-gpui/src/editor/cursor.rs
+++ b/crates/ratex-gpui/src/editor/cursor.rs
@@ -119,6 +119,43 @@ fn resolve_mut<'a>(row: &'a mut Row, path: &[Step]) -> &'a mut Row {
     }
 }
 
+/// Collapse two positions into a selection in their deepest COMMON row: each end
+/// climbs out of any structure the other doesn't share, taking that structure in
+/// whole (MathQuill's drag-selection semantics). Returns `(row_path, lo, hi)`;
+/// `lo == hi` when both ends resolve to the same spot.
+pub fn common_row_selection(a: &Cursor, b: &Cursor) -> (Vec<Step>, usize, usize) {
+    let common = a
+        .path
+        .iter()
+        .zip(b.path.iter())
+        .take_while(|(x, y)| x == y)
+        .count();
+    // Each end's position at the common depth: the atom of the structure it's still
+    // inside, or its own index when it lives in the common row.
+    let pos = |c: &Cursor| c.path.get(common).map(|s| s.atom).unwrap_or(c.index);
+    let (pa, pb) = (pos(a), pos(b));
+    let path = a.path[..common].to_vec();
+    if a.path.len() > common && b.path.len() > common && pa == pb {
+        // Both inside the same structure but on divergent branches (e.g. a
+        // fraction's num vs den): the selection is that structure, whole.
+        return (path, pa, pa + 1);
+    }
+    // The left end includes its structure from its left edge (the atom itself);
+    // the right end includes through its right edge (atom + 1).
+    let edge = |c: &Cursor, p: usize, rightward: bool| {
+        if c.path.len() > common {
+            if rightward { p + 1 } else { p }
+        } else {
+            c.index
+        }
+    };
+    if pa <= pb {
+        (path, edge(a, pa, false), edge(b, pb, true))
+    } else {
+        (path, edge(b, pb, false), edge(a, pa, true))
+    }
+}
+
 impl Cursor {
     /// Cursor at the start of the top-level row.
     pub fn start() -> Self {
@@ -687,6 +724,49 @@ mod tests {
         cur.move_right(&top); // base end -> out after the accent
         assert_eq!(cur.path, vec![]);
         assert_eq!(cur.index, 1);
+    }
+
+    #[test]
+    fn common_row_selection_reconciles_divergent_ends() {
+        let step = |atom, slot| Step { atom, slot };
+        // Ends inside two different structures of the top row: both climb out,
+        // each structure taken whole (atoms 1 and 3 → 1..4).
+        let a = Cursor {
+            path: vec![step(1, Slot::Base)],
+            index: 0,
+        };
+        let b = Cursor {
+            path: vec![step(3, Slot::Base)],
+            index: 1,
+        };
+        assert_eq!(common_row_selection(&a, &b), (vec![], 1, 4));
+        // Order-independent.
+        assert_eq!(common_row_selection(&b, &a), (vec![], 1, 4));
+        // One end deep, one in the row: the structure is included whole.
+        let c = Cursor {
+            path: vec![],
+            index: 0,
+        };
+        assert_eq!(common_row_selection(&c, &a), (vec![], 0, 2));
+        // Divergent branches of the SAME structure select just that structure.
+        let n = Cursor {
+            path: vec![step(2, Slot::Num)],
+            index: 0,
+        };
+        let d = Cursor {
+            path: vec![step(2, Slot::Den)],
+            index: 1,
+        };
+        assert_eq!(common_row_selection(&n, &d), (vec![], 2, 3));
+        // Both in one nested row: a plain range there.
+        let e = Cursor {
+            path: vec![step(2, Slot::Num)],
+            index: 2,
+        };
+        assert_eq!(
+            common_row_selection(&n, &e),
+            (vec![step(2, Slot::Num)], 0, 2)
+        );
     }
 
     #[test]

--- a/crates/ratex-gpui/src/editor/geometry.rs
+++ b/crates/ratex-gpui/src/editor/geometry.rs
@@ -103,6 +103,7 @@ fn slot_model_row(atom: &Atom, slot: Slot) -> Option<&Row> {
         (Atom::Sqrt { radicand, .. }, Slot::Radicand) => Some(radicand),
         (Atom::Sqrt { index: Some(i), .. }, Slot::Index) => Some(i),
         (Atom::Delim { body, .. }, Slot::Body) => Some(body),
+        (Atom::Accent { base, .. }, Slot::Base) => Some(base),
         (Atom::SupSub { sub: Some(r), .. }, Slot::Sub) => Some(r),
         (Atom::SupSub { sup: Some(r), .. }, Slot::Sup) => Some(r),
         (Atom::Matrix { rows }, Slot::Cell(r, c)) => rows.get(r).and_then(|row| row.get(c)),
@@ -262,6 +263,9 @@ fn descend(
         (BoxContent::LeftRight { left, inner, .. }, Slot::Body) => {
             Some((&**inner, x + left.width * scale, y, scale))
         }
+        // Accent base: `to_display` emits the base at the accent box's own origin
+        // (the mark floats above it), so the base inherits (x, y, scale) unchanged.
+        (BoxContent::Accent { base, .. }, Slot::Base) => Some((&**base, x, y, scale)),
         // Square-root radicand: right of the surd glyph.
         (BoxContent::Radical { body, .. }, Slot::Radicand) => {
             Some((&**body, x + (boxx.width - body.width) * scale, y, scale))

--- a/crates/ratex-gpui/src/editor/input.rs
+++ b/crates/ratex-gpui/src/editor/input.rs
@@ -44,6 +44,17 @@ pub fn type_char(top: &mut Row, cursor: &mut Cursor, ch: char) {
             },
         ),
         ')' => close_delim(cursor),
+        // A typed brace is the literal `\{…\}` pair, mirroring `(` — a bare `{` Sym
+        // would be TeX group syntax and render as nothing (#77).
+        '{' => cursor.insert(
+            top,
+            Atom::Delim {
+                open: r"\{".into(),
+                body: Row::new(),
+                close: r"\}".into(),
+            },
+        ),
+        '}' => close_delim(cursor),
         ' ' => exit_structure(cursor),
         _ => cursor.insert(top, Atom::Sym(ch.to_string())),
     }
@@ -104,6 +115,9 @@ enum Command {
     OpSub(&'static str),
     /// A matrix — a 2×2 grid of empty cells (caret into the top-left).
     Matrix,
+    /// An accent (`\hat`, `\bar`, …) over an editable base. With a selection it wraps
+    /// it; otherwise an empty base (caret inside).
+    Accent(&'static str),
 }
 
 /// The known `\commands`. Table order is the autocomplete order.
@@ -117,6 +131,12 @@ const COMMANDS: &[(&str, Command)] = &[
     ("brace", Command::Delim(r"\{", r"\}")), ("abs", Command::Delim("|", "|")),
     ("norm", Command::Delim(r"\|", r"\|")), ("angle", Command::Delim(r"\langle", r"\rangle")),
     ("floor", Command::Delim(r"\lfloor", r"\rfloor")), ("ceil", Command::Delim(r"\lceil", r"\rceil")),
+    // accents (wrap a selection, or insert an empty base)
+    ("hat", Command::Accent(r"\hat")), ("widehat", Command::Accent(r"\widehat")),
+    ("bar", Command::Accent(r"\bar")), ("vec", Command::Accent(r"\vec")),
+    ("tilde", Command::Accent(r"\tilde")), ("widetilde", Command::Accent(r"\widetilde")),
+    ("dot", Command::Accent(r"\dot")), ("ddot", Command::Accent(r"\ddot")),
+    ("check", Command::Accent(r"\check")), ("breve", Command::Accent(r"\breve")),
     // operators / functions
     ("int", Command::OpLimits(r"\int")), ("iint", Command::OpLimits(r"\iint")),
     ("oint", Command::OpLimits(r"\oint")), ("sum", Command::OpLimits(r"\sum")),
@@ -237,6 +257,13 @@ pub fn commit_command(top: &mut Row, cursor: &mut Cursor, name: &str) -> bool {
                 close: close.to_string(),
             },
         ),
+        Some(Command::Accent(accent)) => cursor.insert(
+            top,
+            Atom::Accent {
+                accent: accent.to_string(),
+                base: Row::new(),
+            },
+        ),
         None => return false,
     }
     true
@@ -268,6 +295,10 @@ pub fn commit_command_selecting(
         }
         (Some(Command::Delim(open, close)), Some((lo, hi))) => {
             cursor.wrap_delim(top, lo, hi, open, close);
+            true
+        }
+        (Some(Command::Accent(accent)), Some((lo, hi))) => {
+            cursor.wrap_accent(top, lo, hi, accent);
             true
         }
         _ => commit_command(top, cursor, name),
@@ -324,6 +355,21 @@ mod tests {
             type_char(&mut top, &mut cur, ch);
         }
         top
+    }
+
+    #[test]
+    fn typed_braces_are_a_literal_pair() {
+        // `{x}` types as the `\{…\}` delimiter, `}` hops out — never a bare group (#77).
+        assert_eq!(typed("{x}y").to_latex(), r"\left\{ x \right\} y");
+    }
+
+    #[test]
+    fn hat_command_descends_into_base() {
+        let mut top = Row::new();
+        let mut cur = Cursor::start();
+        assert!(commit_command(&mut top, &mut cur, "hat"));
+        type_char(&mut top, &mut cur, 'X');
+        assert_eq!(top.to_latex(), r"\hat{X}");
     }
 
     #[test]

--- a/crates/ratex-gpui/src/editor/input.rs
+++ b/crates/ratex-gpui/src/editor/input.rs
@@ -342,6 +342,8 @@ pub const PALETTE: &[(&str, &str)] = &[
     ("≤", "le"),     ("≥", "ge"),      ("≠", "ne"),     ("≈", "approx"),
     ("×", "times"),  ("÷", "div"),     ("·", "cdot"),   ("±", "pm"),
     ("→", "to"),     ("∂", "partial"), ("∇", "nabla"),  ("∈", "in"),
+    // accents — wrap the selection, or insert an empty base (#77)
+    ("x\u{302}", "hat"), ("x\u{304}", "bar"), ("x\u{20D7}", "vec"), ("x\u{303}", "tilde"), ("x\u{307}", "dot"),
 ];
 
 #[cfg(test)]

--- a/crates/ratex-gpui/src/editor/latex.rs
+++ b/crates/ratex-gpui/src/editor/latex.rs
@@ -1,8 +1,8 @@
 //! LaTeX → edit-tree parsing — the inverse of [`Row::to_latex`]. Rather than hand-write a
 //! LaTeX tokenizer, we reuse RaTeX's own parser (`ratex_parser::parse` → `ParseNode` AST)
 //! and walk that tree into our `Row`/`Atom` model. Best-effort: constructs the model doesn't
-//! represent (accents, fonts, colors, spacing, …) degrade to their inner content or are
-//! dropped, so an existing `$$…$$` block round-trips for editing and never errors on input.
+//! represent (fonts, colors, spacing, …) degrade to their inner content or are dropped,
+//! so an existing `$$…$$` block round-trips for editing and never errors on input.
 
 use crate::editor::model::{Atom, Row};
 use ratex_parser::{ParseNode, parse};
@@ -132,9 +132,13 @@ fn push_node(atoms: &mut Vec<Atom>, node: &ParseNode) {
                 push_node(atoms, n);
             }
         }
-        ParseNode::Accent { base, .. } | ParseNode::AccentUnder { base, .. } => {
-            push_node(atoms, base)
-        }
+        // An accent keeps its base editable (#77) — previously it degraded to the bare
+        // base, so opening `\hat{X}` for editing silently rewrote it as `X`.
+        ParseNode::Accent { label, base, .. } => atoms.push(Atom::Accent {
+            accent: label.clone(),
+            base: node_to_row(base),
+        }),
+        ParseNode::AccentUnder { base, .. } => push_node(atoms, base),
         ParseNode::Overline { body, .. }
         | ParseNode::Underline { body, .. }
         | ParseNode::VPhantom { body, .. }
@@ -194,6 +198,47 @@ mod tests {
                 index: Some(Row::syms("3")),
             }],
         });
+    }
+
+    #[test]
+    fn roundtrips_accent() {
+        // The #77 data-loss guard: `\hat{X}` must survive parse → serialize unchanged.
+        roundtrip(Row {
+            atoms: vec![Atom::Accent {
+                accent: r"\hat".into(),
+                base: Row::syms("X"),
+            }],
+        });
+    }
+
+    /// Every accent the editor can insert must round-trip through RaTeX and lay out —
+    /// guards against shipping a `Command::Accent` the engine can't parse.
+    #[test]
+    fn accent_variants_roundtrip_and_lay_out() {
+        for accent in [
+            r"\hat",
+            r"\widehat",
+            r"\bar",
+            r"\vec",
+            r"\tilde",
+            r"\widetilde",
+            r"\dot",
+            r"\ddot",
+            r"\check",
+            r"\breve",
+        ] {
+            let row = Row {
+                atoms: vec![Atom::Accent {
+                    accent: accent.into(),
+                    base: Row::syms("x"),
+                }],
+            };
+            let latex = row.to_latex();
+            assert_eq!(parse_latex(&latex), row, "{latex} round-trips");
+            let nodes = parse(&latex).unwrap_or_else(|_| panic!("RaTeX parses {latex}"));
+            let lbox = ratex_layout::layout(&nodes, &ratex_layout::LayoutOptions::default());
+            assert!(lbox.width > 0.0, "{latex} lays out to a non-empty box");
+        }
     }
 
     #[test]

--- a/crates/ratex-gpui/src/editor/model.rs
+++ b/crates/ratex-gpui/src/editor/model.rs
@@ -25,6 +25,9 @@ pub enum Atom {
     SupSub { sup: Option<Row>, sub: Option<Row> },
     /// `\sqrt{radicand}` or `\sqrt[index]{radicand}`.
     Sqrt { radicand: Row, index: Option<Row> },
+    /// An accent over an editable base: `\hat{base}`, `\bar{base}`, `\vec{base}`, ….
+    /// `accent` is the command (`"\\hat"`).
+    Accent { accent: String, base: Row },
     /// Auto-growing delimiters: `\left<open> body \right<close>`.
     Delim {
         open: String,
@@ -69,6 +72,10 @@ impl Row {
 impl Atom {
     pub fn to_latex(&self) -> String {
         match self {
+            // A bare brace is TeX group syntax, not a glyph — escape it so a stray
+            // `{` Sym can never emit an unbalanced group (#77).
+            Atom::Sym(s) if s == "{" => r"\{".to_string(),
+            Atom::Sym(s) if s == "}" => r"\}".to_string(),
             Atom::Sym(s) => s.clone(),
             Atom::Frac { num, den } => {
                 format!(r"\frac{{{}}}{{{}}}", num.to_latex(), den.to_latex())
@@ -89,6 +96,7 @@ impl Atom {
                 Some(idx) => format!(r"\sqrt[{}]{{{}}}", idx.to_latex(), radicand.to_latex()),
                 None => format!(r"\sqrt{{{}}}", radicand.to_latex()),
             },
+            Atom::Accent { accent, base } => format!("{}{{{}}}", accent, base.to_latex()),
             Atom::Delim { open, body, close } => {
                 format!(r"\left{} {} \right{}", open, body.to_latex(), close)
             }
@@ -192,6 +200,25 @@ mod tests {
             index: Some(Row::syms("3")),
         };
         assert_eq!(s.to_latex(), r"\sqrt[3]{x}");
+    }
+
+    #[test]
+    fn accent_wraps_its_base() {
+        let a = Atom::Accent {
+            accent: r"\hat".into(),
+            base: Row::syms("X"),
+        };
+        assert_eq!(a.to_latex(), r"\hat{X}");
+        let nodes = ratex_parser::parse(&a.to_latex()).expect("RaTeX parses accents");
+        let lbox = ratex_layout::layout(&nodes, &ratex_layout::LayoutOptions::default());
+        assert!(lbox.width > 0.0);
+    }
+
+    #[test]
+    fn bare_brace_syms_escape() {
+        // A stray brace Sym must never emit TeX group syntax (#77).
+        assert_eq!(Atom::Sym("{".into()).to_latex(), r"\{");
+        assert_eq!(Atom::Sym("}".into()).to_latex(), r"\}");
     }
 
     #[test]

--- a/crates/ratex-gpui/src/editor/view.rs
+++ b/crates/ratex-gpui/src/editor/view.rs
@@ -355,6 +355,21 @@ impl MathEditor {
         // An arrow that left the caret unmoved in normal mode is a boundary: hand focus back
         // to the host so the text caret flows out of the formula (left/up → before the block,
         // right/down → after it), the way arrowing past a table cell's edge exits the table.
+        // An up that can't move seats the caret at the formula's start (text-editor
+        // convention for up on the first line); only a second up at the start exits.
+        // Keeps a stray up from dumping the caret out of the formula — worst where
+        // the block opens the document and "before the block" reveals the raw source.
+        if was_normal
+            && !ks.modifiers.shift
+            && ks.key == "up"
+            && self.cursor == cursor_before
+            && self.cursor != Cursor::start()
+        {
+            self.anchor = None;
+            self.cursor = Cursor::start();
+            cx.notify();
+            return;
+        }
         if was_normal
             && !ks.modifiers.shift
             && self.cursor == cursor_before

--- a/crates/ratex-gpui/src/editor/view.rs
+++ b/crates/ratex-gpui/src/editor/view.rs
@@ -135,11 +135,11 @@ impl Render for SelectDrag {
         gpui::Empty
     }
 }
-/// The palette panel's full height: 40 buttons wrap to 8 rows at this width
+/// The palette panel's full height: 45 buttons wrap to 9 rows at this width
 /// (32px + 4px gap), plus padding and the drag handle. Used to flip the
 /// panel above the formula when the below-dock would clip at the window
 /// bottom — an estimate is fine, it only steers the flip.
-const PALETTE_H: f32 = 330.0;
+const PALETTE_H: f32 = 366.0;
 
 /// Cap on the formula's in-place undo history, to bound memory.
 const UNDO_CAP: usize = 200;

--- a/crates/ratex-gpui/src/editor/view.rs
+++ b/crates/ratex-gpui/src/editor/view.rs
@@ -423,7 +423,9 @@ impl MathEditor {
             },
             _ => match ks.key_char.as_ref().and_then(|s| s.chars().next()) {
                 Some('\\') => {
-                    self.anchor = None;
+                    // Keep the anchor: a selection survives into `\command` mode so a
+                    // wrap-capable command (frac, sqrt, delimiters, accents) typed over
+                    // it wraps it, MathQuill-style — commit_pending passes it along.
                     self.pending = Some(String::new());
                     self.selected = 0;
                     self.scroll_match_into_view();
@@ -527,10 +529,14 @@ impl MathEditor {
     /// Resolve the pending `\name`: the highlighted match, else the literal letters.
     fn commit_pending(&mut self) {
         let name = self.pending.take().unwrap_or_default();
+        let sel = self.selection_range();
+        self.anchor = None;
         let matches = input::command_matches(&name);
         match matches.get(self.selected).or_else(|| matches.first()) {
             Some(&chosen) => {
-                input::commit_command(&mut self.root, &mut self.cursor, chosen);
+                // A wrap-capable command typed over a selection wraps it (the
+                // selection becomes the numerator / radicand / accent base).
+                input::commit_command_selecting(&mut self.root, &mut self.cursor, chosen, sel);
             }
             None => {
                 for c in name.chars() {

--- a/crates/ratex-gpui/src/editor/view.rs
+++ b/crates/ratex-gpui/src/editor/view.rs
@@ -89,6 +89,9 @@ pub struct MathEditor {
     toolbar_drag: Option<(f32, f32)>,
     /// During an autocomplete-scrollbar drag: (grab mouse y, scrolled px at grab).
     thumb_drag: Option<(f32, f32)>,
+    /// During a mouse drag over the formula: the cursor at the press, i.e. the
+    /// selection's fixed end. Selection is single-row, like shift-arrows.
+    select_drag: Option<Cursor>,
     /// In-line edit mode (hosted in a note's text flow): left-align the formula at its spot
     /// and hide the floating palette + white background, vs the centered standalone editor.
     inline: bool,
@@ -117,6 +120,17 @@ const PALETTE_W: f32 = 200.0;
 struct GripDrag;
 
 impl Render for GripDrag {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        gpui::Empty
+    }
+}
+
+/// Drag payload for mouse selection over the formula — same on_drag/on_drag_move
+/// machinery as [`GripDrag`], so events keep flowing when the pointer leaves the
+/// formula's bounds mid-drag.
+struct SelectDrag;
+
+impl Render for SelectDrag {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         gpui::Empty
     }
@@ -242,6 +256,7 @@ impl MathEditor {
             toolbar_off: (0.0, 8.0),
             toolbar_drag: None,
             thumb_drag: None,
+            select_drag: None,
             inline,
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
@@ -1080,12 +1095,52 @@ impl Render for MathEditor {
                     }
                 }),
             )
+            .on_drag_move(
+                cx.listener(|this, e: &gpui::DragMoveEvent<SelectDrag>, _window, cx| {
+                    let Some(from) = this.select_drag.clone() else {
+                        return;
+                    };
+                    let Some((ex, ey)) = this.em_at(e.event.position) else {
+                        return;
+                    };
+                    let to = geometry::cursor_at(&this.root, ex, ey);
+                    // Selection is single-row: both ends climb to their deepest COMMON
+                    // row, taking each structure crossed in whole (a press inside one
+                    // accent's base dragged into another's must not bail).
+                    let (path, lo, hi) = crate::editor::cursor::common_row_selection(&from, &to);
+                    if lo == hi {
+                        this.anchor = None;
+                        this.cursor = Cursor { path, index: lo };
+                    } else {
+                        // The moving end follows the pointer's side of the range: compare
+                        // the two ends' positions at the common depth (the same measure
+                        // common_row_selection orders by).
+                        let depth = path.len();
+                        let pos = |c: &Cursor| c.path.get(depth).map(|s| s.atom).unwrap_or(c.index);
+                        let (fixed, moving) = if pos(&from) <= pos(&to) {
+                            (lo, hi)
+                        } else {
+                            (hi, lo)
+                        };
+                        this.anchor = Some(Cursor {
+                            path: path.clone(),
+                            index: fixed,
+                        });
+                        this.cursor = Cursor {
+                            path,
+                            index: moving,
+                        };
+                    }
+                    cx.notify();
+                }),
+            )
             .on_mouse_up(
                 MouseButton::Left,
                 cx.listener(|this, _: &MouseUpEvent, _window, cx| {
                     let dragged = this.palette_drag.take().is_some();
                     let dragged = this.toolbar_drag.take().is_some() || dragged;
                     let dragged = this.thumb_drag.take().is_some() || dragged;
+                    this.select_drag = None;
                     if dragged {
                         cx.notify();
                     }
@@ -1110,9 +1165,14 @@ impl Render for MathEditor {
             .children(root_palette)
             .child(
                 div()
+                    .id("ratex-formula")
                     .relative()
                     .w(px(w))
                     .h(px(h))
+                    .on_drag(SelectDrag, |_, _, _, cx| {
+                        cx.stop_propagation();
+                        cx.new(|_| SelectDrag)
+                    })
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(|this, ev: &MouseDownEvent, window, cx| {
@@ -1131,7 +1191,12 @@ impl Render for MathEditor {
                             }
                             // 1 click → caret, 2 → select the atom, 3+ → select the row/slot.
                             match ev.click_count {
-                                1 => this.click_to_caret(ev.position, cx),
+                                1 => {
+                                    this.click_to_caret(ev.position, cx);
+                                    // Arm drag-selection from the pressed caret; the root's
+                                    // SelectDrag on_drag_move extends it as the mouse moves.
+                                    this.select_drag = Some(this.cursor.clone());
+                                }
                                 2 => this.select_cell_at(ev.position, cx),
                                 _ => this.select_row_at(ev.position, cx),
                             }

--- a/crates/ratex-gpui/src/editor/view.rs
+++ b/crates/ratex-gpui/src/editor/view.rs
@@ -87,6 +87,8 @@ pub struct MathEditor {
     toolbar_off: (f32, f32),
     /// During a toolbar drag: the previous cursor position, for delta-based movement.
     toolbar_drag: Option<(f32, f32)>,
+    /// During an autocomplete-scrollbar drag: (grab mouse y, scrolled px at grab).
+    thumb_drag: Option<(f32, f32)>,
     /// In-line edit mode (hosted in a note's text flow): left-align the formula at its spot
     /// and hide the floating palette + white background, vs the centered standalone editor.
     inline: bool,
@@ -239,6 +241,7 @@ impl MathEditor {
             palette_drag: None,
             toolbar_off: (0.0, 8.0),
             toolbar_drag: None,
+            thumb_drag: None,
             inline,
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
@@ -499,19 +502,11 @@ impl MathEditor {
     }
 
     /// Scroll the autocomplete dropdown so the highlighted match stays visible — the list can
-    /// run past the height cap (the full `\` menu is ~75 entries). Mirrors the host slash menu.
+    /// run past the height cap (the full `\` menu is ~75 entries). gpui's `scroll_to_item`
+    /// uses the MEASURED child + viewport bounds at prepaint; the previous hand-rolled
+    /// `DROP_ITEM_H`/`DROP_MAX_H` math drifted whenever they disagreed with the paint.
     fn scroll_match_into_view(&self) {
-        let top = self.selected as f32 * DROP_ITEM_H;
-        let bot = top + DROP_ITEM_H;
-        let cur = -f32::from(self.match_scroll.offset().y);
-        let new = if top < cur {
-            top
-        } else if bot > cur + DROP_MAX_H {
-            bot - DROP_MAX_H
-        } else {
-            return;
-        };
-        self.match_scroll.set_offset(point(px(0.0), px(-new)));
+        self.match_scroll.scroll_to_item(self.selected);
     }
 
     /// Resolve the pending `\name`: the highlighted match, else the literal letters.
@@ -928,7 +923,16 @@ impl Render for MathEditor {
                 .flex()
                 .flex_col()
                 .children(matches.iter().enumerate().map(|(i, name)| {
-                    let row = div().px_2().py_1().child(format!("\\{name}"));
+                    // Pinned to DROP_ITEM_H so the scroll-into-view + thumb math (which
+                    // multiply by it) match the painted rows — padding-derived heights
+                    // drifted ~3px/row and the highlight walked off before scrolling.
+                    let row = div()
+                        .h(px(DROP_ITEM_H))
+                        .flex_shrink_0()
+                        .px_2()
+                        .flex()
+                        .items_center()
+                        .child(format!("\\{name}"));
                     if i == selected {
                         row.bg(theme.accent_bg).text_color(theme.accent)
                     } else {
@@ -938,15 +942,19 @@ impl Render for MathEditor {
 
             // Scrollbar thumb, shown only when the rows overflow the cap — sized from the
             // content height + positioned from the live offset (mirrors the host slash menu).
-            let rows_h = matches.len() as f32 * DROP_ITEM_H;
-            let thumb = (rows_h > DROP_MAX_H).then(|| {
-                let scrolled =
-                    (-f32::from(self.match_scroll.offset().y)).clamp(0.0, rows_h - DROP_MAX_H);
-                let thumb_h = (DROP_MAX_H * DROP_MAX_H / rows_h).max(24.0);
-                let thumb_top = scrolled / (rows_h - DROP_MAX_H) * (DROP_MAX_H - thumb_h);
+            // All MEASURED (last frame's bounds/content): estimating content height
+            // as rows × DROP_ITEM_H drifted from the paint, leaving the thumb short
+            // of the bottom on a fully-scrolled list. `max_offset` is content − view.
+            let vh = f32::from(self.match_scroll.bounds().size.height);
+            let max_scroll = f32::from(self.match_scroll.max_offset().y);
+            let thumb = (vh > 0.0 && max_scroll > 0.0).then(|| {
+                let scrolled = (-f32::from(self.match_scroll.offset().y)).clamp(0.0, max_scroll);
+                let thumb_h = (vh * vh / (vh + max_scroll)).max(24.0);
+                let thumb_top = scrolled / max_scroll * (vh - thumb_h);
                 let mut thumb_c = theme.muted;
                 thumb_c.a = 0.5;
                 div()
+                    .id("ratex-cmd-thumb")
                     .absolute()
                     .top(px(thumb_top))
                     .right(px(2.0))
@@ -954,6 +962,22 @@ impl Render for MathEditor {
                     .h(px(thumb_h))
                     .rounded(px(3.0))
                     .bg(thumb_c)
+                    .cursor_pointer()
+                    // Draggable: grab records (mouse y, scrolled-at-grab); the root's
+                    // on_drag_move maps the delta back to a scroll offset (same
+                    // GripDrag machinery as the palette).
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, ev: &MouseDownEvent, _window, cx| {
+                            this.thumb_drag = Some((f32::from(ev.position.y), scrolled));
+                            cx.stop_propagation();
+                            cx.notify();
+                        }),
+                    )
+                    .on_drag(GripDrag, |_, _, _, cx| {
+                        cx.stop_propagation();
+                        cx.new(|_| GripDrag)
+                    })
             });
 
             Some(
@@ -968,6 +992,10 @@ impl Render for MathEditor {
                     .rounded_md()
                     .overflow_hidden()
                     .text_size(px(14.0))
+                    // An absolute container offers min-content width, which wraps a
+                    // command name to one glyph per line — keep rows on one line so
+                    // the panel sizes to its longest match.
+                    .whitespace_nowrap()
                     .child(viewport)
                     .children(thumb),
             )
@@ -1014,6 +1042,20 @@ impl Render for MathEditor {
                         this.toolbar_off.1 += my - ly;
                         this.toolbar_drag = Some((mx, my));
                         cx.notify();
+                    } else if let Some((gy, scrolled_at_grab)) = this.thumb_drag {
+                        // Thumb-drag → scroll offset: a thumb pixel covers
+                        // max_scroll / (vh − thumb_h) content pixels. Same MEASURED
+                        // quantities the thumb render derives, so they stay in step.
+                        let vh = f32::from(this.match_scroll.bounds().size.height);
+                        let max_scroll = f32::from(this.match_scroll.max_offset().y);
+                        let thumb_h = (vh * vh / (vh + max_scroll)).max(24.0);
+                        if max_scroll > 0.0 && vh > thumb_h {
+                            let scrolled = (scrolled_at_grab
+                                + (my - gy) * max_scroll / (vh - thumb_h))
+                                .clamp(0.0, max_scroll);
+                            this.match_scroll.set_offset(point(px(0.0), px(-scrolled)));
+                            cx.notify();
+                        }
                     }
                 }),
             )
@@ -1022,6 +1064,7 @@ impl Render for MathEditor {
                 cx.listener(|this, _: &MouseUpEvent, _window, cx| {
                     let dragged = this.palette_drag.take().is_some();
                     let dragged = this.toolbar_drag.take().is_some() || dragged;
+                    let dragged = this.thumb_drag.take().is_some() || dragged;
                     if dragged {
                         cx.notify();
                     }
@@ -1093,17 +1136,17 @@ impl Render for MathEditor {
                     .children(image)
                     .children(caret)
                     .children(pending)
-                    // Deferred: the dropdown floats below the caret, often past
-                    // the host's reserved gap — without deferral, later-painted
-                    // siblings (the next journal day) draw over it.
-                    .children(dropdown.map(deferred))
                     // In-line palette + matrix toolbar live in the container, so they track the
                     // formula's centered / right-aligned position automatically.
-                    // Deferred like the dropdown: both panels float outside the
-                    // reserved gap (palette below the formula, toolbar under a
-                    // matrix) and must paint above the host's later content.
+                    // Deferred: both panels float outside the reserved gap (palette
+                    // below the formula, toolbar under a matrix) and must paint above
+                    // the host's later content.
                     .children(inner_palette.map(deferred))
-                    .children(self.matrix_toolbar(cx).map(deferred)),
+                    .children(self.matrix_toolbar(cx).map(deferred))
+                    // Deferred like the panels, and painted LAST: the dropdown floats
+                    // below the caret, often past the reserved gap and over the
+                    // palette (#77) — it must win both overlaps.
+                    .children(dropdown.map(deferred)),
             )
     }
 }

--- a/crates/ratex-gpui/src/editor/view.rs
+++ b/crates/ratex-gpui/src/editor/view.rs
@@ -488,6 +488,9 @@ impl MathEditor {
                     self.pending.as_mut().unwrap().push(c);
                     self.selected = 0;
                 }
+                // `{` commits like enter — LaTeX muscle memory types `\hat{` and expects
+                // the structure's slot to open (#77); the brace itself is consumed.
+                Some('{') => self.commit_pending(),
                 _ => return false,
             },
         }

--- a/src/app/math.rs
+++ b/src/app/math.rs
@@ -224,8 +224,19 @@ impl AppView {
         // Seat the editor: an inline `$…$` overlays the formula's spot (surrounding text stays
         // put); a `$$` block reserves a full-width gap at its row, sized to the cached render.
         if inline {
+            // Align the editor's glyphs with the displayed formula's: the editor pads
+            // its raster PAD px at text size, but the display raster's PAD was baked
+            // at the block em (FONT_SIZE) and scaled down — without compensation the
+            // formula shifts down/right by the difference on entering edit (#77).
+            let pad_delta =
+                ratex_gpui::render::PAD * (self.text_size / crate::math::FONT_SIZE - 1.0);
             source.update(cx, |e, cx| {
-                e.set_editing_inline(range, editor.clone().into(), cx)
+                e.set_editing_inline(
+                    range,
+                    editor.clone().into(),
+                    gpui::point(gpui::px(pad_delta), gpui::px(pad_delta)),
+                    cx,
+                )
             });
         } else {
             let height = self

--- a/src/app/math.rs
+++ b/src/app/math.rs
@@ -427,6 +427,20 @@ impl AppView {
     /// same line; a `$$` block seats it on the adjacent line.
     fn exit_math_edit(&mut self, after: bool, window: &mut Window, cx: &mut Context<Self>) {
         let inline = self.math_edit.as_ref().is_some_and(|m| m.inline);
+        // A `$$` block with nothing above it (document start, or only its own
+        // `<!-- math:ALIGN -->` marker): exiting "before" would seat the text caret
+        // on the opening fence row and reveal the raw source — stay in the formula.
+        if !after
+            && !inline
+            && let Some(edit) = self.math_edit.as_ref()
+            && let Some(range) = edit.source.read(cx).editing_block_range()
+        {
+            let text = edit.source.read(cx).value();
+            let above = text[..range.start.min(text.len())].trim_end_matches('\n');
+            if above.is_empty() || (!above.contains('\n') && above.starts_with("<!-- math:")) {
+                return;
+            }
+        }
         if let Some((source, block)) = self.commit_math_edit(cx) {
             // ratex-gpui reports the arrow it was handed — left/up = before the
             // span, right/down = after — which is the left-to-right reading. On


### PR DESCRIPTION
Fixes #77 — $\hat{X}$ was untypeable in WYSIWYG — plus the editing papercuts found live-testing the fix.

## The reported bug
- **`Atom::Accent { accent, base }`**: new command group (hat, widehat, bar, vec, tilde, widetilde, dot, ddot, check, breve) with an editable base slot, through model/serializer/parser/cursor/geometry. `parse_latex` maps `ParseNode::Accent` to it instead of degrading to the bare base — which silently rewrote `\hat{X}` as `X` on commit (data loss).
- **Braces**: typed `{` opens the literal `\{…\}` pair (mirroring `(`), `}` hops out; a bare-brace `Sym` escapes on serialize; `{` also commits a pending `\command`, so `\hat{` opens the slot the way LaTeX muscle memory expects.

## UX found while testing
- Autocomplete dropdown: paints above the palette, sizes to its content, keyboard scroll-into-view uses gpui's measured `scroll_to_item`, scrollbar thumb is draggable and derives from measured `max_offset`.
- Inline edit: the overlay compensates the padding-scale delta so entering edit no longer shifts the formula; arrow-entry from the right works on plain LTR rows (the bidi branch's lands-on-a-formula nudge, mirrored).
- First-line block: up-arrow no longer reveals the raw source (up seats the caret at the formula start first; the host swallows an exit with nothing above).
- Backspace after an accent peels the wrapper, keeping the base (MathQuill convention).
- `\command` typed over a selection wraps it (selection → accent base / numerator / radicand / delimiter body).
- Mouse drag-selection over the formula, reconciling both ends to their deepest common row.
- Palette: a ninth row of accent buttons (x̂ x̄ x⃗ x̃ ẋ).

18 new unit tests (round-trips through the real RaTeX engine, cursor navigation, peel, common-row selection). Live-tested end to end on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)