### PR TITLE
gpui-kit adoption: Settings builder, link hover previews, command palette, dev tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,7 @@ updates:
       - dependency-name: "gpui-pre-platform"
       - dependency-name: "gpui-component"
       - dependency-name: "gpui-kit-assets"
+      - dependency-name: "gpui-fps"
     groups:
       # One PR for the routine patch/minor sweep instead of a dozen; majors
       # still come through individually so they get a proper look.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ features — the legend is in that crate's `lib.rs` top doc.
 
 ```
 cargo run                                            # launch the app (root bin: zorite)
+cargo run --features fps                             # + gpui-fps performance HUD (dev only)
 ```
 
 Before every commit, run what CI runs (`.github/workflows/ci.yml`) — these must pass:
@@ -116,6 +117,10 @@ change must stay cross-platform.
 
 - Unit tests live in-file under `#[cfg(test)]`; cover non-trivial logic (import parsers,
   editor/whiteboard geometry, DB and link-rewriting).
+- Headless UI tests of chrome flows live in `src/app/ui_tests.rs`: a real `AppView` in
+  gpui's test window (`#[gpui::test]`, `VisualTestContext`), actions dispatched, keys
+  simulated, state read back. `paths::data_dir` is a throwaway dir under `cfg(test)`, so
+  they never open a real notebook. Add one when a chrome flow gets verified by hand.
 - Live-testing the GUI: synthetic **keyboard** input does not reach a GPUI window (mouse
   does) — verify shortcuts by hand. Kill all running instances before relaunching, and
   close the app before touching its SQLite DB (it opens a real one in the platform data dir).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10614,7 +10614,6 @@ dependencies = [
  "base64 0.22.1",
  "embed-resource",
  "env_logger",
- "gpui-bidi",
  "gpui-component",
  "gpui-kit-assets",
  "gpui-pdf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,7 +1679,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2773,6 +2782,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpui-fps"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4204e7d165577788c9a33fbf56c78513eedcd607198d579a620626000fbac891"
+dependencies = [
+ "core-graphics 0.24.0",
+ "gpui-pre",
+ "libc",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "sysinfo 0.37.2",
+ "uuid",
+ "wayland-client",
+ "web-time",
+ "windows 0.58.0",
+]
+
+[[package]]
 name = "gpui-kit-assets"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,6 +2836,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-task",
+ "backtrace",
  "bindgen",
  "bitflags 2.13.1",
  "chrono",
@@ -2830,6 +2858,7 @@ dependencies = [
  "gpui-pre-util",
  "gpui-pre-util-macros",
  "gpui-pre-ztracing",
+ "hdrhistogram",
  "heapless",
  "image",
  "inventory",
@@ -2843,6 +2872,7 @@ dependencies = [
  "pollster 0.4.0",
  "postage",
  "profiling",
+ "proptest",
  "rand 0.9.5",
  "raw-window-handle",
  "regex",
@@ -3534,6 +3564,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
 name = "heapless"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3902,7 +3942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -5302,6 +5342,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6014,6 +6064,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.1",
+ "num-traits",
+ "proptest-macro",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efaa288b896cb2b345da7b7f2110ab19e51565b83495b56fcec98a62f8b1f33e"
+dependencies = [
+ "convert_case 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pulp"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6050,6 +6132,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -6226,6 +6314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -6447,7 +6544,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -6922,6 +7019,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustybuzz"
@@ -7813,6 +7922,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7976,7 +8099,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl 0.1.12",
  "zune-jpeg 0.5.15",
 ]
@@ -8644,6 +8767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8986,6 +9115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
  "libc",
 ]
 
@@ -10451,7 +10589,7 @@ dependencies = [
  "rand 0.8.8",
  "screencapturekit",
  "screencapturekit-sys",
- "sysinfo",
+ "sysinfo 0.31.4",
  "tao-core-video-sys",
  "windows 0.61.3",
  "windows-capture",
@@ -10615,6 +10753,7 @@ dependencies = [
  "embed-resource",
  "env_logger",
  "gpui-component",
+ "gpui-fps",
  "gpui-kit-assets",
  "gpui-pdf",
  "gpui-pre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10614,6 +10614,7 @@ dependencies = [
  "base64 0.22.1",
  "embed-resource",
  "env_logger",
+ "gpui-bidi",
  "gpui-component",
  "gpui-kit-assets",
  "gpui-pdf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,6 @@ gpui_platform = { package = "gpui-pre-platform", version = "0.3", features = [
 [dependencies]
 # Our own markdown renderer (clickable wiki-links), a workspace crate.
 zorite-markdown = { path = "crates/zorite-markdown" }
-# Right-to-left rows for the link hover card's excerpt (#66): plain gpui text
-# wraps a bidi paragraph backwards, the same bug both renderers route around.
-gpui-bidi = { path = "crates/gpui-bidi" }
 # PDF export (src/export.rs): `markdown` parses (same crate zorite-markdown uses),
 # oxidize-pdf writes — pure Rust; with default features off it adds only a
 # handful of small crates (cipher primitives) to the tree.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,12 @@ publish = false
 name = "zorite"
 path = "src/main.rs"
 
+[features]
+# `cargo run --features fps`: gpui-fps' performance HUD (frame trace, P95,
+# dropped frames, CPU/GPU/memory) in the main window — for the next #60-style
+# hitch. Dev-only; never in a release build.
+fps = ["dep:gpui-fps"]
+
 [workspace]
 members = ["crates/gpui-bidi", "crates/zorite-editor", "crates/zorite-markdown", "crates/gpui-pdf", "crates/gpui-whiteboard", "crates/os-cursors", "crates/os-spellcheck", "crates/ratex-gpui"]
 resolver = "2"
@@ -164,6 +170,10 @@ gpui-component = { version = "=0.6.0", features = [
 # same version so the icon set tracks the `IconName` enum in gpui-component.
 gpui-kit-assets = "=0.6.0"
 
+# The `fps` feature's HUD (GPUI Kit's, depends on gpui only). Same gpui-pre
+# family, so it unifies with the pin above; move it with the other three.
+gpui-fps = { version = "0.6", optional = true }
+
 # Parse `file://` URLs into filesystem paths correctly across platforms (Windows
 # `file:///C:/…`, percent-decoding). Already in the tree via gpui.
 url = "2"
@@ -280,3 +290,8 @@ signing-identity = "-"
 # Distinct from every other packetThrower app. Never change once an installer ships.
 upgrade-guid = "B73F422B-02A5-4E09-A278-E810B2F7B903"
 include = ["packaging/windows/wix/main.wxs"]
+
+[dev-dependencies]
+# Headless UI tests (`src/app/ui_tests.rs`): gpui's `TestAppContext` /
+# `VisualTestContext` and the `#[gpui::test]` macro.
+gpui = { workspace = true, features = ["test-support"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ gpui_platform = { package = "gpui-pre-platform", version = "0.3", features = [
 [dependencies]
 # Our own markdown renderer (clickable wiki-links), a workspace crate.
 zorite-markdown = { path = "crates/zorite-markdown" }
+# Right-to-left rows for the link hover card's excerpt (#66): plain gpui text
+# wraps a bidi paragraph backwards, the same bug both renderers route around.
+gpui-bidi = { path = "crates/gpui-bidi" }
 # PDF export (src/export.rs): `markdown` parses (same crate zorite-markdown uses),
 # oxidize-pdf writes — pure Rust; with default features off it adds only a
 # handful of small crates (cipher primitives) to the tree.

--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ Developed in close collaboration with Claude (Anthropic).
   OS), any installed or imported font, an adjustable text size, an optional
   line-number gutter, a sidebar that docks left or right, and custom mouse
   cursor themes (any XCursor pack) — all without forking the UI toolkit.
-- A command palette (`⌘⇧P`) runs any menu command, current-page action, or
-  quick setting (WYSIWYG, theme, line numbers, sidebar side) by name, showing
-  its shortcut. Every keyboard shortcut is listed under Settings → Shortcuts,
+- A command palette (`⌘⇧P`) runs any menu command, current-page action,
+  navigation (today, a date, All pages, Graph), or quick setting (WYSIWYG,
+  theme, line numbers, sidebar) by name, showing its shortcut. Every keyboard shortcut is listed under Settings → Shortcuts,
   grouped by where it applies (app, editing, whiteboard, PDF). The app checks for updates
   on launch (pre-releases opt-in) and links to the release notes.
 - Hardened by a security audit: links open only `http`, `https`, and `mailto`;

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ Developed in close collaboration with Claude (Anthropic).
   OS), any installed or imported font, an adjustable text size, an optional
   line-number gutter, a sidebar that docks left or right, and custom mouse
   cursor themes (any XCursor pack) — all without forking the UI toolkit.
-- A command palette (`⌘⇧P`) runs any menu command by name, showing its
-  shortcut. Every keyboard shortcut is listed under Settings → Shortcuts,
+- A command palette (`⌘⇧P`) runs any menu command or current-page action by
+  name, showing its shortcut. Every keyboard shortcut is listed under Settings → Shortcuts,
   grouped by where it applies (app, editing, whiteboard, PDF). The app checks for updates
   on launch (pre-releases opt-in) and links to the release notes.
 - Hardened by a security audit: links open only `http`, `https`, and `mailto`;

--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ Developed in close collaboration with Claude (Anthropic).
   OS), any installed or imported font, an adjustable text size, an optional
   line-number gutter, a sidebar that docks left or right, and custom mouse
   cursor themes (any XCursor pack) — all without forking the UI toolkit.
-- Every keyboard shortcut is listed under Settings → Shortcuts, grouped by
-  where it applies (app, editing, whiteboard, PDF). The app checks for updates
+- A command palette (`⌘⇧P`) runs any menu command by name, showing its
+  shortcut. Every keyboard shortcut is listed under Settings → Shortcuts,
+  grouped by where it applies (app, editing, whiteboard, PDF). The app checks for updates
   on launch (pre-releases opt-in) and links to the release notes.
 - Hardened by a security audit: links open only `http`, `https`, and `mailto`;
   imports and exports can't read or write outside their folders; the database

--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ Developed in close collaboration with Claude (Anthropic).
   OS), any installed or imported font, an adjustable text size, an optional
   line-number gutter, a sidebar that docks left or right, and custom mouse
   cursor themes (any XCursor pack) — all without forking the UI toolkit.
-- A command palette (`⌘⇧P`) runs any menu command or current-page action by
-  name, showing its shortcut. Every keyboard shortcut is listed under Settings → Shortcuts,
+- A command palette (`⌘⇧P`) runs any menu command, current-page action, or
+  quick setting (WYSIWYG, theme, line numbers, sidebar side) by name, showing
+  its shortcut. Every keyboard shortcut is listed under Settings → Shortcuts,
   grouped by where it applies (app, editing, whiteboard, PDF). The app checks for updates
   on launch (pre-releases opt-in) and links to the release notes.
 - Hardened by a security audit: links open only `http`, `https`, and `mailto`;

--- a/TODO.md
+++ b/TODO.md
@@ -359,8 +359,10 @@ family). The dependency move is its own PR. What 0.6 adds that Zorite should
   rasterize; `Kbd` chips on the shortcuts tab; `Combobox` (searchable font
   picker) / `NumberInput` (text size) in Settings. Scrollbar visuals and
   trackpad axis-locking arrive with the upgrade itself.
-- [ ] Dev tooling: `gpui-fps` HUD for the next #60-style hitch;
-  `gpui_kit::test` headless UI tests for chrome flows verified by hand today.
+- [x] Dev tooling — DONE 2026-09-11: `cargo run --features fps` shows the
+  gpui-fps HUD; headless UI tests on gpui's test context in
+  `src/app/ui_tests.rs` (first: the command palette flow), with
+  `paths::data_dir` a throwaway dir under `cfg(test)`.
 
 Skip: dock/tiles, charts, chat components, `NavStack` (tabs cover it),
 `gpui-shell` JS extensions (interesting later, not now).

--- a/TODO.md
+++ b/TODO.md
@@ -338,9 +338,9 @@ family). The dependency move is its own PR. What 0.6 adds that Zorite should
   `TextView` has the same problem).
 
 **Adopt, in this order:**
-- [ ] **`HoverCard` → wiki-link previews**: hover a `[[Page]]` / block ref and
-  see the target's first lines. Cheap; both views already have link hitboxes.
-  Cross-view rule: reader AND WYSIWYG.
+- [x] **`HoverCard` → link previews** — DONE 2026-09-10: wiki-links, tags,
+  block refs, URLs, and property pills in both views (`EditorEvent::HoverLink`,
+  `MarkdownView::on_link_hover`). Left: links inside table cells.
 - [ ] **`Command` palette (⌘K)**: searchable actions with keybinding hints —
   Zorite has dozens of actions and only the slash menu today.
 - [x] **`setting::Settings` page builder** — DONE 2026-09-10 (branch

--- a/TODO.md
+++ b/TODO.md
@@ -341,8 +341,9 @@ family). The dependency move is its own PR. What 0.6 adds that Zorite should
 - [x] **`HoverCard` → link previews** — DONE 2026-09-10: wiki-links, tags,
   block refs, URLs, and property pills in both views (`EditorEvent::HoverLink`,
   `MarkdownView::on_link_hover`). Left: links inside table cells.
-- [ ] **`Command` palette (⌘K)**: searchable actions with keybinding hints —
-  Zorite has dozens of actions and only the slash menu today.
+- [x] **`Command` palette** — DONE 2026-09-11 (⌘⇧P / Ctrl+Shift+P, View menu):
+  every menu command grouped by menu with its shortcut, from one list
+  (`actions::palette_groups`). Left: page/sidebar verbs that need a target.
 - [x] **`setting::Settings` page builder** — DONE 2026-09-10 (branch
   `feat/settings-component`): pages/groups/typed fields with defaults + Reset,
   component sidebar search (titles, descriptions, synonyms, option labels,

--- a/TODO.md
+++ b/TODO.md
@@ -343,7 +343,7 @@ family). The dependency move is its own PR. What 0.6 adds that Zorite should
   `MarkdownView::on_link_hover`). Left: links inside table cells.
 - [x] **`Command` palette** — DONE 2026-09-11 (⌘⇧P / Ctrl+Shift+P, View menu):
   every menu command grouped by menu with its shortcut, from one list
-  (`actions::palette_groups`). Left: page/sidebar verbs that need a target.
+  (`actions::palette_groups`), plus the active page's context-menu verbs.
 - [x] **`setting::Settings` page builder** — DONE 2026-09-10 (branch
   `feat/settings-component`): pages/groups/typed fields with defaults + Reset,
   component sidebar search (titles, descriptions, synonyms, option labels,

--- a/TODO.md
+++ b/TODO.md
@@ -343,8 +343,9 @@ family). The dependency move is its own PR. What 0.6 adds that Zorite should
   `MarkdownView::on_link_hover`). Left: links inside table cells.
 - [x] **`Command` palette** — DONE 2026-09-11 (⌘⇧P / Ctrl+Shift+P, View menu):
   every menu command grouped by menu with its shortcut, from one list
-  (`actions::palette_groups`), the active page's context-menu verbs, and
-  quick settings (WYSIWYG, theme mode, line numbers, sidebar side).
+  (`actions::palette_groups`), the active page's context-menu verbs,
+  navigation (today, jump to date, All pages, Graph, sidebar), and quick
+  settings (WYSIWYG, theme mode, line numbers, sidebar side).
 - [x] **`setting::Settings` page builder** — DONE 2026-09-10 (branch
   `feat/settings-component`): pages/groups/typed fields with defaults + Reset,
   component sidebar search (titles, descriptions, synonyms, option labels,

--- a/TODO.md
+++ b/TODO.md
@@ -343,7 +343,8 @@ family). The dependency move is its own PR. What 0.6 adds that Zorite should
   `MarkdownView::on_link_hover`). Left: links inside table cells.
 - [x] **`Command` palette** — DONE 2026-09-11 (⌘⇧P / Ctrl+Shift+P, View menu):
   every menu command grouped by menu with its shortcut, from one list
-  (`actions::palette_groups`), plus the active page's context-menu verbs.
+  (`actions::palette_groups`), the active page's context-menu verbs, and
+  quick settings (WYSIWYG, theme mode, line numbers, sidebar side).
 - [x] **`setting::Settings` page builder** — DONE 2026-09-10 (branch
   `feat/settings-component`): pages/groups/typed fields with defaults + Reset,
   component sidebar search (titles, descriptions, synonyms, option labels,

--- a/TODO.md
+++ b/TODO.md
@@ -343,11 +343,10 @@ family). The dependency move is its own PR. What 0.6 adds that Zorite should
   Cross-view rule: reader AND WYSIWYG.
 - [ ] **`Command` palette (⌘K)**: searchable actions with keybinding hints —
   Zorite has dozens of actions and only the slash menu today.
-- [ ] **`setting::Settings` page builder** (`SettingPage → SettingGroup →
-  SettingItem → field`: switch/checkbox/input/dropdown/number, `default_value`,
-  `on_reset`). Would replace most of `settings.rs`'s hand-rolled cards and add
-  reset-to-default; the custom `SECTIONS` search filter needs re-plumbing.
-  Large — its own project.
+- [x] **`setting::Settings` page builder** — DONE 2026-09-10 (branch
+  `feat/settings-component`): pages/groups/typed fields with defaults + Reset,
+  component sidebar search (titles, descriptions, synonyms, option labels,
+  shortcut labels); `settings.rs` 2,837 → ~2,180 lines, SelectState plumbing gone.
 - [ ] **Accessibility**: 0.6 gives roles/labels/values on every gpui-component
   control for free (plus a macOS hit-test forwarder in gpui-base). The custom
   editor + reader get nothing automatically — separate work if a11y matters.

--- a/crates/zorite-editor/API.md
+++ b/crates/zorite-editor/API.md
@@ -1094,6 +1094,15 @@ An inline (mid-text) image thumbnail was left-clicked; the payload is its
 
 **Host obligation:** open a full-size preview.
 
+### `HoverLink(Option<(LinkHit, Bounds<Pixels>)>)`
+
+The pointer moved onto an inline link or a property-panel pill (`Some` — the
+`zorite_markdown::syntax::LinkHit` and the link's window-space box, from the
+last paint's layout) or off every link (`None`). Emitted only when the hovered
+link changes, so it is cheap to subscribe to.
+
+**Host obligation:** none. Zorite anchors a hover preview card to the box.
+
 ---
 
 ## `struct SyntaxStyle`

--- a/crates/zorite-editor/src/element.rs
+++ b/crates/zorite-editor/src/element.rs
@@ -65,6 +65,8 @@ pub(crate) struct PrepaintState {
     /// Pointer-cursor hitboxes over inline links (`[[wiki]]` / `#tag` /
     /// `[text](url)`), so hovering a clickable link shows a hand.
     link_grips: Vec<Hitbox>,
+    /// The links' boxes + targets, committed to the editor for hover → `HoverLink`.
+    link_rects: Vec<(Bounds<Pixels>, zorite_markdown::syntax::LinkHit)>,
     /// Pointer-cursor hitboxes over clickable property-panel pills, so hovering
     /// a pill shows a hand (like `link_grips`).
     prop_pill_grips: Vec<Hitbox>,
@@ -747,6 +749,7 @@ impl Element for EditorElement {
         // a 3+-row link are skipped). Widget/code/table rows carry no inline
         // links (images and chips have their own machinery).
         let mut link_grips = Vec::new();
+        let mut link_rects: Vec<(Bounds<Pixels>, zorite_markdown::syntax::LinkHit)> = Vec::new();
         let mut inline_image_grips = Vec::new();
         if editor.markdown_style.is_some() && !editor.content.is_empty() {
             let starts = editor.line_starts();
@@ -775,10 +778,11 @@ impl Element for EditorElement {
                             .filter(|(_, id)| f(id) > 0)
                             .map(|(at, _)| at..line.len())
                     });
-                for range in markdown_syntax::links(line)
+                // `None` = the badge (clickable, but not a link to preview).
+                for (range, hit) in markdown_syntax::links(line)
                     .into_iter()
-                    .map(|(r, _)| r)
-                    .chain(badge)
+                    .map(|(r, h)| (r, Some(h)))
+                    .chain(badge.map(|r| (r, None)))
                 {
                     let map = maps.get(i).and_then(Option::as_ref);
                     let d1 = display_col_in(map, range.start);
@@ -793,6 +797,7 @@ impl Element for EditorElement {
                         continue; // fully hidden (e.g. collapsed markers)
                     }
                     let origin = point(bounds.origin.x + inset, bounds.origin.y + line_tops[i]);
+                    let hit_ref = hit;
                     if p1.y == p2.y {
                         // An RTL link ends to the LEFT of where it starts, so
                         // the box spans min→max x rather than p1→p2.
@@ -801,6 +806,9 @@ impl Element for EditorElement {
                             size((p2.x - p1.x).abs(), *lh),
                         );
                         link_grips.push(window.insert_hitbox(hit, HitboxBehavior::Normal));
+                        if let Some(h) = hit_target(&hit_ref) {
+                            link_rects.push((hit, h));
+                        }
                     } else {
                         // Wrapped: head runs to the row's end, tail from its row's start.
                         let head = Bounds::new(
@@ -810,6 +818,10 @@ impl Element for EditorElement {
                         let tail = Bounds::new(point(origin.x, origin.y + p2.y), size(p2.x, *lh));
                         link_grips.push(window.insert_hitbox(head, HitboxBehavior::Normal));
                         link_grips.push(window.insert_hitbox(tail, HitboxBehavior::Normal));
+                        if let Some(h) = hit_target(&hit_ref) {
+                            link_rects.push((head, h.clone()));
+                            link_rects.push((tail, h));
+                        }
                     }
                 }
                 // Inline images on this line get a pointer-cursor hitbox (they
@@ -1421,6 +1433,7 @@ impl Element for EditorElement {
             heading_fold_grips,
             heading_row_rects,
             link_grips,
+            link_rects,
             prop_pill_grips,
             inline_image_grips,
             alert_icons: editor
@@ -2373,6 +2386,7 @@ impl Element for EditorElement {
             editor.image_rects = image_rects;
             editor.inline_math_rects = inline_math_rects;
             editor.prop_pill_rects = prop_pill_rects;
+            editor.link_rects = std::mem::take(&mut prepaint.link_rects);
             editor.prop_row_rects = prop_row_rects;
             editor.checkbox_rects = checkbox_rects;
             editor.table_thumbs = prepaint.table_thumbs.iter().map(|(t, _)| *t).collect();
@@ -4338,4 +4352,12 @@ fn paint_chip(
         window,
         cx,
     );
+}
+
+/// The previewable target of a link range: a real link, or `None` for the
+/// reference-count badge that rides along in the same loop.
+fn hit_target(
+    hit: &Option<zorite_markdown::syntax::LinkHit>,
+) -> Option<zorite_markdown::syntax::LinkHit> {
+    hit.clone()
 }

--- a/crates/zorite-editor/src/lib.rs
+++ b/crates/zorite-editor/src/lib.rs
@@ -443,7 +443,7 @@ impl TableMenuAction {
 
 /// Events the editor emits so a host can react. Subscribe with
 /// `cx.subscribe(&editor, …)` — e.g. to re-run spell-check after an edit.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum EditorEvent {
     /// The document text changed via a user edit (typing, delete, paste, IME,
     /// applying a suggestion). Not emitted for programmatic `set_text`.
@@ -494,6 +494,11 @@ pub enum EditorEvent {
     /// An inline `![](src)` image was left-clicked — the host opens a full-size
     /// preview. The text is untouched.
     PreviewImage(SharedString),
+    /// The pointer moved onto an inline link (`Some` — the target and the
+    /// link's window-space box, from this frame's layout) or off every link
+    /// (`None`). Emitted only on change, so a host can show a preview card
+    /// anchored to the link.
+    HoverLink(Option<(zorite_markdown::syntax::LinkHit, Bounds<Pixels>)>),
 }
 
 /// A table column's text alignment, for the host-driven alignment toolbar
@@ -953,6 +958,11 @@ pub struct EditorState {
     /// Painted bounds + target of each property-panel pill (from the last paint),
     /// so a left-click opens it (`OpenWikiLink` / `OpenLink`).
     prop_pill_rects: Vec<(Bounds<Pixels>, zorite_markdown::syntax::LinkHit)>,
+    /// Inline links' painted boxes + targets from the last paint (the same
+    /// geometry as the hand-cursor hitboxes), for hover → `HoverLink`.
+    link_rects: Vec<(Bounds<Pixels>, zorite_markdown::syntax::LinkHit)>,
+    /// The link under the pointer, if any — `HoverLink` fires on change.
+    hovered_link: Option<(zorite_markdown::syntax::LinkHit, Bounds<Pixels>)>,
     /// Painted bounds of each property-panel row (from the last paint), so
     /// `on_mouse_move` repaints when the hovered row changes (the panel's hover
     /// border reads the live pointer during paint).
@@ -1090,6 +1100,8 @@ impl EditorState {
             inline_math_rects: Vec::new(),
             editing_inline: None,
             prop_pill_rects: Vec::new(),
+            link_rects: Vec::new(),
+            hovered_link: None,
             prop_row_rects: Vec::new(),
             prop_hover_row: None,
             folded_headings: std::collections::HashSet::new(),
@@ -3322,6 +3334,18 @@ impl EditorState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Link under the pointer → `HoverLink` on change (a host shows a preview
+        // card there). Painted boxes from the last frame, like the hand cursor.
+        let over_link = self
+            .link_rects
+            .iter()
+            .chain(self.prop_pill_rects.iter())
+            .find(|(b, _)| b.contains(&event.position))
+            .map(|(b, hit)| (hit.clone(), *b));
+        if over_link != self.hovered_link {
+            self.hovered_link = over_link.clone();
+            cx.emit(EditorEvent::HoverLink(over_link));
+        }
         // While dragging an image's grip, track the pointer: the new width is the
         // grab width plus the horizontal travel, floored at `IMG_MIN_W` and capped
         // to the content width left of the image's inset (so a bulleted image's cap

--- a/crates/zorite-markdown/API.md
+++ b/crates/zorite-markdown/API.md
@@ -75,6 +75,7 @@ isn't public. Feature `—` = always compiled (`zorite_markdown::syntax`);
 | [`MarkdownView::track_blocks`](#markdownviewtrack_blocks) | builder | `fn track_blocks(self, handle: ScrollHandle) -> Self` | Track-scroll the block column (scroll-to-match) | `view` |
 | [`MarkdownView::on_click_source`](#markdownviewon_click_source) | builder | `fn on_click_source(self, handler: ClickSourceHandler) -> Self` | Click-to-caret (source offset of a click) | `view` |
 | [`MarkdownView::on_image_preview`](#markdownviewon_image_preview) | builder | `fn on_image_preview(self, handler: ImagePreviewHandler) -> Self` | Handle inline-thumbnail clicks | `view` |
+| [`MarkdownView::on_link_hover`](#markdownviewon_link_hover) | builder | `fn on_link_hover(self, handler: LinkHoverHandler) -> Self` | Report the link under the pointer + its box (hover previews) | `view` |
 | [`MarkdownView::on_task_toggle`](#markdownviewon_task_toggle) | builder | `fn on_task_toggle(self, handler: TaskToggleHandler) -> Self` | Make task checkboxes clickable | `view` |
 | [`MarkdownView::on_alert_toggle`](#markdownviewon_alert_toggle) | builder | `fn on_alert_toggle(self, handler: TaskToggleHandler) -> Self` | Handle foldable-callout title clicks | `view` |
 | [`MarkdownView::on_embed`](#markdownviewon_embed) | builder | `fn on_embed(self, provider: EmbedProvider) -> Self` | Resolve standalone `![[target]]` transclusions | `view` |
@@ -97,6 +98,7 @@ isn't public. Feature `—` = always compiled (`zorite_markdown::syntax`);
 | [`InlineImageRenderer`](#inlineimagerenderer) | type alias | `Rc<dyn Fn(SharedString) -> Option<(Arc<RenderImage>, f32, f32)>>` | Mid-text image → raster + logical size | `view` |
 | [`ClickSourceHandler`](#clicksourcehandler) | type alias | `Rc<dyn Fn(usize, Pixels, &mut Window, &mut App)>` | Click-to-caret callback (source offset, window y) | `view` |
 | [`ImagePreviewHandler`](#imagepreviewhandler) | type alias | `Rc<dyn Fn(SharedString, &mut Window, &mut App)>` | Inline-thumbnail click callback (src) | `view` |
+| [`LinkHoverHandler`](#linkhoverhandler) | type alias | `Rc<dyn Fn(Option<(LinkHit, Bounds<Pixels>)>, &mut Window, &mut App)>` | Link-hover callback: target + window-space box, or `None` off every link | `view` |
 | [`TaskToggleHandler`](#tasktogglehandler) | type alias | `Rc<dyn Fn(usize, &mut Window, &mut App)>` | Task / callout toggle callback (source offset) | `view` |
 | [`HeadingToggleHandler`](#headingtogglehandler) | type alias | `Rc<dyn Fn(&str, &mut Window, &mut App)>` | Heading fold-chevron callback (fold key) | `view` |
 | [`EmbedProvider`](#embedprovider) | type alias | `Rc<dyn Fn(&str) -> Option<(SharedString, SharedString)>>` | Resolve `![[target]]` → `(label, content)` | `view` |
@@ -1066,6 +1068,26 @@ pub fn on_image_preview(self, handler: ImagePreviewHandler) -> Self
 Handle a click on an inline thumbnail — open a full-size preview (see
 [`ImagePreviewHandler`](#imagepreviewhandler)).
 
+### `MarkdownView::on_link_hover`
+
+```rust
+pub fn on_link_hover(self, handler: LinkHoverHandler) -> Self
+```
+
+Report the link under the pointer as the mouse moves, so the host can show a
+preview card anchored to it (see [`LinkHoverHandler`](#linkhoverhandler)).
+Covers paragraph links in both text directions (a wrapped link reports the
+row it starts on) and property-panel pills. Links inside table cells don't
+report yet.
+
+**Guarantees & edge cases**
+
+- Fires on every pointer move over the paragraph, including repeated `None`s
+  off links — hosts should compare against their last value before
+  repainting.
+- The box is window-space, from this frame's layout; it goes stale if the
+  content scrolls without the pointer moving.
+
 ### `MarkdownView::on_task_toggle`
 
 ```rust
@@ -1443,6 +1465,19 @@ opens a full-size preview. Set via
 [`on_image_preview`](#markdownviewon_image_preview).
 
 ---
+
+## `LinkHoverHandler`
+
+```rust
+pub type LinkHoverHandler =
+    Rc<dyn Fn(Option<(LinkHit, Bounds<Pixels>)>, &mut Window, &mut App)>;
+```
+
+The pointer moved onto a link (`Some` — its [`LinkHit`](#enum-linkhit) and its
+window-space box) or off every link (`None`). Set via
+[`on_link_hover`](#markdownviewon_link_hover). A `[[wiki]]` / `#tag` arrives
+as `LinkHit::Page`, a URL as `LinkHit::Url`, a pill's `((id))` as
+`LinkHit::BlockRef`.
 
 ## `TaskToggleHandler`
 

--- a/crates/zorite-markdown/src/view.rs
+++ b/crates/zorite-markdown/src/view.rs
@@ -13,10 +13,10 @@ use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 use gpui::{
     AnyElement, App, Bounds, ClipboardItem, Corners, ElementId, FontStyle, FontWeight,
     HighlightStyle, Hsla, InteractiveElement, InteractiveText, IntoElement, MouseButton,
-    MouseDownEvent, ParentElement, Pixels, Point, RenderImage, RenderOnce, ScrollHandle,
-    SharedString, StatefulInteractiveElement, StrikethroughStyle, Styled, StyledText, TextLayout,
-    TextRun, Window, canvas, div, point, prelude::FluentBuilder, px, relative, rgb, rgba, size,
-    svg,
+    MouseDownEvent, MouseMoveEvent, ParentElement, Pixels, Point, RenderImage, RenderOnce,
+    ScrollHandle, SharedString, StatefulInteractiveElement, StrikethroughStyle, Styled, StyledText,
+    TextLayout, TextRun, Window, canvas, div, point, prelude::FluentBuilder, px, relative, rgb,
+    rgba, size, svg,
 };
 use markdown::mdast;
 
@@ -442,6 +442,12 @@ pub type ClickSourceHandler = Rc<dyn Fn(usize, Pixels, &mut Window, &mut App)>;
 /// full-size preview. Set via [`MarkdownView::on_image_preview`].
 pub type ImagePreviewHandler = Rc<dyn Fn(SharedString, &mut Window, &mut App)>;
 
+/// Host callback as the pointer moves onto a link (`Some` — its target and its
+/// window-space box) or off every link (`None`), so the host can show a
+/// preview card anchored to it. Set via [`MarkdownView::on_link_hover`].
+pub type LinkHoverHandler =
+    Rc<dyn Fn(Option<(crate::syntax::LinkHit, Bounds<Pixels>)>, &mut Window, &mut App)>;
+
 /// Toggle the task checkbox of a clicked list item — the argument is the source
 /// byte offset of that task item (feed it to [`toggle_task_at`]). Set via
 /// [`MarkdownView::on_task_toggle`].
@@ -499,6 +505,7 @@ pub struct MarkdownView {
     /// Click-to-caret: maps a click on the rendered text to its source offset.
     on_click_source: Option<ClickSourceHandler>,
     on_image_preview: Option<ImagePreviewHandler>,
+    on_link_hover: Option<LinkHoverHandler>,
     /// Click a task checkbox to toggle it (the host applies + persists).
     on_task_toggle: Option<TaskToggleHandler>,
     on_alert_toggle: Option<TaskToggleHandler>,
@@ -529,6 +536,7 @@ impl MarkdownView {
             current_match: 0,
             block_scroll: None,
             on_click_source: None,
+            on_link_hover: None,
             on_image_preview: None,
             on_task_toggle: None,
             on_alert_toggle: None,
@@ -628,6 +636,14 @@ impl MarkdownView {
     }
 
     /// Supply a handler for a click on an inline image (opens a preview).
+    /// Report the link under the pointer (and its box) as the mouse moves, for
+    /// a host-drawn preview card. Both text directions; property pills and
+    /// table-cell links don't report yet.
+    pub fn on_link_hover(mut self, handler: LinkHoverHandler) -> Self {
+        self.on_link_hover = Some(handler);
+        self
+    }
+
     pub fn on_image_preview(mut self, handler: ImagePreviewHandler) -> Self {
         self.on_image_preview = Some(handler);
         self
@@ -962,6 +978,7 @@ impl RenderOnce for MarkdownView {
             match_ix: 0,
             on_click_source: self.on_click_source,
             on_image_preview: self.on_image_preview,
+            on_link_hover: self.on_link_hover,
             on_task_toggle: self.on_task_toggle,
             on_alert_toggle: self.on_alert_toggle,
             on_embed: self.on_embed,
@@ -1064,6 +1081,7 @@ struct Ctx {
     match_ix: usize,
     on_click_source: Option<ClickSourceHandler>,
     on_image_preview: Option<ImagePreviewHandler>,
+    on_link_hover: Option<LinkHoverHandler>,
     on_task_toggle: Option<TaskToggleHandler>,
     on_alert_toggle: Option<TaskToggleHandler>,
     on_embed: Option<EmbedProvider>,
@@ -1900,6 +1918,14 @@ impl TextHandle {
 /// Open a link target. Shared by both directions: LTR goes through
 /// `InteractiveText`, RTL hit-tests through its own layout, but what a click
 /// DOES must not depend on which.
+/// A paragraph link as the shared recognition type the hover callback reports.
+fn link_hit(target: &LinkTarget) -> crate::syntax::LinkHit {
+    match target {
+        LinkTarget::Wiki(t) => crate::syntax::LinkHit::Page(t.to_string()),
+        LinkTarget::Url(u) => crate::syntax::LinkHit::Url(u.to_string()),
+    }
+}
+
 fn follow_link(
     target: Option<&LinkTarget>,
     on_wiki: &Option<WikiLinkHandler>,
@@ -2070,6 +2096,10 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
             let ranges = link_ranges.clone();
             let targets = targets.clone();
             let on_wiki = ctx.on_wiki_link.clone();
+            let hover_hit = hit.clone();
+            let hover_ranges = link_ranges.clone();
+            let hover_targets = targets.clone();
+            let on_hover = ctx.on_link_hover.clone();
             div()
                 .child(rtl)
                 .on_mouse_down(MouseButton::Left, move |ev: &MouseDownEvent, window, cx| {
@@ -2080,6 +2110,24 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
                         cx.stop_propagation();
                         follow_link(targets.get(k), &on_wiki, window, cx);
                     }
+                })
+                .when_some(on_hover, |el, on_hover| {
+                    el.on_mouse_move(move |ev: &MouseMoveEvent, window, cx| {
+                        // Same lookup as the click: the row layout that painted the
+                        // glyphs maps the pointer to a byte, then to a link's boxes.
+                        let hit = hover_hit
+                            .index_for_position(ev.position)
+                            .ok()
+                            .and_then(|ix| hover_ranges.iter().position(|r| r.contains(&ix)))
+                            .and_then(|k| {
+                                let b = hover_hit
+                                    .rects_for_range(hover_ranges[k].clone())
+                                    .into_iter()
+                                    .next()?;
+                                Some((link_hit(hover_targets.get(k)?), b))
+                            });
+                        on_hover(hit, window, cx);
+                    })
                 })
                 .into_any_element()
         };
@@ -2096,12 +2144,39 @@ fn inline_element(nodes: &[mdast::Node], ctx: &mut Ctx) -> AnyElement {
             ctx.counter += 1;
             let id = ElementId::Name(format!("{}-{}", ctx.id_base, ctx.counter).into());
             let on_wiki = ctx.on_wiki_link.clone();
+            let hover_layout = styled.layout().clone();
+            let hover_ranges = link_ranges.clone();
+            let hover_targets = targets.clone();
+            let on_hover = ctx.on_link_hover.clone();
             InteractiveText::new(id, styled)
                 .on_click(link_ranges.clone(), move |ix, window, cx| {
                     // The click was on a link range; consume it so it doesn't also reach
                     // a surrounding host handler (e.g. the click-to-caret below).
                     cx.stop_propagation();
                     follow_link(targets.get(ix), &on_wiki, window, cx);
+                })
+                .when_some(on_hover, |el, on_hover| {
+                    el.on_hover(move |ix, _ev, window, cx| {
+                        // The hovered char → its link range → that range's box on the
+                        // row it starts on (a wrapped link reports its first row).
+                        let hit = ix
+                            .and_then(|ix| hover_ranges.iter().position(|r| r.contains(&ix)))
+                            .and_then(|k| {
+                                let r = &hover_ranges[k];
+                                let start = hover_layout.position_for_index(r.start)?;
+                                let end = hover_layout.position_for_index(r.end);
+                                let right = match end {
+                                    Some(e) if e.y == start.y => e.x,
+                                    _ => hover_layout.bounds().right(),
+                                };
+                                let b = Bounds::new(
+                                    start,
+                                    size((right - start.x).max(px(0.)), hover_layout.line_height()),
+                                );
+                                Some((link_hit(hover_targets.get(k)?), b))
+                            });
+                        on_hover(hit, window, cx);
+                    })
                 })
                 .into_any_element()
         };
@@ -2952,6 +3027,8 @@ fn render_property_table(
         .id(SharedString::from(format!("{}-props-{id}", ctx.id_base)))
         .flex()
         .flex_col();
+    // Hover needs a stateful element: one id per pill within this panel.
+    let mut pill_n = 0usize;
     for (key, value, _v_off) in rows.into_iter() {
         // Value: plain runs, plus tags/wiki-links as clickable pills.
         let mut val = div()
@@ -2984,40 +3061,75 @@ fn render_property_table(
                     let mut bg = color;
                     bg.a = 0.16;
                     let on_wiki = ctx.on_wiki_link.clone();
+                    // The pill's painted box, for the hover preview's anchor:
+                    // a div doesn't learn its bounds, so a zero-cost canvas
+                    // laid over it records them each paint.
+                    let pill_bounds: Rc<std::cell::Cell<Option<Bounds<Pixels>>>> = Rc::default();
+                    let probe_bounds = pill_bounds.clone();
+                    let hover_target = target.clone();
+                    let on_hover = ctx.on_link_hover.clone();
+                    pill_n += 1;
                     val = val.child(
                         div()
-                            .px(px(7.0))
-                            .py(px(1.0))
-                            .rounded(px(6.0))
-                            .bg(bg)
-                            .text_color(color)
-                            .cursor_pointer()
-                            .child(SharedString::from(label))
-                            .on_mouse_down(
-                                MouseButton::Left,
-                                move |_: &MouseDownEvent, window, cx| {
-                                    cx.stop_propagation();
-                                    match &target {
-                                        crate::syntax::LinkHit::Page(t) => {
-                                            if let Some(h) = &on_wiki {
-                                                h(t.clone().into(), window, cx);
+                            .id(SharedString::from(format!(
+                                "{}-props-{id}-pill-{pill_n}",
+                                ctx.id_base
+                            )))
+                            .relative()
+                            .when_some(on_hover, |d, on_hover| {
+                                d.on_hover(move |hovered: &bool, window, cx| {
+                                    let hit = hovered
+                                        .then(|| pill_bounds.get())
+                                        .flatten()
+                                        .map(|b| (hover_target.clone(), b));
+                                    on_hover(hit, window, cx);
+                                })
+                            })
+                            .child(
+                                canvas(
+                                    |_, _, _| {},
+                                    move |bounds, _: (), _window, _cx| {
+                                        probe_bounds.set(Some(bounds));
+                                    },
+                                )
+                                .absolute()
+                                .inset_0(),
+                            )
+                            .child(
+                                div()
+                                    .px(px(7.0))
+                                    .py(px(1.0))
+                                    .rounded(px(6.0))
+                                    .bg(bg)
+                                    .text_color(color)
+                                    .cursor_pointer()
+                                    .child(SharedString::from(label))
+                                    .on_mouse_down(
+                                        MouseButton::Left,
+                                        move |_: &MouseDownEvent, window, cx| {
+                                            cx.stop_propagation();
+                                            match &target {
+                                                crate::syntax::LinkHit::Page(t) => {
+                                                    if let Some(h) = &on_wiki {
+                                                        h(t.clone().into(), window, cx);
+                                                    }
+                                                }
+                                                crate::syntax::LinkHit::BlockRef(id) => {
+                                                    if let Some(h) = &on_wiki {
+                                                        h(format!("#^{id}").into(), window, cx);
+                                                    }
+                                                }
+                                                // Same allowlist as the inline-link
+                                                // click above: property values are
+                                                // untrusted markdown too.
+                                                crate::syntax::LinkHit::Url(u) => {
+                                                    if crate::syntax::is_safe_external_url(u) {
+                                                        cx.open_url(u);
+                                                    }
+                                                }
                                             }
-                                        }
-                                        crate::syntax::LinkHit::BlockRef(id) => {
-                                            if let Some(h) = &on_wiki {
-                                                h(format!("#^{id}").into(), window, cx);
-                                            }
-                                        }
-                                        // Same allowlist as the inline-link
-                                        // click above: property values are
-                                        // untrusted markdown too.
-                                        crate::syntax::LinkHit::Url(u) => {
-                                            if crate::syntax::is_safe_external_url(u) {
-                                                cx.open_url(u);
-                                            }
-                                        }
-                                    }
-                                },
+                                        },
+                                    ),
                             ),
                     );
                 }

--- a/docs/src/content/docs/usage/shortcuts.md
+++ b/docs/src/content/docs/usage/shortcuts.md
@@ -1,6 +1,6 @@
 ---
 title: Keyboard shortcuts
-description: 'Keyboard shortcuts in Zorite — new tab, new window, close tab, tab switching, settings, find in page, search all notes, and the slash command menu.'
+description: 'Keyboard shortcuts in Zorite — the command palette, new tab, new window, close tab, tab switching, settings, find in page, search all notes, and the slash command menu.'
 ---
 
 One binding works on every OS: the modifier shown as **⌘** below is **Cmd** on
@@ -10,6 +10,7 @@ macOS and **Ctrl** on Windows and Linux.
 
 | Action | macOS | Windows / Linux |
 |---|---|---|
+| Command palette | `⌘⇧P` | `Ctrl+Shift+P` |
 | New tab (new page) | `⌘T` | `Ctrl+T` |
 | New window | `⌘N` | `Ctrl+N` |
 | Close tab | `⌘W` | `Ctrl+W` |
@@ -21,6 +22,8 @@ macOS and **Ctrl** on Windows and Linux.
 | Open settings | `⌘,` | `Ctrl+,` |
 | Quit | `⌘Q` | `Ctrl+Q` |
 
+**Command palette** lists every menu command with its shortcut — type to
+filter, `↑` / `↓` to pick, `Enter` to run, `Esc` to close.
 **Find in page** searches the current page (reading view or editor); on the
 Journal it opens the feed's find bar, matching across every loaded day.
 **Search all notes** opens the note-wide search (see

--- a/docs/src/content/docs/usage/shortcuts.md
+++ b/docs/src/content/docs/usage/shortcuts.md
@@ -23,7 +23,8 @@ macOS and **Ctrl** on Windows and Linux.
 | Quit | `⌘Q` | `Ctrl+Q` |
 
 **Command palette** lists every menu command with its shortcut and, on a page
-tab, that page's actions (favorite, copy link, rename, delete…), plus quick
+tab, that page's actions (favorite, copy link, rename, delete…), plus
+navigation (today, jump to date, All pages, Graph, sidebar) and quick
 settings (WYSIWYG, theme, line numbers, sidebar side) — type to filter, `↑` / `↓` to pick, `Enter` to run, `Esc` to close.
 **Find in page** searches the current page (reading view or editor); on the
 Journal it opens the feed's find bar, matching across every loaded day.

--- a/docs/src/content/docs/usage/shortcuts.md
+++ b/docs/src/content/docs/usage/shortcuts.md
@@ -22,7 +22,8 @@ macOS and **Ctrl** on Windows and Linux.
 | Open settings | `⌘,` | `Ctrl+,` |
 | Quit | `⌘Q` | `Ctrl+Q` |
 
-**Command palette** lists every menu command with its shortcut — type to
+**Command palette** lists every menu command with its shortcut and, on a page
+tab, that page's actions (favorite, copy link, rename, delete…) — type to
 filter, `↑` / `↓` to pick, `Enter` to run, `Esc` to close.
 **Find in page** searches the current page (reading view or editor); on the
 Journal it opens the feed's find bar, matching across every loaded day.

--- a/docs/src/content/docs/usage/shortcuts.md
+++ b/docs/src/content/docs/usage/shortcuts.md
@@ -23,8 +23,8 @@ macOS and **Ctrl** on Windows and Linux.
 | Quit | `⌘Q` | `Ctrl+Q` |
 
 **Command palette** lists every menu command with its shortcut and, on a page
-tab, that page's actions (favorite, copy link, rename, delete…) — type to
-filter, `↑` / `↓` to pick, `Enter` to run, `Esc` to close.
+tab, that page's actions (favorite, copy link, rename, delete…), plus quick
+settings (WYSIWYG, theme, line numbers, sidebar side) — type to filter, `↑` / `↓` to pick, `Enter` to run, `Esc` to close.
 **Find in page** searches the current page (reading view or editor); on the
 Journal it opens the feed's find bar, matching across every loaded day.
 **Search all notes** opens the note-wide search (see

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -211,6 +211,19 @@ settings:
     current_password: "Current password"
     new_password: "New password"
     confirm_password: "Confirm new password"
+  item:
+    enabled: Enabled
+    show_gutter: Show gutter
+    dock_right: Dock on the right
+    theme: Theme
+    mode: Mode
+    family: Family
+    size: Size
+    quality: Quality
+    spaces_per_level: Spaces per level
+    language: Language
+    format: Format
+    lock_after: Lock after
   note:
     set_password_first: "Set a password first."
     cursor_relaunch: "Cursor changes take effect after a relaunch."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -724,6 +724,16 @@ menu:
   command_palette: "Command Palette…"
 command_palette:
   placeholder: "Type a command…"
+  settings: Settings
+  wysiwyg_on: "Turn on WYSIWYG editing"
+  wysiwyg_off: "Turn off WYSIWYG editing"
+  gutter_show: "Show line numbers"
+  gutter_hide: "Hide line numbers"
+  sidebar_left: "Dock the sidebar on the left"
+  sidebar_right: "Dock the sidebar on the right"
+  theme_light: "Theme: Light"
+  theme_dark: "Theme: Dark"
+  theme_auto: "Theme: Auto (follow system)"
 paths:
   not_a_folder: "That isn't a folder."
   nested_or_parent: "Pick a folder that's neither inside nor the parent of the current data folder."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -291,6 +291,7 @@ settings:
     fit_images: "Fit oversized images to view"
     export_pdf: "Export active tab as PDF"
     open_settings: "Open settings"
+    command_palette: "Open the command palette"
     quit: "Quit"
     slash_menu: "Open the slash command menu"
     menu_nav: "Move up / down in the menu"
@@ -720,6 +721,9 @@ menu:
   fit_images: "Fit Images to View"
   next_tab: "Next Tab"
   prev_tab: "Previous Tab"
+  command_palette: "Command Palette…"
+command_palette:
+  placeholder: "Type a command…"
 paths:
   not_a_folder: "That isn't a folder."
   nested_or_parent: "Pick a folder that's neither inside nor the parent of the current data folder."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -89,6 +89,9 @@ slash:
     link: Link
     wiki_link: Wiki link
     image: Image
+link_preview:
+  no_page: Not created yet
+
 settings:
   title: Settings
   filter_placeholder: "Filter settings…"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -724,6 +724,13 @@ menu:
   command_palette: "Command Palette…"
 command_palette:
   placeholder: "Type a command…"
+  navigate: Navigate
+  go_to_today: "Go to today"
+  jump_to_date: "Jump to date…"
+  all_pages: "Open All pages"
+  graph: "Open the Graph"
+  sidebar_show: "Show sidebar"
+  sidebar_hide: "Hide sidebar"
   settings: Settings
   wysiwyg_on: "Turn on WYSIWYG editing"
   wysiwyg_off: "Turn off WYSIWYG editing"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -724,6 +724,13 @@ menu:
   command_palette: "命令面板…"
 command_palette:
   placeholder: "输入命令…"
+  navigate: 导航
+  go_to_today: "转到今天"
+  jump_to_date: "跳转到日期…"
+  all_pages: "打开所有页面"
+  graph: "打开图谱"
+  sidebar_show: "显示侧边栏"
+  sidebar_hide: "隐藏侧边栏"
   settings: 设置
   wysiwyg_on: "开启所见即所得编辑"
   wysiwyg_off: "关闭所见即所得编辑"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -291,6 +291,7 @@ settings:
     fit_images: "使超大图片适应视图"
     export_pdf: "将当前标签页导出为 PDF"
     open_settings: "打开设置"
+    command_palette: "打开命令面板"
     quit: "退出"
     slash_menu: "打开斜杠命令菜单"
     menu_nav: "在菜单中上/下移动"
@@ -720,6 +721,9 @@ menu:
   fit_images: "将图像适应到视图"
   next_tab: "下一个标签页"
   prev_tab: "上一个标签页"
+  command_palette: "命令面板…"
+command_palette:
+  placeholder: "输入命令…"
 paths:
   not_a_folder: "这不是一个文件夹。"
   nested_or_parent: "请选择既不在当前数据文件夹内、也不是其父级的文件夹。"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -211,6 +211,19 @@ settings:
     current_password: "当前密码"
     new_password: "新密码"
     confirm_password: "确认新密码"
+  item:
+    enabled: 启用
+    show_gutter: 显示行号栏
+    dock_right: 停靠在右侧
+    theme: 主题
+    mode: 模式
+    family: 字体
+    size: 大小
+    quality: 质量
+    spaces_per_level: 每级空格数
+    language: 语言
+    format: 格式
+    lock_after: 锁定延迟
   note:
     set_password_first: "请先设置密码。"
     cursor_relaunch: "光标更改将在重新启动后生效。"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -89,6 +89,9 @@ slash:
     link: 链接
     wiki_link: Wiki 链接
     image: 图片
+link_preview:
+  no_page: 尚未创建
+
 settings:
   title: 设置
   filter_placeholder: "筛选设置…"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -724,6 +724,16 @@ menu:
   command_palette: "命令面板…"
 command_palette:
   placeholder: "输入命令…"
+  settings: 设置
+  wysiwyg_on: "开启所见即所得编辑"
+  wysiwyg_off: "关闭所见即所得编辑"
+  gutter_show: "显示行号"
+  gutter_hide: "隐藏行号"
+  sidebar_left: "将侧边栏停靠在左侧"
+  sidebar_right: "将侧边栏停靠在右侧"
+  theme_light: "主题：浅色"
+  theme_dark: "主题：深色"
+  theme_auto: "主题：自动（跟随系统）"
 paths:
   not_a_folder: "这不是一个文件夹。"
   nested_or_parent: "请选择既不在当前数据文件夹内、也不是其父级的文件夹。"

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -50,6 +50,14 @@ actions!(
         OpenSettings,
         // ⌘⇧P: the searchable list of every menu command (`palette_groups`).
         OpenCommandPalette,
+        // Quick settings, reachable from the palette only (no keybindings):
+        // handlers on `AppView` flip the same setters the Settings window uses.
+        ToggleWysiwyg,
+        ToggleLineNumbers,
+        ToggleSidebarSide,
+        ThemeLight,
+        ThemeDark,
+        ThemeAuto,
         Quit,
         // Find: in the current page's rendered text, or the global note search.
         FindInPage,

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -13,7 +13,7 @@
 //! `ToggleFavorite` have no keybinding — they're dispatched by right-click
 //! context menus (sidebar pages and tabs) and handled on `AppView`.
 
-use gpui::{App, KeyBinding, Menu, MenuItem, actions};
+use gpui::{Action, App, KeyBinding, Menu, MenuItem, SharedString, actions};
 use rust_i18n::t;
 
 actions!(
@@ -48,6 +48,8 @@ actions!(
         NextTab,
         PrevTab,
         OpenSettings,
+        // ⌘⇧P: the searchable list of every menu command (`palette_groups`).
+        OpenCommandPalette,
         Quit,
         // Find: in the current page's rendered text, or the global note search.
         FindInPage,
@@ -136,6 +138,7 @@ pub fn bind_keys(cx: &mut App) {
         KeyBinding::new("secondary-w", CloseTab, None),
         KeyBinding::new("secondary-p", ExportActivePdf, None),
         KeyBinding::new("secondary-,", OpenSettings, None),
+        KeyBinding::new("secondary-shift-p", OpenCommandPalette, None),
         KeyBinding::new("ctrl-tab", NextTab, None),
         KeyBinding::new("ctrl-shift-tab", PrevTab, None),
         // Find-in-page (a Page tab's rendered text) vs the global note search.
@@ -216,8 +219,41 @@ fn build_app_menus() -> Vec<Menu> {
             items: vec![
                 MenuItem::action(t!("menu.next_tab"), NextTab),
                 MenuItem::action(t!("menu.prev_tab"), PrevTab),
+                MenuItem::separator(),
+                MenuItem::action(t!("menu.command_palette"), OpenCommandPalette),
             ],
             disabled: false,
         },
     ]
+}
+
+/// One palette entry: its menu label and the action it dispatches.
+pub type PaletteCommand = (SharedString, Box<dyn Action>);
+
+/// The command palette's entries, grouped by menu: every menu-bar command,
+/// so the palette and the menus can't drift apart. Only the app's own
+/// actions — the Edit menu's clipboard/undo items are gpui-component input
+/// actions that, run from the palette, would act on its own search field —
+/// and not the palette itself.
+pub fn palette_groups() -> Vec<(SharedString, Vec<PaletteCommand>)> {
+    build_app_menus()
+        .into_iter()
+        .map(|menu| {
+            let items: Vec<_> = menu
+                .items
+                .into_iter()
+                .filter_map(|item| match item {
+                    MenuItem::Action { name, action, .. }
+                        if action.name().starts_with("zorite::")
+                            && action.name() != OpenCommandPalette.name() =>
+                    {
+                        Some((name, action))
+                    }
+                    _ => None,
+                })
+                .collect();
+            (menu.name, items)
+        })
+        .filter(|(_, items)| !items.is_empty())
+        .collect()
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -58,6 +58,12 @@ actions!(
         ThemeLight,
         ThemeDark,
         ThemeAuto,
+        // Navigation, palette-only likewise.
+        GoToToday,
+        JumpToDate,
+        OpenAllPages,
+        OpenGraph,
+        ToggleSidebar,
         Quit,
         // Find: in the current page's rendered text, or the global note search.
         FindInPage,

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,9 +37,9 @@ use zorite_editor::{Diagnostic, EditorEvent, EditorState};
 use crate::actions::{
     CloseTab, CopyPageContents, CopyPageContentsMarkdown, CopyPageLink, DeletePage,
     ExportActivePdf, ExportNotebook, ExportPdf, FindInPage, FitImages, GlobalSearch, ImportLogseq,
-    ImportObsidian, InsertTab, NewPage, NewSubPage, NewWhiteboard, NextTab, OpenInNewTab,
-    OpenInNewWindow, OpenSettings, Outdent, PasteImage, PrevTab, RenamePage, SlashCancel,
-    SlashConfirm, SlashDown, SlashUp, ToggleFavorite,
+    ImportObsidian, InsertTab, NewPage, NewSubPage, NewWhiteboard, NextTab, OpenCommandPalette,
+    OpenInNewTab, OpenInNewWindow, OpenSettings, Outdent, PasteImage, PrevTab, RenamePage,
+    SlashCancel, SlashConfirm, SlashDown, SlashUp, ToggleFavorite,
 };
 use crate::db::Db;
 use crate::images::ImageSeed;
@@ -7245,6 +7245,9 @@ impl Render for AppView {
                             this.slash = None;
                             cx.notify();
                         }
+                        // An open dialog (the command palette, a prompt) owns Esc —
+                        // otherwise editing a note underneath would blur instead.
+                        None if window.has_active_dialog(cx) => cx.propagate(),
                         // A seated PDF form field drops without writing.
                         None if this.pdf_field_edit.is_some() => this.cancel_pdf_field_edit(cx),
                         // An open find bar takes Esc first (closes it).
@@ -7301,6 +7304,11 @@ impl Render for AppView {
                     // must not be mid-update (same reason the gear defers).
                     let view = cx.entity();
                     window.defer(cx, move |_, cx| AppView::open_settings(view, cx));
+                }),
+            )
+            .on_action(
+                cx.listener(|this: &mut AppView, _: &OpenCommandPalette, window, cx| {
+                    this.open_command_palette(window, cx)
                 }),
             )
             .on_action(

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,7 +39,8 @@ use crate::actions::{
     ExportActivePdf, ExportNotebook, ExportPdf, FindInPage, FitImages, GlobalSearch, ImportLogseq,
     ImportObsidian, InsertTab, NewPage, NewSubPage, NewWhiteboard, NextTab, OpenCommandPalette,
     OpenInNewTab, OpenInNewWindow, OpenSettings, Outdent, PasteImage, PrevTab, RenamePage,
-    SlashCancel, SlashConfirm, SlashDown, SlashUp, ToggleFavorite,
+    SlashCancel, SlashConfirm, SlashDown, SlashUp, ThemeAuto, ThemeDark, ThemeLight,
+    ToggleFavorite, ToggleLineNumbers, ToggleSidebarSide, ToggleWysiwyg,
 };
 use crate::db::Db;
 use crate::images::ImageSeed;
@@ -7309,6 +7310,38 @@ impl Render for AppView {
             .on_action(
                 cx.listener(|this: &mut AppView, _: &OpenCommandPalette, window, cx| {
                     this.open_command_palette(window, cx)
+                }),
+            )
+            // Quick settings from the palette — the Settings window's setters.
+            .on_action(cx.listener(|this: &mut AppView, _: &ToggleWysiwyg, _, cx| {
+                let on = !this.wysiwyg();
+                this.set_wysiwyg(on, cx);
+            }))
+            .on_action(
+                cx.listener(|this: &mut AppView, _: &ToggleLineNumbers, _, cx| {
+                    let on = !this.line_numbers();
+                    this.set_line_numbers(on, cx);
+                }),
+            )
+            .on_action(
+                cx.listener(|this: &mut AppView, _: &ToggleSidebarSide, _, cx| {
+                    let right = !this.sidebar_right;
+                    this.set_sidebar_right(right, cx);
+                }),
+            )
+            .on_action(
+                cx.listener(|this: &mut AppView, _: &ThemeLight, window, cx| {
+                    this.set_theme_mode(theme::Mode::Light, window, cx);
+                }),
+            )
+            .on_action(
+                cx.listener(|this: &mut AppView, _: &ThemeDark, window, cx| {
+                    this.set_theme_mode(theme::Mode::Dark, window, cx);
+                }),
+            )
+            .on_action(
+                cx.listener(|this: &mut AppView, _: &ThemeAuto, window, cx| {
+                    this.set_theme_mode(theme::Mode::Auto, window, cx);
                 }),
             )
             .on_action(

--- a/src/app.rs
+++ b/src/app.rs
@@ -1481,9 +1481,40 @@ impl AppView {
     /// owns its open/close timing and stays while the pointer is on it), showing
     /// the target page's first lines — or the URL, the way a browser's status
     /// bar does.
-    fn link_hover_card(&self, cx: &App) -> Option<gpui::AnyElement> {
+    fn link_hover_card(&mut self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
         let (hit, bounds) = self.link_hover.clone()?;
         let preview = self.link_preview(&hit, cx);
+        // The excerpt renders as real markdown through the reader, with the
+        // same renderer set an embed gets, so images/math/mermaid in the
+        // preview look like the page they came from. Warm their stores first
+        // (idempotent — `upsert_embed` does the same each pass).
+        if let LinkPreview::Page {
+            excerpt: Some(md), ..
+        } = &preview
+        {
+            self.ensure_content_images(md, cx);
+            self.ensure_content_mermaid(md, cx);
+            self.ensure_content_math(md, cx);
+            self.ensure_content_parsed(md, cx);
+        }
+        let style = theme::markdown_style(self.list_indent(), px(13.0));
+        let image = crate::ui::image::embed_renderer(self, cx);
+        let mermaid = crate::ui::mermaid::renderer(self, cx);
+        let math = crate::ui::math::renderer(self, cx);
+        let inline_math = crate::ui::math::inline_renderer(self);
+        let highlight = self.highlighter_fn();
+        let markdown = move |source: String| {
+            zorite_markdown::MarkdownView::new("link-preview", source)
+                .set_labels(crate::i18n::reader_labels())
+                .style(style.clone())
+                .on_image(image.clone())
+                .on_embed_image(image.clone())
+                .on_mermaid(mermaid.clone())
+                .on_math(math.clone())
+                .on_inline_math(inline_math.clone())
+                .on_highlight(highlight.clone())
+                .into_any_element()
+        };
         Some(
             gpui::deferred(
                 gpui::anchored().position(bounds.origin).child(
@@ -1491,7 +1522,7 @@ impl AppView {
                         .anchor(gpui::Anchor::TopLeft)
                         .open_delay(std::time::Duration::from_millis(450))
                         .trigger(div().w(bounds.size.width).h(bounds.size.height))
-                        .content(move |_, _, _| preview.clone().render()),
+                        .content(move |_, _, _| preview.clone().render(&markdown)),
                 ),
             )
             .into_any_element(),
@@ -7947,45 +7978,27 @@ enum LinkPreview {
 }
 
 impl LinkPreview {
-    fn render(self) -> gpui::Div {
+    /// `markdown` renders a page excerpt through the reader (see
+    /// `AppView::link_hover_card`, which supplies the renderer set).
+    fn render(self, markdown: &dyn Fn(String) -> gpui::AnyElement) -> gpui::Div {
         let body = div().max_w(px(380.0)).flex().flex_col().gap(px(4.0));
         match self {
-            LinkPreview::Page { title, excerpt } => {
-                let text = excerpt.unwrap_or_else(|| t!("link_preview.no_page").into_owned());
-                // #66: gpui wraps a paragraph containing right-to-left text
-                // backwards (rows sliced from reordered glyphs), so such an
-                // excerpt goes through the bidi row layout, one line per
-                // paragraph the way the reader does it. The card follows the
-                // excerpt's base direction so an Arabic page reads from the
-                // right edge; a definite width gives the rows an edge to align to.
-                let bidi = zorite_markdown::syntax::contains_rtl(&text);
-                let rtl = zorite_markdown::syntax::base_direction(&text).is_rtl();
-                body.when(rtl, |b| b.w(px(380.0)).text_right())
-                    .child(
-                        div()
-                            .text_size(px(13.0))
-                            .font_weight(gpui::FontWeight::SEMIBOLD)
-                            .child(title),
-                    )
-                    .child(
-                        div()
-                            .text_size(px(12.0))
-                            .text_color(theme::text_secondary())
-                            .map(|el| {
-                                if bidi {
-                                    el.flex().flex_col().children(text.lines().map(|line| {
-                                        gpui_bidi::paragraph::RtlText::new(line.to_string())
-                                            .with_base_rtl(
-                                                zorite_markdown::syntax::base_direction(line)
-                                                    .is_rtl(),
-                                            )
-                                    }))
-                                } else {
-                                    el.child(text)
-                                }
-                            }),
-                    )
-            }
+            LinkPreview::Page { title, excerpt } => body
+                .w(px(380.0))
+                .child(
+                    div()
+                        .text_size(px(13.0))
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .child(title),
+                )
+                .child(match excerpt {
+                    Some(md) => markdown(md),
+                    None => div()
+                        .text_size(px(12.0))
+                        .text_color(theme::text_secondary())
+                        .child(t!("link_preview.no_page").into_owned())
+                        .into_any_element(),
+                }),
             LinkPreview::Block(id) => body.child(
                 div()
                     .text_size(px(12.0))
@@ -8003,16 +8016,23 @@ impl LinkPreview {
     }
 }
 
-/// The first few content lines of a page for its hover card: blank lines and
-/// hidden marker comments skipped, capped so the card stays a glance.
+/// The first few content lines of a page for its hover card, as markdown
+/// source: hidden marker comments skipped, blank lines kept (they separate
+/// paragraphs) but not counted, capped so the card stays a glance.
 fn excerpt(content: &str) -> String {
     let mut out = String::new();
+    let mut kept = 0;
     for line in content
         .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty() && !l.starts_with("<!--"))
-        .take(8)
+        .map(str::trim_end)
+        .filter(|l| !l.trim_start().starts_with("<!--"))
     {
+        if !line.is_empty() {
+            kept += 1;
+            if kept > 8 {
+                break;
+            }
+        }
         if !out.is_empty() {
             out.push('\n');
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,6 +59,8 @@ mod importing;
 mod math;
 mod persistence;
 mod stores;
+#[cfg(test)]
+mod ui_tests;
 
 pub use find::{FeedFind, PageFind};
 use math::MathEdit;
@@ -7521,6 +7523,7 @@ impl Render for AppView {
             .children(image_lightbox)
             .children(ctx_menu_overlay)
             .children(link_hover_overlay)
+            .children(fps_hud(window, cx))
             // gpui-component's `Root` tracks dialog state but does NOT render
             // the dialog layer — the host view must, or dialogs (like the
             // delete-page confirm) stay invisible.
@@ -8030,6 +8033,17 @@ mod auto_link_tests {
         assert_eq!(auto_link_match(&t, "not-a-match"), None);
         assert_eq!(auto_link_match(&t, "meetings "), None); // trailing ws = no word completed
     }
+}
+
+/// The `fps` feature's performance HUD (`cargo run --features fps`), over the
+/// main window's content. `None` in every other build.
+#[cfg(feature = "fps")]
+fn fps_hud(window: &mut Window, cx: &mut App) -> Option<gpui::AnyElement> {
+    Some(gpui_fps::fps_monitor(window, cx).into_any_element())
+}
+#[cfg(not(feature = "fps"))]
+fn fps_hud(_window: &mut Window, _cx: &mut App) -> Option<gpui::AnyElement> {
+    None
 }
 
 /// The data behind the link hover card (see `AppView::link_hover_card`).

--- a/src/app.rs
+++ b/src/app.rs
@@ -7950,19 +7950,42 @@ impl LinkPreview {
     fn render(self) -> gpui::Div {
         let body = div().max_w(px(380.0)).flex().flex_col().gap(px(4.0));
         match self {
-            LinkPreview::Page { title, excerpt } => body
-                .child(
-                    div()
-                        .text_size(px(13.0))
-                        .font_weight(gpui::FontWeight::SEMIBOLD)
-                        .child(title),
-                )
-                .child(
-                    div()
-                        .text_size(px(12.0))
-                        .text_color(theme::text_secondary())
-                        .child(excerpt.unwrap_or_else(|| t!("link_preview.no_page").into_owned())),
-                ),
+            LinkPreview::Page { title, excerpt } => {
+                let text = excerpt.unwrap_or_else(|| t!("link_preview.no_page").into_owned());
+                // #66: gpui wraps a paragraph containing right-to-left text
+                // backwards (rows sliced from reordered glyphs), so such an
+                // excerpt goes through the bidi row layout, one line per
+                // paragraph the way the reader does it. The card follows the
+                // excerpt's base direction so an Arabic page reads from the
+                // right edge; a definite width gives the rows an edge to align to.
+                let bidi = zorite_markdown::syntax::contains_rtl(&text);
+                let rtl = zorite_markdown::syntax::base_direction(&text).is_rtl();
+                body.when(rtl, |b| b.w(px(380.0)).text_right())
+                    .child(
+                        div()
+                            .text_size(px(13.0))
+                            .font_weight(gpui::FontWeight::SEMIBOLD)
+                            .child(title),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .text_color(theme::text_secondary())
+                            .map(|el| {
+                                if bidi {
+                                    el.flex().flex_col().children(text.lines().map(|line| {
+                                        gpui_bidi::paragraph::RtlText::new(line.to_string())
+                                            .with_base_rtl(
+                                                zorite_markdown::syntax::base_direction(line)
+                                                    .is_rtl(),
+                                            )
+                                    }))
+                                } else {
+                                    el.child(text)
+                                }
+                            }),
+                    )
+            }
             LinkPreview::Block(id) => body.child(
                 div()
                     .text_size(px(12.0))

--- a/src/app.rs
+++ b/src/app.rs
@@ -560,6 +560,9 @@ pub struct AppView {
     prop_edit: Option<PropEdit>,
     // Right-click context menu on a rendered formula (Copy LaTeX / Export SVG / Export PNG).
     ctx_menu: Option<CtxMenu>,
+    /// The link under the pointer in any view + its window-space box, for the
+    /// hover preview card (see `link_hover_card`). Both renderers report here.
+    link_hover: Option<(zorite_markdown::syntax::LinkHit, Bounds<Pixels>)>,
     // Pending image decodes, run a bounded few at a time (`image_decodes` counts
     // what's in flight, capped at `MAX_IMAGE_DECODES`). The bound keeps the
     // transient full-resolution buffers in check — decoding a 12 MP photo briefly
@@ -881,6 +884,7 @@ impl AppView {
             math_edit: None,
             prop_edit: None,
             ctx_menu: None,
+            link_hover: None,
             image_queue: std::collections::VecDeque::new(),
             image_decodes: 0,
             pdf_views: HashMap::new(),
@@ -1194,6 +1198,7 @@ impl AppView {
                         cx,
                     );
                 }
+                EditorEvent::HoverLink(hover) => this.set_link_hover(hover.clone(), cx),
                 EditorEvent::PreviewImage(src) => {
                     this.open_image_lightbox(src.clone(), window, cx);
                 }
@@ -1454,6 +1459,72 @@ impl AppView {
             Ok(Some(page)) => self.open_page_foreground(page, window, cx),
             Ok(None) => log::warn!("page {id} not found"),
             Err(e) => log::error!("open page {id}: {e}"),
+        }
+    }
+
+    /// A view reported the link under the pointer (or that there is none) —
+    /// see [`Self::link_hover_card`]. Both renderers call this; only a change
+    /// repaints.
+    pub fn set_link_hover(
+        &mut self,
+        hover: Option<(zorite_markdown::syntax::LinkHit, Bounds<Pixels>)>,
+        cx: &mut Context<Self>,
+    ) {
+        if self.link_hover != hover {
+            self.link_hover = hover;
+            cx.notify();
+        }
+    }
+
+    /// The hover preview for the link under the pointer: gpui-component's
+    /// `HoverCard` over an invisible trigger the size of the link (so the card
+    /// owns its open/close timing and stays while the pointer is on it), showing
+    /// the target page's first lines — or the URL, the way a browser's status
+    /// bar does.
+    fn link_hover_card(&self, cx: &App) -> Option<gpui::AnyElement> {
+        let (hit, bounds) = self.link_hover.clone()?;
+        let preview = self.link_preview(&hit, cx);
+        Some(
+            gpui::deferred(
+                gpui::anchored().position(bounds.origin).child(
+                    gpui_component::hover_card::HoverCard::new("link-preview")
+                        .anchor(gpui::Anchor::TopLeft)
+                        .open_delay(std::time::Duration::from_millis(450))
+                        .trigger(div().w(bounds.size.width).h(bounds.size.height))
+                        .content(move |_, _, _| preview.clone().render()),
+                ),
+            )
+            .into_any_element(),
+        )
+    }
+
+    /// What the preview card shows for `hit`: the page's title and first lines
+    /// (anchors stripped, aliases resolved), a block reference's id, or the URL.
+    fn link_preview(&self, hit: &zorite_markdown::syntax::LinkHit, _cx: &App) -> LinkPreview {
+        use zorite_markdown::syntax::{LinkHit, split_block_anchor, split_heading_anchor};
+        match hit {
+            LinkHit::Url(u) => LinkPreview::Url(u.clone()),
+            LinkHit::BlockRef(id) => LinkPreview::Block(id.clone()),
+            LinkHit::Page(target) => {
+                let (base, _) = split_block_anchor(target);
+                let (base, _) = split_heading_anchor(base);
+                let page = self
+                    .db
+                    .get_page_by_title(base)
+                    .ok()
+                    .flatten()
+                    .or_else(|| self.db.get_page_by_alias(base).ok().flatten());
+                match page {
+                    Some(p) => LinkPreview::Page {
+                        title: p.title,
+                        excerpt: Some(excerpt(&p.content)),
+                    },
+                    None => LinkPreview::Page {
+                        title: base.to_string(),
+                        excerpt: None,
+                    },
+                }
+            }
         }
     }
 
@@ -2021,6 +2092,7 @@ impl AppView {
                         cx,
                     );
                 }
+                EditorEvent::HoverLink(hover) => this.set_link_hover(hover.clone(), cx),
                 EditorEvent::PreviewImage(src) => {
                     this.open_image_lightbox(src.clone(), window, cx);
                 }
@@ -6983,6 +7055,7 @@ impl Render for AppView {
                 .into_any_element()
             });
 
+        let link_hover_overlay = self.link_hover_card(cx);
         let ctx_menu_overlay = self.ctx_menu.as_ref().map(|menu| {
             // Action ids: 0..=2 formula copy/export, 3 day/page Edit, 4..=6 align L/C/R (only
             // while editing the formula, where the in-line editor can re-justify it live).
@@ -7349,6 +7422,7 @@ impl Render for AppView {
             .children(mermaid_lightbox)
             .children(image_lightbox)
             .children(ctx_menu_overlay)
+            .children(link_hover_overlay)
             // gpui-component's `Root` tracks dialog state but does NOT render
             // the dialog layer — the host view must, or dialogs (like the
             // delete-page confirm) stay invisible.
@@ -7858,4 +7932,75 @@ mod auto_link_tests {
         assert_eq!(auto_link_match(&t, "not-a-match"), None);
         assert_eq!(auto_link_match(&t, "meetings "), None); // trailing ws = no word completed
     }
+}
+
+/// The data behind the link hover card (see `AppView::link_hover_card`).
+#[derive(Clone)]
+enum LinkPreview {
+    /// A wiki target; `excerpt` is `None` when no such page exists yet.
+    Page {
+        title: String,
+        excerpt: Option<String>,
+    },
+    Block(String),
+    Url(String),
+}
+
+impl LinkPreview {
+    fn render(self) -> gpui::Div {
+        let body = div().max_w(px(380.0)).flex().flex_col().gap(px(4.0));
+        match self {
+            LinkPreview::Page { title, excerpt } => body
+                .child(
+                    div()
+                        .text_size(px(13.0))
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .child(title),
+                )
+                .child(
+                    div()
+                        .text_size(px(12.0))
+                        .text_color(theme::text_secondary())
+                        .child(excerpt.unwrap_or_else(|| t!("link_preview.no_page").into_owned())),
+                ),
+            LinkPreview::Block(id) => body.child(
+                div()
+                    .text_size(px(12.0))
+                    .text_color(theme::text_secondary())
+                    .child(format!("(({id}))")),
+            ),
+            LinkPreview::Url(url) => body.child(
+                div()
+                    .text_size(px(12.0))
+                    .text_color(theme::text_secondary())
+                    .truncate()
+                    .child(url),
+            ),
+        }
+    }
+}
+
+/// The first few content lines of a page for its hover card: blank lines and
+/// hidden marker comments skipped, capped so the card stays a glance.
+fn excerpt(content: &str) -> String {
+    let mut out = String::new();
+    for line in content
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with("<!--"))
+        .take(8)
+    {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(line);
+        if out.chars().count() > 360 {
+            break;
+        }
+    }
+    if out.chars().count() > 360 {
+        out = out.chars().take(360).collect();
+        out.push('…');
+    }
+    out
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,11 +36,12 @@ use zorite_editor::{Diagnostic, EditorEvent, EditorState};
 
 use crate::actions::{
     CloseTab, CopyPageContents, CopyPageContentsMarkdown, CopyPageLink, DeletePage,
-    ExportActivePdf, ExportNotebook, ExportPdf, FindInPage, FitImages, GlobalSearch, ImportLogseq,
-    ImportObsidian, InsertTab, NewPage, NewSubPage, NewWhiteboard, NextTab, OpenCommandPalette,
-    OpenInNewTab, OpenInNewWindow, OpenSettings, Outdent, PasteImage, PrevTab, RenamePage,
-    SlashCancel, SlashConfirm, SlashDown, SlashUp, ThemeAuto, ThemeDark, ThemeLight,
-    ToggleFavorite, ToggleLineNumbers, ToggleSidebarSide, ToggleWysiwyg,
+    ExportActivePdf, ExportNotebook, ExportPdf, FindInPage, FitImages, GlobalSearch, GoToToday,
+    ImportLogseq, ImportObsidian, InsertTab, JumpToDate, NewPage, NewSubPage, NewWhiteboard,
+    NextTab, OpenAllPages, OpenCommandPalette, OpenGraph, OpenInNewTab, OpenInNewWindow,
+    OpenSettings, Outdent, PasteImage, PrevTab, RenamePage, SlashCancel, SlashConfirm, SlashDown,
+    SlashUp, ThemeAuto, ThemeDark, ThemeLight, ToggleFavorite, ToggleLineNumbers, ToggleSidebar,
+    ToggleSidebarSide, ToggleWysiwyg,
 };
 use crate::db::Db;
 use crate::images::ImageSeed;
@@ -7343,6 +7344,31 @@ impl Render for AppView {
                 cx.listener(|this: &mut AppView, _: &ThemeAuto, window, cx| {
                     this.set_theme_mode(theme::Mode::Auto, window, cx);
                 }),
+            )
+            // Navigation from the palette.
+            .on_action(
+                cx.listener(|this: &mut AppView, _: &GoToToday, window, cx| {
+                    let today = date_for_offset(0);
+                    this.open_journal_day(&today, window, cx);
+                }),
+            )
+            .on_action(cx.listener(|this: &mut AppView, _: &JumpToDate, _, cx| {
+                if !this.show_calendar {
+                    this.toggle_calendar(cx);
+                }
+            }))
+            .on_action(
+                cx.listener(|this: &mut AppView, _: &OpenAllPages, window, cx| {
+                    this.open_all_pages(window, cx)
+                }),
+            )
+            .on_action(
+                cx.listener(|this: &mut AppView, _: &OpenGraph, window, cx| {
+                    this.open_graph(window, cx)
+                }),
+            )
+            .on_action(
+                cx.listener(|this: &mut AppView, _: &ToggleSidebar, _, cx| this.toggle_sidebar(cx)),
             )
             .on_action(
                 cx.listener(|this: &mut AppView, _: &FindInPage, window, cx| {

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -3,9 +3,65 @@
 //! DB-error modal) and their submit helpers — split from `app.rs`.
 
 use super::*;
+use gpui_component::{h_flex, kbd::Kbd};
 use rust_i18n::t;
 
 impl AppView {
+    /// ⌘⇧P — gpui-component's `Command` palette over every menu command
+    /// (`actions::palette_groups`), in a chrome-less dialog. Confirm closes
+    /// the dialog FIRST and dispatches after: an item's built-in `.action`
+    /// would fire before the close, whose focus restore then lands on top of
+    /// whatever the command focused (the find bar, the search box).
+    pub(super) fn open_command_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        use gpui_component::command::{Command, CommandGroup, CommandItem, CommandState};
+        let state = cx.new(|cx| CommandState::new(window, cx));
+        let groups = Rc::new(crate::actions::palette_groups());
+        let focus = state.clone();
+        window.open_dialog(cx, move |dialog, _window, _cx| {
+            let on_confirm = groups.clone();
+            let command =
+                groups.iter().fold(
+                    Command::new(&state)
+                        .bordered(false)
+                        .placeholder(t!("command_palette.placeholder"))
+                        .on_confirm(move |ix, window, cx| {
+                            window.close_dialog(cx);
+                            if let Some((_, action)) = on_confirm
+                                .get(ix.section)
+                                .and_then(|(_, items)| items.get(ix.row))
+                            {
+                                window.dispatch_action(action.boxed_clone(), cx);
+                            }
+                        }),
+                    |command, (label, items)| {
+                        command.group(CommandGroup::new().label(label.clone()).items(
+                            items.iter().map(|(name, action)| {
+                                let (name, action) = (name.clone(), action.boxed_clone());
+                                CommandItem::new()
+                                    .label(name.clone())
+                                    .child(move |window, _cx| {
+                                        // The default row would draw this hint itself, but only
+                                        // for an item carrying `.action` — see above.
+                                        h_flex()
+                                            .flex_1()
+                                            .gap_2()
+                                            .items_center()
+                                            .child(div().flex_1().truncate().child(name.clone()))
+                                            .children(Kbd::binding_for_action(
+                                                action.as_ref(),
+                                                None,
+                                                window,
+                                            ))
+                                    })
+                            }),
+                        ))
+                    },
+                );
+            dialog.w(px(480.0)).close_button(false).child(command)
+        });
+        focus.update(cx, |state, cx| state.focus(window, cx));
+    }
+
     /// Open the "insert page card" dialog, then place the chosen page as a card
     /// at world `(x, y)` on board `board_id`.
     pub(super) fn place_embed_dialog(

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -17,6 +17,62 @@ impl AppView {
         use gpui_component::command::{Command, CommandGroup, CommandItem, CommandState};
         let state = cx.new(|cx| CommandState::new(window, cx));
         let mut groups = crate::actions::palette_groups();
+        // Quick settings, worded as the change they make; the theme mode the
+        // app is already in is left out.
+        let mut quick: Vec<crate::actions::PaletteCommand> = vec![
+            (
+                if self.wysiwyg() {
+                    t!("command_palette.wysiwyg_off")
+                } else {
+                    t!("command_palette.wysiwyg_on")
+                }
+                .into(),
+                Box::new(ToggleWysiwyg),
+            ),
+            (
+                if self.line_numbers() {
+                    t!("command_palette.gutter_hide")
+                } else {
+                    t!("command_palette.gutter_show")
+                }
+                .into(),
+                Box::new(ToggleLineNumbers),
+            ),
+            (
+                if self.sidebar_right {
+                    t!("command_palette.sidebar_left")
+                } else {
+                    t!("command_palette.sidebar_right")
+                }
+                .into(),
+                Box::new(ToggleSidebarSide),
+            ),
+        ];
+        let modes: [(theme::Mode, &str, Box<dyn gpui::Action>); 3] = [
+            (
+                theme::Mode::Light,
+                "command_palette.theme_light",
+                Box::new(ThemeLight),
+            ),
+            (
+                theme::Mode::Dark,
+                "command_palette.theme_dark",
+                Box::new(ThemeDark),
+            ),
+            (
+                theme::Mode::Auto,
+                "command_palette.theme_auto",
+                Box::new(ThemeAuto),
+            ),
+        ];
+        let current = self.theme_mode();
+        quick.extend(
+            modes
+                .into_iter()
+                .filter(|(mode, _, _)| *mode != current)
+                .map(|(_, key, action)| (t!(key).into(), action)),
+        );
+        groups.push((t!("command_palette.settings").into(), quick));
         // The page verbs read their target from `context_page` (armed by a
         // right-click); the palette arms it with the active page on confirm.
         let page = match self.tabs.get(self.active) {

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -8,34 +8,85 @@ use rust_i18n::t;
 
 impl AppView {
     /// ⌘⇧P — gpui-component's `Command` palette over every menu command
-    /// (`actions::palette_groups`), in a chrome-less dialog. Confirm closes
-    /// the dialog FIRST and dispatches after: an item's built-in `.action`
-    /// would fire before the close, whose focus restore then lands on top of
+    /// (`actions::palette_groups`) plus, on a page tab, that page's context-menu
+    /// verbs under its title, in a chrome-less dialog. Confirm closes the
+    /// dialog FIRST and dispatches after: an item's built-in `.action` would
+    /// fire before the close, whose focus restore then lands on top of
     /// whatever the command focused (the find bar, the search box).
     pub(super) fn open_command_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         use gpui_component::command::{Command, CommandGroup, CommandItem, CommandState};
         let state = cx.new(|cx| CommandState::new(window, cx));
-        let groups = Rc::new(crate::actions::palette_groups());
+        let mut groups = crate::actions::palette_groups();
+        // The page verbs read their target from `context_page` (armed by a
+        // right-click); the palette arms it with the active page on confirm.
+        let page = match self.tabs.get(self.active) {
+            Some(
+                tab @ OpenTab {
+                    kind: TabKind::Page(id),
+                    ..
+                },
+            ) => {
+                let fav = if self.is_favorite(*id) {
+                    t!("page_ctx.remove_favorite")
+                } else {
+                    t!("page_ctx.add_favorite")
+                };
+                let verbs: Vec<crate::actions::PaletteCommand> = vec![
+                    (fav.into(), Box::new(ToggleFavorite)),
+                    (
+                        t!("page_ctx.open_new_window").into(),
+                        Box::new(OpenInNewWindow),
+                    ),
+                    (t!("page_ctx.copy_link").into(), Box::new(CopyPageLink)),
+                    (
+                        t!("page_ctx.copy_contents").into(),
+                        Box::new(CopyPageContents),
+                    ),
+                    (
+                        t!("page_ctx.copy_contents_md").into(),
+                        Box::new(CopyPageContentsMarkdown),
+                    ),
+                    (t!("page_ctx.new_sub_page").into(), Box::new(NewSubPage)),
+                    (t!("page_ctx.rename_page").into(), Box::new(RenamePage)),
+                    (t!("page_ctx.delete_page").into(), Box::new(DeletePage)),
+                ];
+                let title = tab.display_title();
+                groups.push((title.clone(), verbs));
+                Some((groups.len() - 1, *id, title))
+            }
+            _ => None,
+        };
+        let groups = Rc::new(groups);
         let focus = state.clone();
+        let weak = cx.entity().downgrade();
         window.open_dialog(cx, move |dialog, _window, _cx| {
             let on_confirm = groups.clone();
-            let command =
-                groups.iter().fold(
-                    Command::new(&state)
-                        .bordered(false)
-                        .placeholder(t!("command_palette.placeholder"))
-                        .on_confirm(move |ix, window, cx| {
-                            window.close_dialog(cx);
-                            if let Some((_, action)) = on_confirm
-                                .get(ix.section)
-                                .and_then(|(_, items)| items.get(ix.row))
-                            {
-                                window.dispatch_action(action.boxed_clone(), cx);
-                            }
-                        }),
-                    |command, (label, items)| {
-                        command.group(CommandGroup::new().label(label.clone()).items(
-                            items.iter().map(|(name, action)| {
+            let page = page.clone();
+            let weak = weak.clone();
+            let command = groups.iter().fold(
+                Command::new(&state)
+                    .bordered(false)
+                    .placeholder(t!("command_palette.placeholder"))
+                    .on_confirm(move |ix, window, cx| {
+                        window.close_dialog(cx);
+                        if let Some((section, id, title)) = &page
+                            && ix.section == *section
+                        {
+                            let _ = weak
+                                .update(cx, |this, _| this.set_context_page(*id, title.clone()));
+                        }
+                        if let Some((_, action)) = on_confirm
+                            .get(ix.section)
+                            .and_then(|(_, items)| items.get(ix.row))
+                        {
+                            window.dispatch_action(action.boxed_clone(), cx);
+                        }
+                    }),
+                |command, (label, items)| {
+                    command.group(
+                        CommandGroup::new()
+                            .label(label.clone())
+                            .items(items.iter().map(|(name, action)| {
                                 let (name, action) = (name.clone(), action.boxed_clone());
                                 CommandItem::new()
                                     .label(name.clone())
@@ -53,10 +104,10 @@ impl AppView {
                                                 window,
                                             ))
                                     })
-                            }),
-                        ))
-                    },
-                );
+                            })),
+                    )
+                },
+            );
             dialog.w(px(480.0)).close_button(false).child(command)
         });
         focus.update(cx, |state, cx| state.focus(window, cx));

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -189,7 +189,15 @@ impl AppView {
                     )
                 },
             );
-            dialog.w(px(480.0)).close_button(false).child(command)
+            // Raised surface + the visible rule token, so the palette stands off
+            // the page on a theme whose content and window are the same color
+            // (CRT: black on black, where the stock border all but vanishes).
+            dialog
+                .w(px(480.0))
+                .close_button(false)
+                .bg(theme::elevated())
+                .border_color(theme::divider())
+                .child(command)
         });
         focus.update(cx, |state, cx| state.focus(window, cx));
     }

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -17,6 +17,31 @@ impl AppView {
         use gpui_component::command::{Command, CommandGroup, CommandItem, CommandState};
         let state = cx.new(|cx| CommandState::new(window, cx));
         let mut groups = crate::actions::palette_groups();
+        let nav: Vec<crate::actions::PaletteCommand> = vec![
+            (
+                t!("command_palette.go_to_today").into(),
+                Box::new(GoToToday),
+            ),
+            (
+                t!("command_palette.jump_to_date").into(),
+                Box::new(JumpToDate),
+            ),
+            (
+                t!("command_palette.all_pages").into(),
+                Box::new(OpenAllPages),
+            ),
+            (t!("command_palette.graph").into(), Box::new(OpenGraph)),
+            (
+                if self.sidebar_collapsed {
+                    t!("command_palette.sidebar_show")
+                } else {
+                    t!("command_palette.sidebar_hide")
+                }
+                .into(),
+                Box::new(ToggleSidebar),
+            ),
+        ];
+        groups.push((t!("command_palette.navigate").into(), nav));
         // Quick settings, worded as the change they make; the theme mode the
         // app is already in is left out.
         let mut quick: Vec<crate::actions::PaletteCommand> = vec![

--- a/src/app/ui_tests.rs
+++ b/src/app/ui_tests.rs
@@ -1,0 +1,72 @@
+//! Headless UI tests of chrome flows that used to be verified by hand: a real
+//! `AppView` in gpui's test window, actions dispatched and keys simulated, the
+//! outcome read back from the view. No pixels are inspected.
+//!
+//! `paths::data_dir` is a throwaway directory under `cfg(test)`, so the
+//! database these open is never a real notebook.
+
+use super::*;
+use gpui::{TestAppContext, VisualTestContext};
+
+/// What `main` sets up before the window opens, minus the platform bits
+/// (assets, cursors, fonts): the widget library, the keymap, and the globals
+/// `AppView::new` reads.
+fn boot(cx: &mut TestAppContext) -> (Entity<AppView>, &mut VisualTestContext) {
+    cx.update(|cx| {
+        gpui_component::init(cx);
+        crate::actions::bind_keys(cx);
+        let doc_signal = cx.new(|_| DocSignal);
+        cx.set_global(GlobalDocSignal(doc_signal));
+        cx.set_global(GlobalDraggingTab::default());
+        cx.set_global(GlobalDropTarget::default());
+        cx.set_global(GlobalAppWindows::default());
+        cx.set_global(crate::updater::UpdateState::default());
+    });
+    let mut app = None;
+    let (_root, cx) = cx.add_window_view(|window, cx| {
+        let view = cx.new(|cx| AppView::new(window, cx));
+        app = Some(view.clone());
+        Root::new(view, window, cx)
+    });
+    let app = app.expect("the window builder ran");
+    // Actions dispatch along the focused element's path; the app's root div
+    // (where the handlers live) is focused once the user interacts, so do it.
+    cx.update(|window, cx| {
+        let handle = app.read(cx).focus_handle.clone();
+        window.focus(&handle, cx);
+    });
+    cx.run_until_parked();
+    (app, cx)
+}
+
+fn dialog_open(cx: &mut VisualTestContext) -> bool {
+    cx.update(|window, cx| window.has_active_dialog(cx))
+}
+
+#[gpui::test]
+fn command_palette_opens_closes_and_runs_a_command(cx: &mut TestAppContext) {
+    let (app, cx) = boot(cx);
+
+    // ⌘⇧P's action opens the palette as a dialog…
+    cx.dispatch_action(OpenCommandPalette);
+    cx.run_until_parked();
+    assert!(dialog_open(cx), "the palette should be open");
+
+    // …and Esc on an empty query closes it (the app's own Esc binding must
+    // propagate past the note editor while a dialog is up).
+    cx.simulate_keystrokes("escape");
+    assert!(!dialog_open(cx), "escape should close the palette");
+
+    // Type to filter, Enter to confirm: the dialog closes first, then the
+    // command runs — here the Navigate group's "Hide sidebar".
+    assert!(!cx.update(|_, cx| app.read(cx).sidebar_collapsed));
+    cx.dispatch_action(OpenCommandPalette);
+    cx.run_until_parked();
+    cx.simulate_input("Hide sidebar");
+    cx.simulate_keystrokes("enter");
+    assert!(!dialog_open(cx), "confirm should close the palette");
+    assert!(
+        cx.update(|_, cx| app.read(cx).sidebar_collapsed),
+        "the confirmed command should have run"
+    );
+}

--- a/src/mentions.rs
+++ b/src/mentions.rs
@@ -40,7 +40,9 @@ pub fn unlinked_mention_ranges(content: &str, title: &str) -> Vec<Range<usize>> 
         while let Some(rel) = hay[from..].find(&needle) {
             let start = from + rel;
             let end = start + needle.len();
-            from = start + 1;
+            // Step past the match's first character, not its first byte —
+            // a title starting with a multi-byte letter would slice mid-char.
+            from = start + needle.chars().next().map_or(1, char::len_utf8);
             // Word boundaries — but only where the title itself starts/ends
             // with a word character ("C++" needs no trailing boundary).
             let bounded_left = !needle.as_bytes()[0].is_ascii_alphanumeric()
@@ -140,6 +142,14 @@ fn inline_code_ranges(line: &str) -> Vec<Range<usize>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn non_ascii_title_does_not_slice_mid_char() {
+        let content = "امروز یادداشت فارسی را خواندم\n[[یادداشت فارسی]]";
+        let hits = unlinked_mention_ranges(content, "یادداشت فارسی");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(&content[hits[0].clone()], "یادداشت فارسی");
+    }
 
     #[test]
     fn finds_plain_mentions_only() {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -52,6 +52,7 @@ fn default_data_dir() -> PathBuf {
 /// 1. `ZORITE_DATA` — a full override for throwaway/dev data sets.
 /// 2. The user-chosen directory from the location-pointer file.
 /// 3. The OS default ([`default_data_dir`]).
+#[cfg_attr(test, allow(dead_code))] // `data_dir` bypasses it under test
 fn resolve_data_dir() -> PathBuf {
     if let Some(dir) = std::env::var_os("ZORITE_DATA") {
         return PathBuf::from(dir);
@@ -71,7 +72,17 @@ fn resolve_data_dir() -> PathBuf {
 /// pending move runs (before the database is opened).
 pub fn data_dir() -> PathBuf {
     static DIR: OnceLock<PathBuf> = OnceLock::new();
-    DIR.get_or_init(resolve_data_dir).clone()
+    DIR.get_or_init(|| {
+        // Under test, one throwaway directory per process: the headless UI
+        // tests open a real `AppView` (and so a real database) and must never
+        // land in the user's notebook, whatever `ZORITE_DATA` or the pointer
+        // file say.
+        #[cfg(test)]
+        return std::env::temp_dir().join(format!("zorite-test-{}", std::process::id()));
+        #[cfg(not(test))]
+        resolve_data_dir()
+    })
+    .clone()
 }
 
 // --- Window-bounds persistence (Settings → General toggle) ---

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2446,3 +2446,13 @@ mod keys {
         vec![MOD, SHIFT, "Z"]
     }
 }
+#[cfg(not(target_os = "macos"))]
+mod keys {
+    pub const MOD: &str = "Ctrl";
+    pub const CTRL: &str = "Ctrl";
+    pub const SHIFT: &str = "Shift";
+    pub const ALT: &str = "Alt";
+    pub fn redo() -> Vec<&'static str> {
+        vec!["Ctrl", "Y"]
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1872,6 +1872,10 @@ fn keyboard_page() -> SettingPage {
         .keywords(labels)
     }
     let app_rows: Vec<(String, Vec<&'static str>)> = vec![
+        (
+            t!("settings.kb.command_palette").to_string(),
+            vec![keys::MOD, keys::SHIFT, "P"],
+        ),
         (t!("settings.kb.new_tab").to_string(), vec![keys::MOD, "T"]),
         (
             t!("settings.kb.new_window").to_string(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,97 +1,71 @@
-//! The Settings window — a card-based, two-pane layout styled after
-//! Baudrun's Skins screen: a left nav + cards with a title / description /
-//! control. The **Appearance** pane has an App Theme dropdown, an
-//! Appearance (light/dark/auto) dropdown, and an Installed-themes card
-//! (reveal folder + reload + the user themes loaded from disk).
-//!
-//! The dropdowns are gpui-component `Select`s; selecting one calls back
-//! into `AppView` so the change applies live to every window.
+//! The Settings window, built on gpui-component's `setting` module: a
+//! sidebar of pages with a search box, and cards (`SettingGroup`s) of typed
+//! fields — switches and dropdowns that read the live value from `AppView`
+//! and write back through its setters — plus custom rows for the parts that
+//! aren't a single control (notebooks, the data folder, passwords, updates,
+//! the shortcut lists). Typed fields carry their default, so a page shows a
+//! reset button whenever something differs from it.
 
 use std::path::PathBuf;
 
 use gpui::{
-    AppContext, Context, Entity, FontWeight, InteractiveElement, IntoElement, MouseButton,
-    MouseUpEvent, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled,
-    Subscription, WeakEntity, Window, div, prelude::FluentBuilder as _, px,
+    AnyElement, App, AppContext, Context, Entity, FontWeight, InteractiveElement, IntoElement,
+    ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Subscription,
+    WeakEntity, Window, div, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
-    Disableable, IndexPath, Root, Sizable, TitleBar, WindowExt,
+    Root, Sizable, TitleBar, WindowExt,
     button::{Button, ButtonVariants as _},
     dialog::{DialogButtonProps, DialogFooter},
-    input::{Input, InputEvent, InputState},
-    select::{Select, SelectEvent, SelectItem, SelectState},
+    input::{Input, InputState},
+    setting::{SelectIndex, SettingField, SettingGroup, SettingItem, SettingPage, Settings},
     slider::{Slider, SliderEvent, SliderState},
-    switch::Switch,
 };
 
 use crate::app::AppView;
 use crate::theme::{self, Mode};
 use rust_i18n::t;
 
-/// One choice in a `Select`: `id` is the stored value, `title` the label.
-#[derive(Clone)]
-struct Opt {
-    id: String,
-    title: SharedString,
+/// Dropdown choices as gpui-component's setting fields take them: `(stored
+/// value, label)`.
+type Options = Vec<(SharedString, SharedString)>;
+
+fn opt(id: &str, label: impl Into<SharedString>) -> (SharedString, SharedString) {
+    (SharedString::from(id.to_string()), label.into())
 }
 
-impl Opt {
-    fn new(id: &str, title: &str) -> Self {
-        Self {
-            id: id.to_string(),
-            title: SharedString::from(title.to_string()),
-        }
-    }
-}
-
-impl SelectItem for Opt {
-    type Value = String;
-    fn title(&self) -> SharedString {
-        self.title.clone()
-    }
-    fn value(&self) -> &Self::Value {
-        &self.id
-    }
-}
-
-fn make_select(
-    opts: Vec<Opt>,
-    selected: &str,
-    window: &mut Window,
-    cx: &mut Context<SettingsView>,
-) -> Entity<SelectState<Vec<Opt>>> {
-    let idx = opts
-        .iter()
-        .position(|o| o.id == selected)
-        .map(IndexPath::new);
-    cx.new(|cx| SelectState::new(opts, idx, window, cx))
-}
-
-fn theme_opts(app: &WeakEntity<AppView>, cx: &Context<SettingsView>) -> (Vec<Opt>, String) {
+fn theme_options(app: &WeakEntity<AppView>, cx: &App) -> (Options, SharedString) {
     if let Some(a) = app.upgrade() {
         let a = a.read(cx);
         (
-            a.skins().iter().map(|s| Opt::new(&s.id, &s.name)).collect(),
-            a.active_skin_id().to_string(),
+            a.skins()
+                .iter()
+                .map(|s| opt(&s.id, s.name.clone()))
+                .collect(),
+            a.active_skin_id().to_string().into(),
         )
     } else {
-        (Vec::new(), String::new())
+        (Vec::new(), SharedString::default())
     }
+}
+
+/// Installed font families, once: gpui appends its internal fallback aliases
+/// (".ZedMono", ".ZedSans", ".SystemUIFont") to the OS list. They only render
+/// inside Zed, which bundles the font files those aliases point at — here
+/// they'd silently fall back to the default face, so don't offer them
+/// ("Default (System)" already covers the system face).
+fn installed_font_names(cx: &App) -> Vec<String> {
+    let mut names = cx.text_system().all_font_names();
+    names.retain(|n| !n.starts_with('.'));
+    names.sort();
+    names.dedup();
+    names
 }
 
 /// Font-dropdown choices: Default (named for what it resolves to — the active
 /// theme's font, else the system face), then every installed family (including
 /// the user-added ones registered at startup / via "Add font file…").
-fn font_opts(app: &WeakEntity<AppView>, cx: &Context<SettingsView>) -> (Vec<Opt>, String) {
-    let mut names = cx.text_system().all_font_names();
-    // gpui appends its internal fallback aliases (".ZedMono", ".ZedSans",
-    // ".SystemUIFont") to the OS list. They only render inside Zed, which
-    // bundles the font files those aliases point at — here they'd silently
-    // fall back to the default face, so don't offer them ("Default (System)"
-    // already covers the system face).
-    names.retain(|n| !n.starts_with('.'));
-    names.sort();
-    names.dedup();
+fn font_options(app: &WeakEntity<AppView>, names: &[String], cx: &App) -> (Options, SharedString) {
     let default_font = app.upgrade().and_then(|a| {
         let a = a.read(cx);
         a.skins()
@@ -104,65 +78,53 @@ fn font_opts(app: &WeakEntity<AppView>, cx: &Context<SettingsView>) -> (Vec<Opt>
         .map(|s| s.to_string())
         .unwrap_or_else(|| t!("settings.opt.system").to_string());
     let default_label = t!("settings.opt.font_default", name = default_name).to_string();
-    let mut opts = vec![Opt::new("", &default_label)];
-    opts.extend(names.iter().map(|n| Opt::new(n, n)));
+    let mut opts = vec![opt("", default_label)];
+    opts.extend(names.iter().map(|n| opt(n, n.clone())));
     let current = app
         .upgrade()
         .map(|a| a.read(cx).ui_font().to_string())
         .unwrap_or_default();
-    (opts, current)
+    (opts, current.into())
 }
 
 /// Cursor-theme dropdown choices: System, then the bundled pack and every
-/// user-added pack on disk (see `cursors::available`).
-fn cursor_opts() -> (Vec<Opt>, String) {
+/// user-added pack on disk (see `cursors::available`). The pack lists are
+/// scanned once and after an import, not per frame.
+fn cursor_options(packs: &[String], reactive: &[String]) -> (Options, SharedString) {
     let mut opts = vec![
-        Opt::new("", &t!("settings.opt.cursor_system")),
-        Opt::new(
+        opt("", t!("settings.opt.cursor_system").to_string()),
+        opt(
             crate::cursors::THEME_PACK,
-            &t!("settings.opt.cursor_bibata"),
+            t!("settings.opt.cursor_bibata").to_string(),
         ),
     ];
-    opts.extend(crate::cursors::available().iter().map(|n| Opt::new(n, n)));
+    opts.extend(packs.iter().map(|n| opt(n, n.clone())));
     // User packs with SVG sources render theme-reactively as a second entry.
-    opts.extend(crate::cursors::reactive_available().iter().map(|n| {
-        Opt::new(
+    opts.extend(reactive.iter().map(|n| {
+        opt(
             &format!("{}{n}", crate::cursors::THEME_PREFIX),
-            &format!("{n} (match theme)"),
+            format!("{n} (match theme)"),
         )
     }));
-    (opts, crate::cursors::selected().unwrap_or_default())
+    (opts, crate::cursors::selected().unwrap_or_default().into())
 }
 
 /// Language-picker choices: Auto (its label is itself localized, so the
 /// dropdown reads "自动" / "Auto" with the active locale) plus each offered
 /// locale shown in its own script. The persisted ids come from
-/// [`crate::i18n::LANGUAGE_OPTS`].
-fn language_opts() -> Vec<Opt> {
+/// [`crate::i18n::LANGUAGE_OPTS`]. Built per frame, so a live language switch
+/// relabels it without reopening Settings.
+fn language_options() -> Options {
     crate::i18n::LANGUAGE_OPTS
         .iter()
         .map(|(id, name)| {
-            let title = if *id == "auto" {
-                rust_i18n::t!("settings.language.auto").to_string()
+            if *id == "auto" {
+                opt(id, t!("settings.language.auto").to_string())
             } else {
-                (*name).to_string()
-            };
-            Opt::new(id, &title)
+                opt(id, (*name).to_string())
+            }
         })
         .collect()
-}
-
-/// Which settings category the left nav has selected.
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum Tab {
-    General,
-    Notebooks,
-    Appearance,
-    Pdf,
-    Markdown,
-    Security,
-    Keyboard,
-    Updates,
 }
 
 /// Which password dialog is open: first-time set, change, or removal.
@@ -173,188 +135,149 @@ enum PwMode {
     Remove,
 }
 
-/// Every settings card: `(tab, card title, extra search keywords)`. Drives the
-/// header filter — `section_matches` / `tab_has_matches` look cards up here, so
-/// the titles MUST stay in sync with the `card(…)` / `card_list(…)` calls in
-/// `render`. The title is an i18n key (`settings.section.*`); the rendered
-/// nav/card titles call `t!(key)`. Keywords (lowercase) add synonyms a user
-/// might type for a setting that aren't already in its title - kept in
-/// English so an English-typed synonym still finds a card in any locale.
-const SECTIONS: &[(Tab, &str, &str)] = &[
+/// Extra search words per card (keyed by its title's i18n key). The sidebar
+/// search matches an item's title, description, and keywords; every item of a
+/// card also gets the card's own title + description as keywords, so this is
+/// only for synonyms a user might type that aren't already in that text —
+/// kept in English so an English-typed synonym finds a card in any locale.
+const KEYWORDS: &[(&str, &str)] = &[
     (
-        Tab::Notebooks,
         "settings.section.notebooks",
         "vault workspace switch add remove rename folder data set",
     ),
     (
-        Tab::Notebooks,
         "settings.section.data_location",
         "folder path database directory move attachments notebook vault",
     ),
     (
-        Tab::General,
         "settings.section.unused_images",
         "cleanup delete orphan gc attachments storage space free",
     ),
     (
-        Tab::General,
         "settings.section.language",
         "language locale i18n chinese english 中文 简体",
     ),
     (
-        Tab::General,
         "settings.section.remember_window",
         "bounds size resize reopen restore placement screen monitor position tabs session",
     ),
     (
-        Tab::General,
         "settings.section.date_format",
         "iso us european calendar day month year /date",
     ),
     (
-        Tab::General,
         "settings.section.time_format",
         "24 hour 12 clock am pm /time",
     ),
     (
-        Tab::Appearance,
         "settings.section.app_theme",
         "skin colors palette built-in custom",
     ),
     (
-        Tab::Appearance,
         "settings.section.appearance",
         "light dark auto system mode variant",
     ),
     (
-        Tab::Appearance,
         "settings.section.font",
         "typeface family typography text ttf otf custom",
     ),
     (
-        Tab::Appearance,
         "settings.section.text_size",
         "font size zoom bigger smaller larger scale px",
     ),
     (
-        Tab::Appearance,
         "settings.section.line_numbers",
         "gutter source rows numbering count editor",
     ),
     (
-        Tab::Appearance,
         "settings.section.mouse_cursor",
         "pointer arrow theme pack xcursor bibata custom",
     ),
     (
-        Tab::Appearance,
         "settings.section.sidebar_position",
         "left right side dock rail move rtl navigation panel",
     ),
     (
-        Tab::Appearance,
         "settings.section.installed_themes",
         "custom user json reload reveal folder",
     ),
     (
-        Tab::Pdf,
         "settings.section.pdf_quality",
         "dpi resolution sharpness speed scale render",
     ),
     (
-        Tab::Markdown,
         "settings.section.wysiwyg",
         "live preview inline formatting bold heading links",
     ),
     (
-        Tab::Markdown,
         "settings.section.list_indent",
-        "spaces tab nesting indent bullet",
+        "spaces tab nesting bullets levels",
     ),
     (
-        Tab::Markdown,
         "settings.section.autolink",
-        "wiki link automatic typing wrap unlinked references",
+        "wiki link auto complete title page",
     ),
     (
-        Tab::Keyboard,
         "settings.section.application",
-        "shortcuts keys tab window quit settings find search",
+        "keyboard shortcuts hotkeys keys",
     ),
     (
-        Tab::Keyboard,
         "settings.section.editing",
-        "shortcuts keys slash menu copy paste undo redo indent",
+        "keyboard shortcuts hotkeys keys editor slash",
     ),
     (
-        Tab::Keyboard,
         "settings.section.wb_tools",
-        "shortcuts keys pen shape rectangle ellipse text image",
+        "keyboard shortcuts hotkeys whiteboard tools",
     ),
     (
-        Tab::Keyboard,
         "settings.section.wb_editing",
-        "shortcuts keys z-order delete copy paste",
+        "keyboard shortcuts hotkeys whiteboard",
     ),
     (
-        Tab::Keyboard,
         "settings.section.pdf_viewer",
-        "shortcuts keys page zoom find",
+        "keyboard shortcuts hotkeys pdf zoom",
     ),
     (
-        Tab::Security,
         "settings.section.password",
-        "encrypt encryption lock database sqlcipher passphrase secure",
+        "encrypt encryption sqlcipher lock security",
     ),
     (
-        Tab::Security,
         "settings.section.remember_device",
-        "keychain credential manager auto unlock remember password",
+        "keychain credential store password remember",
     ),
     (
-        Tab::Security,
         "settings.section.autolock",
-        "idle timeout lock minutes away inactivity",
+        "idle timeout lock minutes security",
     ),
     (
-        Tab::Updates,
         "settings.section.updates",
-        "version release github check download",
+        "version release check download new",
     ),
     (
-        Tab::Updates,
         "settings.section.auto_check",
-        "startup auto version",
+        "updates automatic startup check",
     ),
     (
-        Tab::Updates,
         "settings.section.prereleases",
-        "beta prerelease pre-release unstable",
+        "beta alpha rc pre-release updates channel",
     ),
 ];
 
+fn keywords_for(title_key: &str) -> &'static str {
+    KEYWORDS
+        .iter()
+        .find(|(k, _)| *k == title_key)
+        .map_or("", |(_, kw)| kw)
+}
+
 pub struct SettingsView {
     app: WeakEntity<AppView>,
-    theme_select: Entity<SelectState<Vec<Opt>>>,
-    appearance_select: Entity<SelectState<Vec<Opt>>>,
-    font_select: Entity<SelectState<Vec<Opt>>>,
-    cursor_select: Entity<SelectState<Vec<Opt>>>,
-    text_size_select: Entity<SelectState<Vec<Opt>>>,
     quality_slider: Entity<SliderState>,
-    indent_select: Entity<SelectState<Vec<Opt>>>,
-    date_format_select: Entity<SelectState<Vec<Opt>>>,
-    time_format_select: Entity<SelectState<Vec<Opt>>>,
-    /// Settings -> General -> Language picker. Its options are rebuilt when the
-    /// active locale changes (the "Auto" entry is itself localized), so a live
-    /// language switch updates the dropdown without reopening Settings.
-    language_select: Entity<SelectState<Vec<Opt>>>,
-    lang_select_locale: String,
-    /// Header filter box + its current (trimmed, lowercased) text. Empty = no
-    /// filter; non-empty dims the cards + nav tabs that don't match.
-    filter_input: Entity<InputState>,
-    filter: String,
-    /// The selected left-nav category.
-    tab: Tab,
+    /// Installed font families + cursor packs, scanned once (and again after an
+    /// import) rather than on every frame the dropdowns are built.
+    font_names: Vec<String>,
+    cursor_packs: Vec<String>,
+    cursor_reactive: Vec<String>,
     /// Last images-GC outcome ("Removed 12 files (3.4 MB)"), shown under the
     /// Unused images button.
     image_gc_result: Option<String>,
@@ -374,73 +297,7 @@ pub struct SettingsView {
 
 impl SettingsView {
     pub fn new(app: WeakEntity<AppView>, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let (t_opts, active_skin) = theme_opts(&app, cx);
-        let mode = app
-            .upgrade()
-            .map(|a| a.read(cx).theme_mode())
-            .unwrap_or_default();
-        let a_opts = vec![
-            Opt::new("light", &t!("settings.opt.light")),
-            Opt::new("dark", &t!("settings.opt.dark")),
-            Opt::new("auto", &t!("settings.opt.auto_appearance")),
-        ];
-
-        let theme_select = make_select(t_opts, &active_skin, window, cx);
-        let appearance_select = make_select(a_opts, mode.as_str(), window, cx);
-        let (f_opts, current_font) = font_opts(&app, cx);
-        let font_select = make_select(f_opts, &current_font, window, cx);
-        let (c_opts, current_cursor) = cursor_opts();
-        let cursor_select = make_select(c_opts, &current_cursor, window, cx);
-
-        // Note text size (Appearance pane) — one value for all three views.
-        let size_opts: Vec<Opt> = crate::app::TEXT_SIZES
-            .iter()
-            .map(|&s| {
-                let id = format!("{s}");
-                let label = if s == 16.0 {
-                    t!("settings.opt.size_px_default", size = s).to_string()
-                } else {
-                    t!("settings.opt.size_px", size = s).to_string()
-                };
-                Opt::new(&id, &label)
-            })
-            .collect();
-        let cur_size = app
-            .upgrade()
-            .map(|a| format!("{}", f32::from(a.read(cx).text_size())))
-            .unwrap_or_else(|| "16".to_string());
-        let text_size_select = make_select(size_opts, &cur_size, window, cx);
-
         let mut subs = Vec::new();
-        subs.push(Self::on_theme_select(&theme_select, window, cx));
-        subs.push(Self::on_font_select(&font_select, window, cx));
-        subs.push(Self::on_cursor_select(&cursor_select, window, cx));
-        subs.push(cx.subscribe_in(
-            &text_size_select,
-            window,
-            |this: &mut SettingsView, _, ev: &SelectEvent<Vec<Opt>>, _window, cx| {
-                if let SelectEvent::Confirm(Some(id)) = ev
-                    && let Ok(size) = id.parse::<f32>()
-                    && let Some(app) = this.app.upgrade()
-                {
-                    app.update(cx, |a, cx| a.set_text_size(size, cx));
-                    cx.notify();
-                }
-            },
-        ));
-        subs.push(cx.subscribe_in(
-            &appearance_select,
-            window,
-            |this: &mut SettingsView, _, ev: &SelectEvent<Vec<Opt>>, window, cx| {
-                if let SelectEvent::Confirm(Some(id)) = ev {
-                    let mode = Mode::from_str(id);
-                    if let Some(app) = this.app.upgrade() {
-                        app.update(cx, |a, cx| a.set_theme_mode(mode, window, cx));
-                        cx.notify();
-                    }
-                }
-            },
-        ));
 
         // PDF render-quality slider (percentage of native DPI).
         let qpct = app
@@ -467,103 +324,6 @@ impl SettingsView {
             },
         ));
 
-        // List-indent select (Markdown pane): 2 / 4 / 8 spaces.
-        let cur_indent = app
-            .upgrade()
-            .map(|a| a.read(cx).list_indent().to_string())
-            .unwrap_or_else(|| "4".to_string());
-        let indent_select = make_select(
-            vec![
-                Opt::new("2", &t!("settings.opt.indent_2")),
-                Opt::new("4", &t!("settings.opt.indent_4")),
-                Opt::new("8", &t!("settings.opt.indent_8")),
-            ],
-            &cur_indent,
-            window,
-            cx,
-        );
-        subs.push(cx.subscribe_in(
-            &indent_select,
-            window,
-            |this: &mut SettingsView, _, ev: &SelectEvent<Vec<Opt>>, _window, cx| {
-                if let SelectEvent::Confirm(Some(id)) = ev
-                    && let Ok(spaces) = id.parse::<usize>()
-                    && let Some(app) = this.app.upgrade()
-                {
-                    app.update(cx, |a, cx| a.set_list_indent(spaces, cx));
-                    cx.notify();
-                }
-            },
-        ));
-
-        // Date / time formats (General pane): the styles used by /date, /time,
-        // and the {{date}} / {{time}} template placeholders.
-        let date_opts: Vec<Opt> = crate::dates::DATE_FORMATS
-            .iter()
-            .map(|&id| Opt::new(id, &crate::dates::date_format_label(id)))
-            .collect();
-        let date_format_select = make_select(date_opts, &crate::dates::date_format(), window, cx);
-        subs.push(cx.subscribe_in(
-            &date_format_select,
-            window,
-            |this: &mut SettingsView, _, ev: &SelectEvent<Vec<Opt>>, _window, cx| {
-                if let SelectEvent::Confirm(Some(id)) = ev
-                    && let Some(app) = this.app.upgrade()
-                {
-                    let id = id.clone();
-                    app.update(cx, |a, _cx| a.set_date_format(&id));
-                    cx.notify();
-                }
-            },
-        ));
-
-        let time_opts: Vec<Opt> = crate::dates::TIME_FORMATS
-            .iter()
-            .map(|&id| Opt::new(id, &crate::dates::time_format_label(id)))
-            .collect();
-        let time_format_select = make_select(time_opts, &crate::dates::time_format(), window, cx);
-        subs.push(cx.subscribe_in(
-            &time_format_select,
-            window,
-            |this: &mut SettingsView, _, ev: &SelectEvent<Vec<Opt>>, _window, cx| {
-                if let SelectEvent::Confirm(Some(id)) = ev
-                    && let Some(app) = this.app.upgrade()
-                {
-                    let id = id.clone();
-                    app.update(cx, |a, _cx| a.set_time_format(&id));
-                    cx.notify();
-                }
-            },
-        ));
-
-        // Settings -> General -> Language. Options: Auto (localized) + each
-        // offered locale shown in its own script. Confirming pushes the choice
-        // into `AppView::set_language`, which switches the locale live.
-        let lang_opts = language_opts();
-        let cur_language = app
-            .upgrade()
-            .map(|a| a.read(cx).language().to_string())
-            .unwrap_or_else(|| "auto".to_string());
-        let language_select = make_select(lang_opts, &cur_language, window, cx);
-        subs.push(cx.subscribe_in(
-            &language_select,
-            window,
-            |this: &mut SettingsView, _, ev: &SelectEvent<Vec<Opt>>, _window, cx| {
-                if let SelectEvent::Confirm(Some(id)) = ev
-                    && let Some(app) = this.app.upgrade()
-                {
-                    let id = id.clone();
-                    app.update(cx, |a, cx| a.set_language(&id, cx));
-                    cx.notify();
-                }
-            },
-        ));
-
-        // Header filter box — dims the cards + nav tabs that don't match as the
-        // user types (Baudrun's Settings filter). Subscribed on every keystroke
-        // (`Change`) so the dim updates live; the value drives `self.filter`.
-        let filter_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder(t!("settings.filter_placeholder")));
         let masked = |ph: &str, window: &mut Window, cx: &mut Context<Self>| {
             let ph = ph.to_string();
             cx.new(|cx| InputState::new(window, cx).masked(true).placeholder(ph))
@@ -571,37 +331,14 @@ impl SettingsView {
         let sec_current = masked(&t!("settings.label.current_password"), window, cx);
         let sec_new = masked(&t!("settings.label.new_password"), window, cx);
         let sec_confirm = masked(&t!("settings.label.confirm_password"), window, cx);
-        subs.push(cx.subscribe(
-            &filter_input,
-            |this: &mut SettingsView, input, ev: &InputEvent, cx| {
-                if let InputEvent::Change = ev {
-                    let next = input.read(cx).value().trim().to_lowercase();
-                    if next != this.filter {
-                        this.filter = next;
-                        cx.notify();
-                    }
-                }
-            },
-        ));
-
         let nb_rename_input = cx.new(|cx| InputState::new(window, cx));
 
         Self {
+            font_names: installed_font_names(cx),
+            cursor_packs: crate::cursors::available(),
+            cursor_reactive: crate::cursors::reactive_available(),
             app,
-            theme_select,
-            appearance_select,
-            font_select,
-            cursor_select,
-            text_size_select,
             quality_slider,
-            indent_select,
-            date_format_select,
-            time_format_select,
-            language_select,
-            lang_select_locale: rust_i18n::locale().to_string(),
-            filter_input,
-            filter: String::new(),
-            tab: Tab::Appearance,
             image_gc_result: None,
             cursor_status: None,
             sec_current,
@@ -784,146 +521,11 @@ impl SettingsView {
         cx.notify();
     }
 
-    /// One notebook in the Notebooks card: name + path on the left, its
-    /// actions on the right (the active row swaps Switch/Remove for a
-    /// "current" tag).
-    fn notebook_settings_row(
-        &self,
-        nb: crate::paths::Notebook,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        let active = nb.is_active();
-        let name = nb.name.clone();
-        let dir = nb.dir.clone();
-        let nb_switch = nb.clone();
-        let nb_rename = nb.clone();
-        let nb_forget = nb.clone();
-        let reveal_dir = PathBuf::from(&nb.dir);
-        let mut actions = div().flex().flex_row().items_center().gap(px(6.0));
-        if active {
-            actions = actions.child(
-                div()
-                    .px(px(8.0))
-                    .py(px(3.0))
-                    .rounded(px(6.0))
-                    .bg(theme::accent_tint())
-                    .text_size(px(11.0))
-                    .text_color(theme::accent())
-                    .child(t!("settings.label.current").to_string()),
-            );
-        } else {
-            actions = actions.child(nb_button(
-                SharedString::from(format!("nb-switch:{}", nb.dir)),
-                &t!("settings.nb.switch"),
-                cx,
-                move |this, window, cx| this.switch_notebook(nb_switch.clone(), window, cx),
-            ));
-        }
-        actions = actions
-            .child(nb_button(
-                SharedString::from(format!("nb-rename:{}", nb.dir)),
-                &t!("settings.nb.rename"),
-                cx,
-                move |this, window, cx| this.rename_notebook(nb_rename.clone(), window, cx),
-            ))
-            .child(nb_button(
-                SharedString::from(format!("nb-reveal:{}", nb.dir)),
-                &t!("settings.nb.reveal"),
-                cx,
-                move |_this, _window, _cx| {
-                    crate::app::AppView::reveal_folder(&reveal_dir);
-                },
-            ));
-        if !active {
-            actions = actions.child(nb_button(
-                SharedString::from(format!("nb-forget:{}", nb.dir)),
-                &t!("settings.nb.remove"),
-                cx,
-                move |this, _window, cx| this.forget_notebook(nb_forget.clone(), cx),
-            ));
-        }
-        div()
-            .px(px(10.0))
-            .py(px(8.0))
-            .rounded(px(8.0))
-            .bg(theme::glass())
-            .border_1()
-            .border_color(theme::border_subtle())
-            .flex()
-            .flex_row()
-            .items_center()
-            .gap(px(10.0))
-            .child(
-                div()
-                    .flex_1()
-                    .min_w_0()
-                    .flex()
-                    .flex_col()
-                    .gap(px(2.0))
-                    .child(
-                        div()
-                            .text_size(px(13.0))
-                            .text_color(theme::text_primary())
-                            .child(name),
-                    )
-                    .child(
-                        div()
-                            .text_size(px(11.0))
-                            .text_color(theme::text_tertiary())
-                            .truncate()
-                            .child(dir),
-                    ),
-            )
-            .child(actions)
-    }
-
     /// Re-run the update check now (Settings → Updates → "Check now").
     fn check_for_updates(&self, cx: &mut Context<Self>) {
         if let Some(app) = self.app.upgrade() {
             app.update(cx, |a, cx| a.check_for_updates_now(cx));
         }
-    }
-
-    /// Subscribe to a theme `Select`'s confirm → apply the picked skin.
-    fn on_theme_select(
-        select: &Entity<SelectState<Vec<Opt>>>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Subscription {
-        cx.subscribe_in(
-            select,
-            window,
-            |this: &mut SettingsView, _, ev: &SelectEvent<Vec<Opt>>, window, cx| {
-                if let SelectEvent::Confirm(Some(id)) = ev {
-                    let id = id.clone();
-                    if let Some(app) = this.app.upgrade() {
-                        app.update(cx, |a, cx| a.set_skin(id, window, cx));
-                        cx.notify();
-                    }
-                }
-            },
-        )
-    }
-
-    /// Subscribe to the font `Select`'s confirm → apply the picked family.
-    fn on_font_select(
-        select: &Entity<SelectState<Vec<Opt>>>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Subscription {
-        cx.subscribe_in(
-            select,
-            window,
-            |this: &mut SettingsView, _, ev: &SelectEvent<Vec<Opt>>, window, cx| {
-                if let SelectEvent::Confirm(Some(id)) = ev {
-                    let id = id.clone();
-                    if let Some(app) = this.app.upgrade() {
-                        app.update(cx, |a, cx| a.set_ui_font(id, window, cx));
-                        cx.notify();
-                    }
-                }
-            },
-        )
     }
 
     /// Pick a font file, import it via the app (validate / copy / apply), and
@@ -948,65 +550,11 @@ impl SettingsView {
                         a.add_ui_font_file(path, window, cx);
                     });
                 }
-                this.rebuild_font_select(window, cx);
+                this.font_names = installed_font_names(cx);
+                cx.notify();
             });
         })
         .detach();
-    }
-
-    fn rebuild_font_select(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let (opts, current) = font_opts(&self.app, cx);
-        let select = make_select(opts, &current, window, cx);
-        self._subs.push(Self::on_font_select(&select, window, cx));
-        self.font_select = select;
-        cx.notify();
-    }
-
-    /// Rebuild the Language picker options after a live locale switch (the
-    /// "Auto" entry's label is itself localized). The selected id is unchanged.
-    fn rebuild_language_select(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let current = self
-            .app
-            .upgrade()
-            .map(|a| a.read(cx).language().to_string())
-            .unwrap_or_else(|| "auto".to_string());
-        let select = make_select(language_opts(), &current, window, cx);
-        self._subs.push(cx.subscribe_in(
-            &select,
-            window,
-            |this: &mut SettingsView, _, ev: &SelectEvent<Vec<Opt>>, _window, cx| {
-                if let SelectEvent::Confirm(Some(id)) = ev
-                    && let Some(app) = this.app.upgrade()
-                {
-                    let id = id.clone();
-                    app.update(cx, |a, cx| a.set_language(&id, cx));
-                    cx.notify();
-                }
-            },
-        ));
-        self.language_select = select;
-        self.lang_select_locale = rust_i18n::locale().to_string();
-        cx.notify();
-    }
-
-    /// Subscribe to the cursor `Select`'s confirm → persist + apply the pack
-    /// (live on macOS/Windows; next launch on Linux).
-    fn on_cursor_select(
-        select: &Entity<SelectState<Vec<Opt>>>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Subscription {
-        cx.subscribe_in(
-            select,
-            window,
-            |this: &mut SettingsView, _, ev: &SelectEvent<Vec<Opt>>, _window, cx| {
-                if let SelectEvent::Confirm(Some(id)) = ev {
-                    crate::cursors::set_selected((!id.is_empty()).then_some(id.as_str()));
-                    this.cursor_status = None;
-                    cx.notify();
-                }
-            },
-        )
     }
 
     /// Pick an XCursor theme folder, import it into the managed `cursors/`
@@ -1025,7 +573,7 @@ impl SettingsView {
             let Some(path) = paths.into_iter().next() else {
                 return;
             };
-            let _ = this.update_in(cx, |this, window, cx| {
+            let _ = this.update_in(cx, |this, _window, cx| {
                 match crate::cursors::import(&path) {
                     Ok(name) => {
                         // An SVG-only pack has no fixed-color variant — select
@@ -1042,35 +590,25 @@ impl SettingsView {
                     }
                     Err(e) => this.cursor_status = Some(e),
                 }
-                this.rebuild_cursor_select(window, cx);
+                this.cursor_packs = crate::cursors::available();
+                this.cursor_reactive = crate::cursors::reactive_available();
+                cx.notify();
             });
         })
         .detach();
     }
 
-    fn rebuild_cursor_select(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let (opts, current) = cursor_opts();
-        let select = make_select(opts, &current, window, cx);
-        self._subs.push(Self::on_cursor_select(&select, window, cx));
-        self.cursor_select = select;
-        cx.notify();
-    }
-
-    /// Re-scan themes on disk and rebuild the theme dropdown to include them.
+    /// Re-scan themes on disk; the theme dropdown rebuilds its options on the
+    /// next frame.
     fn reload_skins(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let Some(app) = self.app.upgrade() else {
             return;
         };
         app.update(cx, |a, cx| a.reload_skins(window, cx));
-        let (opts, active) = theme_opts(&self.app, cx);
-        let select = make_select(opts, &active, window, cx);
-        let sub = Self::on_theme_select(&select, window, cx);
-        self._subs.push(sub);
-        self.theme_select = select;
         cx.notify();
     }
 
-    fn user_theme_names(&self, cx: &Context<Self>) -> Vec<String> {
+    fn user_theme_names(&self, cx: &App) -> Vec<String> {
         self.app
             .upgrade()
             .map(|a| {
@@ -1462,561 +1000,655 @@ impl SettingsView {
         });
     }
 
-    // ---- Header filter (Baudrun-style): dim cards + tabs that don't match ----
+    // --- Pages -----------------------------------------------------------
 
-    /// A settings card that fades when it doesn't match the current filter. It
-    /// stays interactive - the user can change a dimmed setting without first
-    /// clearing the filter.
-    fn section_card(
-        &self,
-        title_key: &str,
-        desc_key: &str,
-        control: impl IntoElement,
-    ) -> gpui::Div {
-        card(&t!(title_key), &t!(desc_key), control).opacity(self.filter_opacity(title_key))
-    }
-
-    /// Filter-aware wrapper for the shortcut-list cards on the Keyboard pane.
-    fn section_list(
-        &self,
-        title_key: &str,
-        desc_key: &str,
-        rows: Vec<(String, Vec<&str>)>,
-    ) -> gpui::Div {
-        card_list(&t!(title_key), &t!(desc_key), rows).opacity(self.filter_opacity(title_key))
-    }
-
-    fn filter_opacity(&self, title_key: &str) -> f32 {
-        if self.section_matches(title_key) {
-            1.0
-        } else {
-            0.3
-        }
-    }
-
-    /// Whether `title_key`'s card matches the filter: an empty filter matches
-    /// all; otherwise the localized title or its `SECTIONS` keywords must
-    /// contain the text.
-    fn section_matches(&self, title_key: &str) -> bool {
-        if self.filter.is_empty() {
-            return true;
-        }
-        if t!(title_key).to_lowercase().contains(self.filter.as_str()) {
-            return true;
-        }
-        SECTIONS
-            .iter()
-            .find(|(_, t, _)| *t == title_key)
-            .is_some_and(|(_, _, kw)| kw.contains(self.filter.as_str()))
-    }
-
-    /// Whether `tab` has at least one matching card - drives the rail dim.
-    fn tab_has_matches(&self, tab: Tab) -> bool {
-        if self.filter.is_empty() {
-            return true;
-        }
-        SECTIONS.iter().copied().any(|(t, title_key, kw)| {
-            t == tab
-                && (t!(title_key).to_lowercase().contains(self.filter.as_str())
-                    || kw.contains(self.filter.as_str()))
-        })
-    }
-
-    /// Left-nav rail. Tabs whose cards all miss the filter render dimmed but
-    /// stay clickable, so a typo doesn't lock you out of the other panes.
-    fn nav(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let active = self.tab;
-        div()
-            .flex_shrink_0()
-            .w(px(184.0))
-            .pl(px(20.0))
-            .pr(px(8.0))
-            .flex()
-            .flex_col()
-            .gap(px(2.0))
-            .child(nav_item(
-                "nav-general",
-                &t!("settings.nav.general"),
-                Tab::General,
-                active,
-                !self.tab_has_matches(Tab::General),
-                cx,
-            ))
-            .child(nav_item(
-                "nav-notebooks",
-                &t!("settings.nav.notebooks"),
-                Tab::Notebooks,
-                active,
-                !self.tab_has_matches(Tab::Notebooks),
-                cx,
-            ))
-            .child(nav_item(
-                "nav-appearance",
-                &t!("settings.nav.appearance"),
-                Tab::Appearance,
-                active,
-                !self.tab_has_matches(Tab::Appearance),
-                cx,
-            ))
-            .child(nav_item(
-                "nav-pdf",
-                &t!("settings.nav.pdf"),
-                Tab::Pdf,
-                active,
-                !self.tab_has_matches(Tab::Pdf),
-                cx,
-            ))
-            .child(nav_item(
-                "nav-markdown",
-                &t!("settings.nav.markdown"),
-                Tab::Markdown,
-                active,
-                !self.tab_has_matches(Tab::Markdown),
-                cx,
-            ))
-            .child(nav_item(
-                "nav-keyboard",
-                &t!("settings.nav.keyboard"),
-                Tab::Keyboard,
-                active,
-                !self.tab_has_matches(Tab::Keyboard),
-                cx,
-            ))
-            .child(nav_item(
-                "nav-security",
-                &t!("settings.nav.security"),
-                Tab::Security,
-                active,
-                !self.tab_has_matches(Tab::Security),
-                cx,
-            ))
-            .child(nav_item(
-                "nav-updates",
-                &t!("settings.nav.updates"),
-                Tab::Updates,
-                active,
-                !self.tab_has_matches(Tab::Updates),
-                cx,
-            ))
-    }
-
-    /// The header filter box: a 220px input + a hand-rolled × clear that shows
-    /// once there's text (gpui-component's built-in clear icon needs an SVG we
-    /// don't bundle — Baudrun's approach).
-    fn filter_bar(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        div()
-            .relative()
-            .w(px(220.0))
-            .child(
-                Input::new(&self.filter_input)
-                    .small()
-                    .appearance(true)
-                    .text_size(px(13.0)),
-            )
-            .when(!self.filter.is_empty(), |row| {
-                row.child(
-                    div()
-                        .id("settings-filter-clear")
-                        .absolute()
-                        .top(px(0.0))
-                        .right(px(8.0))
-                        .h_full()
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .text_size(px(15.0))
-                        .text_color(theme::text_tertiary())
-                        .cursor_pointer()
-                        .hover(|h| h.text_color(theme::text_primary()))
-                        .child("\u{00D7}")
-                        .on_mouse_up(
-                            MouseButton::Left,
-                            cx.listener(|this, _: &MouseUpEvent, window, cx| {
-                                this.filter_input
-                                    .update(cx, |state, cx| state.set_value("", window, cx));
-                                if !this.filter.is_empty() {
-                                    this.filter.clear();
-                                    cx.notify();
-                                }
-                            }),
-                        ),
-                )
-            })
-    }
-}
-
-impl Render for SettingsView {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        // A live language switch (this window or another) changes rust-i18n's
-        // global locale; rebuild the Language picker so its "Auto" label and
-        // the resolved selection track the new locale.
-        let cur_locale = rust_i18n::locale();
-        if self.lang_select_locale != *cur_locale {
-            self.rebuild_language_select(window, cx);
-        }
-
-        let user_names = self.user_theme_names(cx);
-
-        let qpct = self
-            .app
-            .upgrade()
-            .map(|a| (a.read(cx).pdf_quality() * 100.0).round() as i32)
-            .unwrap_or(100);
-        let quality_control = div()
-            .flex()
-            .flex_col()
-            .gap(px(8.0))
-            .child(Slider::new(&self.quality_slider).w_full())
-            .child(
-                div()
-                    .text_size(px(12.0))
-                    .text_color(theme::text_tertiary())
-                    .child(format!("{qpct}%")),
-            );
-
-        // WYSIWYG live-preview toggle (Markdown pane), as a switch. Controlled:
-        // `.checked` reflects the persisted setting each render; the click
-        // persists + re-applies to open editors via `set_wysiwyg`.
-        let wys_on = self
-            .app
-            .upgrade()
-            .map(|a| a.read(cx).wysiwyg())
-            .unwrap_or(true);
-        let wys_app = self.app.clone();
-        let wysiwyg_switch = Switch::new("wysiwyg-toggle")
-            .small()
-            .checked(wys_on)
-            .on_click(move |checked, _window, cx| {
-                if let Some(app) = wys_app.upgrade() {
-                    app.update(cx, |a, cx| a.set_wysiwyg(*checked, cx));
+    fn general_page(&self, weak: &WeakEntity<Self>) -> SettingPage {
+        let app = &self.app;
+        let lang_app = app.clone();
+        let language = dropdown_item(
+            "settings.item.language",
+            language_options(),
+            {
+                let app = app.clone();
+                move |cx| {
+                    app.upgrade()
+                        .map(|a| a.read(cx).language().to_string().into())
+                        .unwrap_or_else(|| "auto".into())
                 }
-            });
-
-        // Sidebar dock side (Appearance pane): checked = docked right.
-        let sb_right = self
-            .app
-            .upgrade()
-            .map(|a| a.read(cx).sidebar_right)
-            .unwrap_or(false);
-        let sb_app = self.app.clone();
-        let sidebar_side_switch = Switch::new("sidebar-right-toggle")
-            .small()
-            .checked(sb_right)
-            .on_click(move |checked, _window, cx| {
-                if let Some(app) = sb_app.upgrade() {
-                    app.update(cx, |a, cx| a.set_sidebar_right(*checked, cx));
+            },
+            move |v, cx| {
+                if let Some(a) = lang_app.upgrade() {
+                    a.update(cx, |a, cx| a.set_language(&v, cx));
                 }
-            });
-
-        // Line-number gutter toggle (Markdown pane).
-        let ln_on = self
-            .app
-            .upgrade()
-            .map(|a| a.read(cx).line_numbers())
-            .unwrap_or(false);
-        let ln_app = self.app.clone();
-        let line_numbers_switch = Switch::new("line-numbers-toggle")
-            .small()
-            .checked(ln_on)
-            .on_click(move |checked, _window, cx| {
-                if let Some(app) = ln_app.upgrade() {
-                    app.update(cx, |a, cx| a.set_line_numbers(*checked, cx));
-                }
-            });
-
-        // Auto-link-as-you-type toggle (Markdown pane).
-        let al_on = self
-            .app
-            .upgrade()
-            .map(|a| a.read(cx).auto_link())
-            .unwrap_or(false);
-        let al_app = self.app.clone();
-        let auto_link_switch = Switch::new("auto-link-toggle")
-            .small()
-            .checked(al_on)
-            .on_click(move |checked, _window, cx| {
-                if let Some(app) = al_app.upgrade() {
-                    app.update(cx, |a, _cx| a.set_auto_link(*checked));
-                }
-            });
-
-        // Updates pane toggles — switches, like the WYSIWYG one. Controlled by
-        // the persisted prefs; the click persists + (for pre-releases) re-checks.
-        let check_on = self
-            .app
-            .upgrade()
-            .map(|a| a.read(cx).check_updates())
-            .unwrap_or(true);
-        let check_app = self.app.clone();
-        let check_updates_switch = Switch::new("check-updates-toggle")
-            .small()
-            .checked(check_on)
-            .on_click(move |checked, _window, cx| {
-                if let Some(app) = check_app.upgrade() {
-                    app.update(cx, |a, _cx| a.set_check_updates(*checked));
-                }
-            });
-        let pre_on = self
-            .app
-            .upgrade()
-            .map(|a| a.read(cx).include_prerelease())
-            .unwrap_or(false);
-        let pre_app = self.app.clone();
-        let prerelease_switch = Switch::new("prerelease-toggle")
-            .small()
-            .checked(pre_on)
-            .on_click(move |checked, _window, cx| {
-                if let Some(app) = pre_app.upgrade() {
-                    app.update(cx, |a, cx| a.set_include_prerelease(*checked, cx));
-                }
-            });
-
-        // Font card body: the family dropdown + an import button.
-        let font_control = div()
-            .flex()
-            .flex_col()
-            .gap(px(8.0))
-            .child(Select::new(&self.font_select).small().w_full())
-            .child(div().flex().flex_row().child(text_button(
-                "font-add",
-                &t!("settings.btn.add_font"),
-                cx,
-                |this, w, cx| this.choose_font_file(w, cx),
-            )));
-
-        // Mouse-cursor card body: the pack dropdown + add/reveal actions, the
-        // last import error, and (Linux) the relaunch note.
-        #[allow(unused_mut)]
-        let mut cursor_control = div()
-            .flex()
-            .flex_col()
-            .gap(px(8.0))
-            .child(Select::new(&self.cursor_select).small().w_full())
-            .child(
-                div()
-                    .flex()
-                    .flex_row()
-                    .gap(px(8.0))
-                    .child(text_button(
-                        "cursor-add",
-                        &t!("settings.btn.add_cursor"),
-                        cx,
-                        |this, w, cx| this.choose_cursor_theme(w, cx),
-                    ))
-                    .child(text_button(
-                        "cursor-reveal",
-                        &t!("settings.btn.reveal_cursors"),
-                        cx,
-                        |_this, _w, _cx| {
-                            let dir = crate::cursors::cursors_dir();
-                            let _ = std::fs::create_dir_all(&dir);
-                            crate::app::AppView::reveal_folder(&dir);
-                        },
-                    )),
-            )
-            .children(self.cursor_status.clone().map(|msg| {
-                div()
-                    .text_size(px(12.0))
-                    .text_color(theme::text_tertiary())
-                    .child(msg)
-            }));
-        #[cfg(target_os = "linux")]
-        {
-            cursor_control = cursor_control.child(
-                div()
-                    .text_size(px(12.0))
-                    .text_color(theme::text_tertiary())
-                    .child(t!("settings.note.cursor_relaunch").to_string()),
-            );
-        }
-
-        // Installed-themes card body: the actions + the list (or empty state).
-        let actions = div()
-            .flex()
-            .flex_row()
-            .gap(px(8.0))
-            .child(text_button(
-                "reveal-themes",
-                &t!("settings.btn.reveal_themes"),
-                cx,
-                |this, _w, cx| {
-                    if let Some(app) = this.app.upgrade() {
-                        app.read(cx).reveal_themes_folder();
-                    }
-                },
-            ))
-            .child(text_button(
-                "reload-themes",
-                &t!("settings.btn.reload"),
-                cx,
-                |this, w, cx| this.reload_skins(w, cx),
-            ));
-
-        let list = if user_names.is_empty() {
-            div()
-                .text_size(px(13.0))
-                .text_color(theme::text_tertiary())
-                .child(t!("settings.note.no_custom_themes").to_string())
-                .into_any_element()
-        } else {
-            let mut col = div().flex().flex_col().gap(px(4.0));
-            for name in user_names {
-                col = col.child(
-                    div()
-                        .px(px(12.0))
-                        .py(px(6.0))
-                        .rounded(px(6.0))
-                        .bg(theme::glass())
-                        .text_size(px(13.0))
-                        .text_color(theme::text_secondary())
-                        .child(name),
-                );
-            }
-            col.into_any_element()
-        };
-
-        let installed = div()
-            .flex()
-            .flex_col()
-            .gap(px(12.0))
-            .child(actions)
-            .child(list);
-
-        // Unused-images card body (General): the cleanup action + its last
-        // outcome.
-        let image_gc_control = div()
-            .flex()
-            .flex_col()
-            .gap(px(10.0))
-            .child(div().flex().flex_row().child(text_button(
-                "image-gc",
-                &t!("settings.btn.cleanup"),
-                cx,
-                |this, window, cx| this.confirm_image_gc(window, cx),
-            )))
-            .children(self.image_gc_result.clone().map(|msg| {
-                div()
-                    .text_size(px(12.0))
-                    .text_color(theme::text_tertiary())
-                    .child(msg)
-            }));
+            },
+            "auto",
+            weak,
+        );
 
         // Remember-window-position toggle: the sidecar file IS the state (see
         // paths::window_bounds_*), written from the main window's live rect.
-        let window_bounds_switch = {
-            let weak = cx.entity().downgrade();
-            Switch::new("window-bounds")
-                .small()
-                .checked(crate::paths::window_bounds_enabled())
-                .on_click(move |on: &bool, _w, cx| {
-                    if *on {
-                        let _ = weak.update(cx, |this, cx| {
-                            if let Some(app) = this.app.upgrade() {
-                                let handle = app.read(cx).window_handle;
-                                let _ = handle.update(cx, |_, window, _| {
-                                    if let gpui::WindowBounds::Windowed(b)
-                                    | gpui::WindowBounds::Maximized(b) = window.window_bounds()
-                                    {
-                                        crate::paths::save_window_bounds(
-                                            f32::from(b.origin.x),
-                                            f32::from(b.origin.y),
-                                            f32::from(b.size.width),
-                                            f32::from(b.size.height),
-                                            matches!(
-                                                window.window_bounds(),
-                                                gpui::WindowBounds::Maximized(_)
-                                            ),
-                                        );
-                                    }
-                                });
+        let bounds_app = app.clone();
+        let window_bounds = SettingItem::new(
+            t!("settings.label.window_size_pos").into_owned(),
+            SettingField::switch(
+                |_cx| crate::paths::window_bounds_enabled(),
+                notify_after(weak, move |on, cx| {
+                    if on {
+                        with_main_window(&bounds_app, cx, |_, window, _| {
+                            if let gpui::WindowBounds::Windowed(b)
+                            | gpui::WindowBounds::Maximized(b) = window.window_bounds()
+                            {
+                                crate::paths::save_window_bounds(
+                                    f32::from(b.origin.x),
+                                    f32::from(b.origin.y),
+                                    f32::from(b.size.width),
+                                    f32::from(b.size.height),
+                                    matches!(
+                                        window.window_bounds(),
+                                        gpui::WindowBounds::Maximized(_)
+                                    ),
+                                );
                             }
-                            cx.notify();
                         });
                     } else {
                         crate::paths::clear_window_bounds();
-                        let _ = weak.update(cx, |_, cx| cx.notify());
                     }
-                })
-        };
-        // Second row of the same card: restore the tab set on relaunch. On
-        // enable, arm the sidecar and have the main window write its current
-        // tabs (its render persists on change; force skips the change check).
-        let open_tabs_switch = {
-            let weak = cx.entity().downgrade();
-            Switch::new("open-tabs")
-                .small()
-                .checked(crate::paths::open_tabs_enabled())
-                .on_click(move |on: &bool, _w, cx| {
-                    if *on {
+                }),
+            )
+            .default_value(false),
+        );
+        // Restore the tab set on relaunch. On enable, arm the sidecar and have
+        // the main window write its current tabs (its render persists on
+        // change; force skips the change check).
+        let tabs_app = app.clone();
+        let open_tabs = SettingItem::new(
+            t!("settings.label.open_tabs").into_owned(),
+            SettingField::switch(
+                |_cx| crate::paths::open_tabs_enabled(),
+                notify_after(weak, move |on, cx| {
+                    if on {
                         crate::paths::save_open_tabs("");
-                        let _ = weak.update(cx, |this, cx| {
-                            if let Some(app) = this.app.upgrade() {
-                                app.update(cx, |a, cx| {
-                                    a.force_persist_open_tabs();
-                                    cx.notify();
-                                });
-                            }
-                            cx.notify();
-                        });
+                        if let Some(a) = tabs_app.upgrade() {
+                            a.update(cx, |a, cx| {
+                                a.force_persist_open_tabs();
+                                cx.notify();
+                            });
+                        }
                     } else {
                         crate::paths::clear_open_tabs();
-                        let _ = weak.update(cx, |_, cx| cx.notify());
                     }
+                }),
+            )
+            .default_value(false),
+        );
+
+        // Unused-images card body: the cleanup action + its last outcome.
+        let gc_weak = weak.clone();
+        let image_gc = custom(move |_window, cx| {
+            let result = gc_weak
+                .upgrade()
+                .and_then(|v| v.read(cx).image_gc_result.clone());
+            div()
+                .flex()
+                .flex_col()
+                .gap(px(10.0))
+                .child(div().flex().flex_row().child(text_button(
+                    "image-gc",
+                    &t!("settings.btn.cleanup"),
+                    &gc_weak,
+                    |this, window, cx| this.confirm_image_gc(window, cx),
+                )))
+                .children(result.map(status_line))
+                .into_any_element()
+        });
+
+        let date_app = app.clone();
+        let date = dropdown_item(
+            "settings.item.format",
+            crate::dates::DATE_FORMATS
+                .iter()
+                .map(|&id| opt(id, crate::dates::date_format_label(id)))
+                .collect(),
+            |_cx| crate::dates::date_format().into(),
+            move |v, cx| {
+                if let Some(a) = date_app.upgrade() {
+                    a.update(cx, |a, _cx| a.set_date_format(&v));
+                }
+            },
+            "iso",
+            weak,
+        );
+        let time_app = app.clone();
+        let time = dropdown_item(
+            "settings.item.format",
+            crate::dates::TIME_FORMATS
+                .iter()
+                .map(|&id| opt(id, crate::dates::time_format_label(id)))
+                .collect(),
+            |_cx| crate::dates::time_format().into(),
+            move |v, cx| {
+                if let Some(a) = time_app.upgrade() {
+                    a.update(cx, |a, _cx| a.set_time_format(&v));
+                }
+            },
+            "24h",
+            weak,
+        );
+
+        SettingPage::new(t!("settings.nav.general").into_owned()).groups([
+            card(
+                "settings.section.language",
+                "settings.desc.language",
+                vec![language],
+            ),
+            card(
+                "settings.section.remember_window",
+                "settings.desc.remember_window",
+                vec![window_bounds, open_tabs],
+            ),
+            card(
+                "settings.section.unused_images",
+                "settings.desc.unused_images",
+                vec![image_gc],
+            ),
+            card(
+                "settings.section.date_format",
+                "settings.desc.date_format",
+                vec![date],
+            ),
+            card(
+                "settings.section.time_format",
+                "settings.desc.time_format",
+                vec![time],
+            ),
+        ])
+    }
+
+    fn notebooks_page(&self, weak: &WeakEntity<Self>) -> SettingPage {
+        // Every registered notebook with per-row actions (switch / rename /
+        // reveal / remove), then "Add notebook…".
+        let nb_weak = weak.clone();
+        let notebooks = custom(move |_window, _cx| {
+            let mut col = div().flex().flex_col().gap(px(8.0));
+            for nb in crate::paths::notebooks() {
+                col = col.child(notebook_row(nb, &nb_weak));
+            }
+            col.child(div().flex().flex_row().mt(px(2.0)).child(text_button(
+                "nb-add",
+                &t!("settings.btn.add_notebook"),
+                &nb_weak,
+                |this, w, cx| this.add_notebook(w, cx),
+            )))
+            .into_any_element()
+        });
+
+        // The current data path, then move / reveal / reset actions.
+        let loc_weak = weak.clone();
+        let location = custom(move |_window, _cx| {
+            let data_path = crate::paths::data_dir().display().to_string();
+            let at_default = crate::paths::is_default_location();
+            div()
+                .flex()
+                .flex_col()
+                .gap(px(10.0))
+                .child(
+                    div()
+                        .px(px(10.0))
+                        .py(px(8.0))
+                        .rounded(px(8.0))
+                        .bg(theme::glass())
+                        .border_1()
+                        .border_color(theme::border_subtle())
+                        .text_size(px(12.0))
+                        .text_color(theme::text_secondary())
+                        .child(data_path),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .flex_row()
+                        .gap(px(8.0))
+                        .child(text_button(
+                            "data-move",
+                            &t!("settings.btn.move"),
+                            &loc_weak,
+                            |this, w, cx| this.choose_data_location(w, cx),
+                        ))
+                        .child(text_button(
+                            "data-reveal",
+                            &t!("settings.btn.reveal"),
+                            &loc_weak,
+                            |_this, _w, _cx| {
+                                crate::app::AppView::reveal_folder(&crate::paths::data_dir());
+                            },
+                        ))
+                        .when(!at_default, |row| {
+                            row.child(text_button(
+                                "data-reset",
+                                &t!("settings.btn.reset_default"),
+                                &loc_weak,
+                                |this, w, cx| this.confirm_reset_data_location(w, cx),
+                            ))
+                        }),
+                )
+                .into_any_element()
+        });
+
+        SettingPage::new(t!("settings.nav.notebooks").into_owned()).groups([
+            card(
+                "settings.section.notebooks",
+                "settings.desc.notebooks",
+                vec![notebooks],
+            ),
+            card(
+                "settings.section.data_location",
+                "settings.desc.data_location",
+                vec![location],
+            ),
+        ])
+    }
+
+    fn appearance_page(&self, weak: &WeakEntity<Self>, cx: &App) -> SettingPage {
+        let app = &self.app;
+
+        let (theme_opts, _) = theme_options(app, cx);
+        let theme_get_app = app.clone();
+        let theme_set_app = app.clone();
+        let app_theme = dropdown_item(
+            "settings.item.theme",
+            theme_opts,
+            move |cx| theme_options(&theme_get_app, cx).1,
+            move |v, cx| {
+                with_main_window(&theme_set_app, cx, move |a, window, cx| {
+                    a.set_skin(v.to_string(), window, cx)
                 })
-        };
-        let labeled_row = |label: &str, control: Switch| {
+            },
+            "zorite",
+            weak,
+        );
+
+        let mode_get_app = app.clone();
+        let mode_set_app = app.clone();
+        let appearance = dropdown_item(
+            "settings.item.mode",
+            vec![
+                opt("light", t!("settings.opt.light").to_string()),
+                opt("dark", t!("settings.opt.dark").to_string()),
+                opt("auto", t!("settings.opt.auto_appearance").to_string()),
+            ],
+            move |cx| {
+                mode_get_app
+                    .upgrade()
+                    .map(|a| a.read(cx).theme_mode())
+                    .unwrap_or_default()
+                    .as_str()
+                    .into()
+            },
+            move |v, cx| {
+                with_main_window(&mode_set_app, cx, move |a, window, cx| {
+                    a.set_theme_mode(Mode::from_str(&v), window, cx)
+                })
+            },
+            "auto",
+            weak,
+        );
+
+        // Font: the family dropdown + an import button.
+        let (font_opts, _) = font_options(app, &self.font_names, cx);
+        let font_get_app = app.clone();
+        let font_set_app = app.clone();
+        let family = dropdown_item_scrollable(
+            "settings.item.family",
+            font_opts,
+            move |cx| {
+                font_get_app
+                    .upgrade()
+                    .map(|a| a.read(cx).ui_font().to_string().into())
+                    .unwrap_or_default()
+            },
+            move |v, cx| {
+                with_main_window(&font_set_app, cx, move |a, window, cx| {
+                    a.set_ui_font(v.to_string(), window, cx)
+                })
+            },
+            "",
+            weak,
+        );
+        let font_weak = weak.clone();
+        let add_font = custom(move |_window, _cx| {
             div()
                 .flex()
                 .flex_row()
-                .items_center()
-                .justify_between()
+                .child(text_button(
+                    "font-add",
+                    &t!("settings.btn.add_font"),
+                    &font_weak,
+                    |this, w, cx| this.choose_font_file(w, cx),
+                ))
+                .into_any_element()
+        });
+
+        // Note text size — one value for all three views.
+        let size_get_app = app.clone();
+        let size_set_app = app.clone();
+        let text_size = dropdown_item(
+            "settings.item.size",
+            crate::app::TEXT_SIZES
+                .iter()
+                .map(|&s| {
+                    let label = if s == 16.0 {
+                        t!("settings.opt.size_px_default", size = s).to_string()
+                    } else {
+                        t!("settings.opt.size_px", size = s).to_string()
+                    };
+                    opt(&format!("{s}"), label)
+                })
+                .collect(),
+            move |cx| {
+                size_get_app
+                    .upgrade()
+                    .map(|a| format!("{}", f32::from(a.read(cx).text_size())).into())
+                    .unwrap_or_else(|| "16".into())
+            },
+            move |v, cx| {
+                if let (Ok(size), Some(a)) = (v.parse::<f32>(), size_set_app.upgrade()) {
+                    a.update(cx, |a, cx| a.set_text_size(size, cx));
+                }
+            },
+            "16",
+            weak,
+        );
+
+        let line_numbers = switch_item(
+            "settings.item.show_gutter",
+            app,
+            |a| a.line_numbers(),
+            |a, on, cx| a.set_line_numbers(on, cx),
+            false,
+            weak,
+        );
+
+        // Mouse cursor: the pack dropdown + add/reveal actions, the last import
+        // error, and (Linux) the relaunch note.
+        let (cursor_opts, _) = cursor_options(&self.cursor_packs, &self.cursor_reactive);
+        let cursor_weak = weak.clone();
+        let cursor = dropdown_item(
+            "settings.item.theme",
+            cursor_opts,
+            |_cx| crate::cursors::selected().unwrap_or_default().into(),
+            move |v, cx| {
+                crate::cursors::set_selected((!v.is_empty()).then_some(v.as_ref()));
+                let _ = cursor_weak.update(cx, |this, _| this.cursor_status = None);
+            },
+            "",
+            weak,
+        );
+        let cursor_weak = weak.clone();
+        let cursor_actions = custom(move |_window, cx| {
+            let status = cursor_weak
+                .upgrade()
+                .and_then(|v| v.read(cx).cursor_status.clone());
+            let col = div()
+                .flex()
+                .flex_col()
+                .gap(px(8.0))
                 .child(
                     div()
-                        .text_size(px(13.0))
-                        .text_color(theme::text_secondary())
-                        .child(label.to_string()),
+                        .flex()
+                        .flex_row()
+                        .gap(px(8.0))
+                        .child(text_button(
+                            "cursor-add",
+                            &t!("settings.btn.add_cursor"),
+                            &cursor_weak,
+                            |this, w, cx| this.choose_cursor_theme(w, cx),
+                        ))
+                        .child(text_button(
+                            "cursor-reveal",
+                            &t!("settings.btn.reveal_cursors"),
+                            &cursor_weak,
+                            |_this, _w, _cx| {
+                                let dir = crate::cursors::cursors_dir();
+                                let _ = std::fs::create_dir_all(&dir);
+                                crate::app::AppView::reveal_folder(&dir);
+                            },
+                        )),
                 )
-                .child(control)
-        };
-        let remember_window_control = div()
-            .flex()
-            .flex_col()
-            .gap(px(10.0))
-            .child(labeled_row(
-                &t!("settings.label.window_size_pos"),
-                window_bounds_switch,
-            ))
-            .child(labeled_row(
-                &t!("settings.label.open_tabs"),
-                open_tabs_switch,
-            ));
+                .children(status.map(status_line));
+            #[cfg(target_os = "linux")]
+            let col = col.child(status_line(t!("settings.note.cursor_relaunch").to_string()));
+            col.into_any_element()
+        });
 
-        // Security cards: the password state drives which actions show.
+        let sidebar_right = switch_item(
+            "settings.item.dock_right",
+            app,
+            |a| a.sidebar_right,
+            |a, on, cx| a.set_sidebar_right(on, cx),
+            false,
+            weak,
+        );
+
+        // Installed themes: the actions + the list (or empty state).
+        let themes_weak = weak.clone();
+        let installed = custom(move |_window, cx| {
+            let names = themes_weak
+                .upgrade()
+                .map(|v| v.read(cx).user_theme_names(cx))
+                .unwrap_or_default();
+            let actions = div()
+                .flex()
+                .flex_row()
+                .gap(px(8.0))
+                .child(text_button(
+                    "reveal-themes",
+                    &t!("settings.btn.reveal_themes"),
+                    &themes_weak,
+                    |this, _w, cx| {
+                        if let Some(app) = this.app.upgrade() {
+                            app.read(cx).reveal_themes_folder();
+                        }
+                    },
+                ))
+                .child(text_button(
+                    "reload-themes",
+                    &t!("settings.btn.reload"),
+                    &themes_weak,
+                    |this, w, cx| this.reload_skins(w, cx),
+                ));
+            let list = if names.is_empty() {
+                div()
+                    .text_size(px(13.0))
+                    .text_color(theme::text_tertiary())
+                    .child(t!("settings.note.no_custom_themes").to_string())
+                    .into_any_element()
+            } else {
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(4.0))
+                    .children(names.into_iter().map(|name| {
+                        div()
+                            .px(px(12.0))
+                            .py(px(6.0))
+                            .rounded(px(6.0))
+                            .bg(theme::glass())
+                            .text_size(px(13.0))
+                            .text_color(theme::text_secondary())
+                            .child(name)
+                    }))
+                    .into_any_element()
+            };
+            div()
+                .flex()
+                .flex_col()
+                .gap(px(12.0))
+                .child(actions)
+                .child(list)
+                .into_any_element()
+        });
+
+        SettingPage::new(t!("settings.nav.appearance").into_owned()).groups([
+            card(
+                "settings.section.app_theme",
+                "settings.desc.app_theme",
+                vec![app_theme],
+            ),
+            card(
+                "settings.section.appearance",
+                "settings.desc.appearance",
+                vec![appearance],
+            ),
+            card(
+                "settings.section.font",
+                "settings.desc.font",
+                vec![family, add_font],
+            ),
+            card(
+                "settings.section.text_size",
+                "settings.desc.text_size",
+                vec![text_size],
+            ),
+            card(
+                "settings.section.line_numbers",
+                "settings.desc.line_numbers",
+                vec![line_numbers],
+            ),
+            card(
+                "settings.section.mouse_cursor",
+                "settings.desc.mouse_cursor",
+                vec![cursor, cursor_actions],
+            ),
+            card(
+                "settings.section.sidebar_position",
+                "settings.desc.sidebar_position",
+                vec![sidebar_right],
+            ),
+            card(
+                "settings.section.installed_themes",
+                "settings.desc.installed_themes",
+                vec![installed],
+            ),
+        ])
+    }
+
+    fn markdown_page(&self, weak: &WeakEntity<Self>) -> SettingPage {
+        let app = &self.app;
+        // WYSIWYG live preview: persists + re-applies to open editors via
+        // `set_wysiwyg`.
+        let wysiwyg = switch_item(
+            "settings.item.enabled",
+            app,
+            |a| a.wysiwyg(),
+            |a, on, cx| a.set_wysiwyg(on, cx),
+            true,
+            weak,
+        );
+        let indent_get_app = app.clone();
+        let indent_set_app = app.clone();
+        let indent = dropdown_item(
+            "settings.item.spaces_per_level",
+            vec![
+                opt("2", t!("settings.opt.indent_2").to_string()),
+                opt("4", t!("settings.opt.indent_4").to_string()),
+                opt("8", t!("settings.opt.indent_8").to_string()),
+            ],
+            move |cx| {
+                indent_get_app
+                    .upgrade()
+                    .map(|a| a.read(cx).list_indent().to_string().into())
+                    .unwrap_or_else(|| "4".into())
+            },
+            move |v, cx| {
+                if let (Ok(spaces), Some(a)) = (v.parse::<usize>(), indent_set_app.upgrade()) {
+                    a.update(cx, |a, cx| a.set_list_indent(spaces, cx));
+                }
+            },
+            "4",
+            weak,
+        );
+        let auto_link = switch_item(
+            "settings.item.enabled",
+            app,
+            |a| a.auto_link(),
+            |a, on, _cx| a.set_auto_link(on),
+            false,
+            weak,
+        );
+        SettingPage::new(t!("settings.nav.markdown").into_owned()).groups([
+            card(
+                "settings.section.wysiwyg",
+                "settings.desc.wysiwyg",
+                vec![wysiwyg],
+            ),
+            card(
+                "settings.section.list_indent",
+                "settings.desc.list_indent",
+                vec![indent],
+            ),
+            card(
+                "settings.section.autolink",
+                "settings.desc.autolink",
+                vec![auto_link],
+            ),
+        ])
+    }
+
+    fn pdf_page(&self) -> SettingPage {
+        let slider = self.quality_slider.clone();
+        let app = self.app.clone();
+        let quality = SettingItem::new(
+            t!("settings.item.quality").into_owned(),
+            SettingField::render(move |_opts, _window, cx| {
+                let qpct = app
+                    .upgrade()
+                    .map(|a| (a.read(cx).pdf_quality() * 100.0).round() as i32)
+                    .unwrap_or(100);
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(8.0))
+                    .min_w(px(220.0))
+                    .child(Slider::new(&slider).w_full())
+                    .child(status_line(format!("{qpct}%")))
+            }),
+        );
+        SettingPage::new(t!("settings.nav.pdf").into_owned()).groups([card(
+            "settings.section.pdf_quality",
+            "settings.desc.pdf_quality",
+            vec![quality],
+        )])
+    }
+
+    fn security_page(&self, weak: &WeakEntity<Self>) -> SettingPage {
         let encrypted = crate::db::db_is_encrypted();
-        let password_control = {
+
+        // The password state drives which actions show.
+        let pw_weak = weak.clone();
+        let password = custom(move |_window, cx| {
+            let status = pw_weak
+                .upgrade()
+                .and_then(|v| v.read(cx).security_status.clone());
+            let encrypted = crate::db::db_is_encrypted();
             let mut row = div().flex().flex_row().flex_wrap().gap(px(8.0));
             if encrypted {
                 row = row
                     .child(text_button(
                         "sec-change",
                         &t!("settings.btn.change_password"),
-                        cx,
-                        |this, w, cx| {
-                            this.open_password_dialog(PwMode::Change, w, cx);
-                        },
+                        &pw_weak,
+                        |this, w, cx| this.open_password_dialog(PwMode::Change, w, cx),
                     ))
                     .child(text_button(
                         "sec-remove",
                         &t!("settings.btn.remove_password"),
-                        cx,
-                        |this, w, cx| {
-                            this.open_password_dialog(PwMode::Remove, w, cx);
-                        },
+                        &pw_weak,
+                        |this, w, cx| this.open_password_dialog(PwMode::Remove, w, cx),
                     ))
                     .child(text_button(
                         "sec-lock",
                         &t!("settings.btn.lock_now"),
-                        cx,
+                        &pw_weak,
                         |_this, _w, cx| {
                             // Deferred: locking closes this window mid-handler.
                             cx.defer(crate::lock_now);
@@ -2026,173 +1658,109 @@ impl Render for SettingsView {
                 row = row.child(text_button(
                     "sec-set",
                     &t!("settings.btn.set_password"),
-                    cx,
-                    |this, w, cx| {
-                        this.open_password_dialog(PwMode::Set, w, cx);
-                    },
+                    &pw_weak,
+                    |this, w, cx| this.open_password_dialog(PwMode::Set, w, cx),
                 ));
             }
-            div().flex().flex_col().gap(px(10.0)).child(row).children(
-                self.security_status.clone().map(|msg| {
-                    div()
-                        .text_size(px(12.0))
-                        .text_color(theme::text_tertiary())
-                        .child(msg)
-                }),
-            )
-        };
-        let remember_control = {
-            let weak = cx.entity().downgrade();
             div()
                 .flex()
                 .flex_col()
-                .gap(px(8.0))
-                .child(
-                    Switch::new("sec-remember")
-                        .small()
-                        .checked(encrypted && crate::security::is_remembered())
-                        .disabled(!encrypted)
-                        .on_click(move |on: &bool, _w, cx| {
-                            if !crate::db::db_is_encrypted() {
-                                return;
-                            }
-                            if *on {
-                                if let Some(pw) = crate::security::session_key() {
-                                    crate::security::remember_password(&pw);
-                                }
-                            } else {
-                                crate::security::forget_password();
-                            }
-                            let _ = weak.update(cx, |_, cx| cx.notify());
-                        }),
-                )
-                .children((!encrypted).then(|| {
-                    div()
-                        .text_size(px(12.0))
-                        .text_color(theme::text_tertiary())
-                        .child(t!("settings.note.set_password_first").to_string())
-                }))
-        };
-        let auto_lock_control = {
-            let current = crate::security::auto_lock_minutes();
-            let mut row = div().flex().flex_row().flex_wrap().gap(px(6.0));
-            for (label, mins) in [
-                (t!("settings.autolock.off").to_string(), 0u64),
-                (t!("settings.autolock.5min").to_string(), 5),
-                (t!("settings.autolock.15min").to_string(), 15),
-                (t!("settings.autolock.30min").to_string(), 30),
-                (t!("settings.autolock.1hour").to_string(), 60),
-            ] {
-                let app = self.app.clone();
-                let mut chip = div()
-                    .id(SharedString::from(format!("autolock-{mins}")))
-                    .px(px(10.0))
-                    .py(px(4.0))
-                    .rounded(px(8.0))
-                    .text_size(px(12.0))
-                    .cursor_pointer();
-                chip = if encrypted && current == mins {
-                    chip.bg(theme::accent_tint()).text_color(theme::accent())
-                } else {
-                    chip.bg(theme::glass()).text_color(theme::text_secondary())
-                };
-                row = row.child(
-                    chip.on_click(cx.listener(move |_this, _: &gpui::ClickEvent, _w, cx| {
-                        if !crate::db::db_is_encrypted() {
-                            return;
-                        }
-                        if let Some(app) = app.upgrade() {
-                            app.update(cx, |a, cx| a.set_auto_lock(mins, cx));
-                        }
-                        cx.notify();
-                    }))
-                    .child(label),
-                );
-            }
-            div()
-                .flex()
-                .flex_col()
-                .gap(px(8.0))
+                .gap(px(10.0))
                 .child(row)
-                .children((!encrypted).then(|| {
-                    div()
-                        .text_size(px(12.0))
-                        .text_color(theme::text_tertiary())
-                        .child(t!("settings.note.set_password_first").to_string())
-                }))
-        };
+                .children(status.map(status_line))
+                .into_any_element()
+        });
 
-        // Notebooks card body: every registered notebook with per-row actions
-        // (switch / rename / reveal / remove), then "Add notebook…".
-        let notebooks_control = {
-            let mut col = div().flex().flex_col().gap(px(8.0));
-            for nb in crate::paths::notebooks() {
-                col = col.child(self.notebook_settings_row(nb, cx));
-            }
-            col.child(div().flex().flex_row().mt(px(2.0)).child(text_button(
-                "nb-add",
-                &t!("settings.btn.add_notebook"),
-                cx,
-                |this, w, cx| this.add_notebook(w, cx),
-            )))
-        };
+        let remember = SettingItem::new(
+            t!("settings.item.enabled").into_owned(),
+            SettingField::switch(
+                |_cx| crate::db::db_is_encrypted() && crate::security::is_remembered(),
+                notify_after(weak, |on, _cx| {
+                    if !crate::db::db_is_encrypted() {
+                        return;
+                    }
+                    if on {
+                        if let Some(pw) = crate::security::session_key() {
+                            crate::security::remember_password(&pw);
+                        }
+                    } else {
+                        crate::security::forget_password();
+                    }
+                }),
+            ),
+        )
+        .disabled(!encrypted);
 
-        // Data-location card body (Notebooks): the current path, then move /
-        // reveal / reset actions.
-        let data_path = crate::paths::data_dir().display().to_string();
-        let at_default = crate::paths::is_default_location();
-        let location_control = div()
-            .flex()
-            .flex_col()
-            .gap(px(10.0))
-            .child(
-                div()
-                    .px(px(10.0))
-                    .py(px(8.0))
-                    .rounded(px(8.0))
-                    .bg(theme::glass())
-                    .border_1()
-                    .border_color(theme::border_subtle())
-                    .text_size(px(12.0))
-                    .text_color(theme::text_secondary())
-                    .child(data_path),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_row()
-                    .gap(px(8.0))
-                    .child(text_button(
-                        "data-move",
-                        &t!("settings.btn.move"),
-                        cx,
-                        |this, w, cx| this.choose_data_location(w, cx),
-                    ))
-                    .child(text_button(
-                        "data-reveal",
-                        &t!("settings.btn.reveal"),
-                        cx,
-                        |_this, _w, _cx| {
-                            crate::app::AppView::reveal_folder(&crate::paths::data_dir());
-                        },
-                    ))
-                    .when(!at_default, |row| {
-                        row.child(text_button(
-                            "data-reset",
-                            &t!("settings.btn.reset_default"),
-                            cx,
-                            |this, w, cx| this.confirm_reset_data_location(w, cx),
-                        ))
-                    }),
-            );
+        let lock_app = self.app.clone();
+        let auto_lock = dropdown_item(
+            "settings.item.lock_after",
+            vec![
+                opt("0", t!("settings.autolock.off").to_string()),
+                opt("5", t!("settings.autolock.5min").to_string()),
+                opt("15", t!("settings.autolock.15min").to_string()),
+                opt("30", t!("settings.autolock.30min").to_string()),
+                opt("60", t!("settings.autolock.1hour").to_string()),
+            ],
+            |_cx| crate::security::auto_lock_minutes().to_string().into(),
+            move |v, cx| {
+                if !crate::db::db_is_encrypted() {
+                    return;
+                }
+                if let (Ok(mins), Some(a)) = (v.parse::<u64>(), lock_app.upgrade()) {
+                    a.update(cx, |a, cx| a.set_auto_lock(mins, cx));
+                }
+            },
+            "0",
+            weak,
+        )
+        .disabled(!encrypted);
 
-        // Updates pane: current version, the available-update banner (read from
-        // the `updater::UpdateState` global), and View-release / Check-now.
-        let available = cx
-            .try_global::<crate::updater::UpdateState>()
-            .and_then(|u| u.available.clone());
-        let cur_version = env!("CARGO_PKG_VERSION");
-        let updates_control = {
+        let mut remember_items = vec![remember];
+        let mut lock_items = vec![auto_lock];
+        if !encrypted {
+            let note = || {
+                custom(|_w, _cx| {
+                    status_line(t!("settings.note.set_password_first").to_string())
+                        .into_any_element()
+                })
+            };
+            remember_items.push(note());
+            lock_items.push(note());
+        }
+
+        SettingPage::new(t!("settings.nav.security").into_owned()).groups([
+            card(
+                "settings.section.password",
+                "settings.desc.password",
+                vec![password],
+            ),
+            card(
+                "settings.section.remember_device",
+                if cfg!(target_os = "linux") {
+                    "settings.desc.remember_device_linux"
+                } else {
+                    "settings.desc.remember_device"
+                },
+                remember_items,
+            ),
+            card(
+                "settings.section.autolock",
+                "settings.desc.autolock",
+                lock_items,
+            ),
+        ])
+    }
+
+    fn updates_page(&self, weak: &WeakEntity<Self>) -> SettingPage {
+        let app = &self.app;
+        // Current version, the available-update banner (read from the
+        // `updater::UpdateState` global), and View-release / Check-now.
+        let up_weak = weak.clone();
+        let updates = custom(move |_window, cx| {
+            let available = cx
+                .try_global::<crate::updater::UpdateState>()
+                .and_then(|u| u.available.clone());
+            let cur_version = env!("CARGO_PKG_VERSION");
             let mut col = div().flex().flex_col().gap(px(10.0)).child(
                 div()
                     .text_size(px(13.0))
@@ -2216,12 +1784,7 @@ impl Render for SettingsView {
                     if notes.chars().count() > 280 {
                         preview.push('…');
                     }
-                    col = col.child(
-                        div()
-                            .text_size(px(12.0))
-                            .text_color(theme::text_tertiary())
-                            .child(preview),
-                    );
+                    col = col.child(status_line(preview));
                 }
                 col = col.child(
                     div()
@@ -2231,13 +1794,13 @@ impl Render for SettingsView {
                         .child(text_button(
                             "updates-view",
                             &t!("settings.btn.view_release"),
-                            cx,
+                            &up_weak,
                             move |_this, _w, _cx| open_url(&url),
                         ))
                         .child(text_button(
                             "updates-check",
                             &t!("settings.btn.check_now"),
-                            cx,
+                            &up_weak,
                             |this, _w, cx| this.check_for_updates(cx),
                         )),
                 );
@@ -2252,13 +1815,240 @@ impl Render for SettingsView {
                     .child(text_button(
                         "updates-check",
                         &t!("settings.btn.check_now"),
-                        cx,
+                        &up_weak,
                         |this, _w, cx| this.check_for_updates(cx),
                     ));
             }
-            col
-        };
+            col.into_any_element()
+        });
+        let auto_check = switch_item(
+            "settings.item.enabled",
+            app,
+            |a| a.check_updates(),
+            |a, on, _cx| a.set_check_updates(on),
+            true,
+            weak,
+        );
+        let prereleases = switch_item(
+            "settings.item.enabled",
+            app,
+            |a| a.include_prerelease(),
+            |a, on, cx| a.set_include_prerelease(on, cx),
+            false,
+            weak,
+        );
+        SettingPage::new(t!("settings.nav.updates").into_owned()).groups([
+            card(
+                "settings.section.updates",
+                "settings.desc.updates",
+                vec![updates],
+            ),
+            card(
+                "settings.section.auto_check",
+                "settings.desc.auto_check",
+                vec![auto_check],
+            ),
+            card(
+                "settings.section.prereleases",
+                "settings.desc.prereleases",
+                vec![prereleases],
+            ),
+        ])
+    }
+}
 
+/// The read-only shortcut lists (Keyboard page).
+fn keyboard_page() -> SettingPage {
+    fn list(rows: Vec<(String, Vec<&'static str>)>) -> SettingItem {
+        let labels: Vec<SharedString> = rows.iter().map(|(l, _)| l.clone().into()).collect();
+        custom(move |_w, _cx| {
+            div()
+                .flex()
+                .flex_col()
+                .gap(px(2.0))
+                .children(rows.iter().map(|(label, combo)| shortcut_row(label, combo)))
+                .into_any_element()
+        })
+        .keywords(labels)
+    }
+    let app_rows: Vec<(String, Vec<&'static str>)> = vec![
+        (t!("settings.kb.new_tab").to_string(), vec![keys::MOD, "T"]),
+        (
+            t!("settings.kb.new_window").to_string(),
+            vec![keys::MOD, "N"],
+        ),
+        (
+            t!("settings.kb.close_tab").to_string(),
+            vec![keys::MOD, "W"],
+        ),
+        (
+            t!("settings.kb.next_tab").to_string(),
+            vec![keys::CTRL, "Tab"],
+        ),
+        (
+            t!("settings.kb.prev_tab").to_string(),
+            vec![keys::CTRL, keys::SHIFT, "Tab"],
+        ),
+        (
+            t!("settings.kb.find_in_page").to_string(),
+            vec![keys::MOD, "F"],
+        ),
+        (
+            t!("settings.kb.search_all").to_string(),
+            vec![keys::MOD, keys::SHIFT, "F"],
+        ),
+        (
+            t!("settings.kb.fit_images").to_string(),
+            vec![keys::MOD, keys::SHIFT, "I"],
+        ),
+        (
+            t!("settings.kb.export_pdf").to_string(),
+            vec![keys::MOD, "P"],
+        ),
+        (
+            t!("settings.kb.open_settings").to_string(),
+            vec![keys::MOD, ","],
+        ),
+        // Windows quits with the OS convention.
+        #[cfg(target_os = "windows")]
+        (t!("settings.kb.quit").to_string(), vec!["Alt", "F4"]),
+        #[cfg(not(target_os = "windows"))]
+        (t!("settings.kb.quit").to_string(), vec![keys::MOD, "Q"]),
+    ];
+    let edit_rows: Vec<(String, Vec<&'static str>)> = vec![
+        (t!("settings.kb.slash_menu").to_string(), vec!["/"]),
+        (t!("settings.kb.menu_nav").to_string(), vec!["↑", "↓"]),
+        (t!("settings.kb.menu_insert").to_string(), vec!["Enter"]),
+        (t!("settings.kb.menu_close").to_string(), vec!["Esc"]),
+        (t!("settings.kb.indent").to_string(), vec!["Tab"]),
+        (
+            t!("settings.kb.outdent").to_string(),
+            vec![keys::SHIFT, "Tab"],
+        ),
+        (t!("settings.kb.copy").to_string(), vec![keys::MOD, "C"]),
+        (t!("settings.kb.cut").to_string(), vec![keys::MOD, "X"]),
+        (t!("settings.kb.paste").to_string(), vec![keys::MOD, "V"]),
+        (t!("settings.kb.undo").to_string(), vec![keys::MOD, "Z"]),
+        (t!("settings.kb.redo").to_string(), keys::redo()),
+        (
+            t!("settings.kb.select_all").to_string(),
+            vec![keys::MOD, "A"],
+        ),
+    ];
+    let wb_tool_rows: Vec<(String, Vec<&'static str>)> = vec![
+        (t!("settings.kb.select").to_string(), vec!["V"]),
+        (t!("settings.kb.pan").to_string(), vec!["H"]),
+        (t!("settings.kb.pen").to_string(), vec!["P"]),
+        (t!("settings.kb.rectangle").to_string(), vec!["R"]),
+        (t!("settings.kb.ellipse").to_string(), vec!["O"]),
+        (t!("settings.kb.diamond").to_string(), vec!["D"]),
+        (t!("settings.kb.triangle").to_string(), vec!["G"]),
+        (t!("settings.kb.rounded_rect").to_string(), vec!["U"]),
+        (t!("settings.kb.star").to_string(), vec!["S"]),
+        (t!("settings.kb.hexagon").to_string(), vec!["X"]),
+        (t!("settings.kb.line").to_string(), vec!["L"]),
+        (t!("settings.kb.arrow").to_string(), vec!["A"]),
+        (t!("settings.kb.text").to_string(), vec!["T"]),
+        (t!("settings.kb.image").to_string(), vec!["I"]),
+    ];
+    let wb_edit_rows: Vec<(String, Vec<&'static str>)> = vec![
+        (t!("settings.kb.undo").to_string(), vec![keys::MOD, "Z"]),
+        (t!("settings.kb.redo").to_string(), keys::redo()),
+        (t!("settings.kb.copy").to_string(), vec![keys::MOD, "C"]),
+        (t!("settings.kb.cut").to_string(), vec![keys::MOD, "X"]),
+        (t!("settings.kb.paste").to_string(), vec![keys::MOD, "V"]),
+        (
+            t!("settings.kb.bring_forward").to_string(),
+            vec![keys::MOD, "]"],
+        ),
+        (
+            t!("settings.kb.bring_front").to_string(),
+            vec![keys::MOD, keys::SHIFT, "]"],
+        ),
+        (
+            t!("settings.kb.send_backward").to_string(),
+            vec![keys::MOD, "["],
+        ),
+        (
+            t!("settings.kb.send_back").to_string(),
+            vec![keys::MOD, keys::SHIFT, "["],
+        ),
+        (t!("settings.kb.delete_sel").to_string(), vec!["Delete"]),
+        (t!("settings.kb.deselect").to_string(), vec!["Esc"]),
+    ];
+    let pdf_rows: Vec<(String, Vec<&'static str>)> = vec![
+        (t!("settings.kb.next_page").to_string(), vec!["PageDown"]),
+        (t!("settings.kb.prev_page").to_string(), vec!["PageUp"]),
+        (t!("settings.kb.first_page").to_string(), vec!["Home"]),
+        (t!("settings.kb.last_page").to_string(), vec!["End"]),
+        (t!("settings.kb.zoom_in").to_string(), vec![keys::MOD, "="]),
+        (t!("settings.kb.zoom_out").to_string(), vec![keys::MOD, "−"]),
+        (
+            t!("settings.kb.reset_zoom").to_string(),
+            vec![keys::MOD, "0"],
+        ),
+        (t!("settings.kb.find").to_string(), vec![keys::MOD, "F"]),
+        (
+            t!("settings.kb.next_match").to_string(),
+            vec![keys::MOD, "G"],
+        ),
+        (
+            t!("settings.kb.prev_match").to_string(),
+            vec![keys::MOD, keys::SHIFT, "G"],
+        ),
+        (
+            t!("settings.kb.toggle_highlight").to_string(),
+            vec![keys::MOD, keys::SHIFT, "H"],
+        ),
+        (
+            t!("settings.kb.go_to_page").to_string(),
+            vec![keys::MOD, keys::ALT, "G"],
+        ),
+    ];
+    SettingPage::new(t!("settings.nav.keyboard").into_owned())
+        .resettable(false)
+        .groups([
+            card(
+                "settings.section.application",
+                "settings.desc.application",
+                vec![list(app_rows)],
+            ),
+            card(
+                "settings.section.editing",
+                "settings.desc.editing",
+                vec![list(edit_rows)],
+            ),
+            card(
+                "settings.section.wb_tools",
+                "settings.desc.wb_tools",
+                vec![list(wb_tool_rows)],
+            ),
+            card(
+                "settings.section.wb_editing",
+                "settings.desc.wb_editing",
+                vec![list(wb_edit_rows)],
+            ),
+            card(
+                "settings.section.pdf_viewer",
+                "settings.desc.pdf_viewer",
+                vec![list(pdf_rows)],
+            ),
+        ])
+}
+
+impl Render for SettingsView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let weak = cx.entity().downgrade();
+        let pages = vec![
+            self.general_page(&weak),
+            self.notebooks_page(&weak),
+            self.appearance_page(&weak, cx),
+            self.markdown_page(&weak),
+            self.pdf_page(),
+            self.security_page(&weak),
+            keyboard_page(),
+            self.updates_page(&weak),
+        ];
         div()
             .flex()
             .flex_col()
@@ -2267,349 +2057,309 @@ impl Render for SettingsView {
             .text_color(theme::text_primary())
             .child(TitleBar::new())
             .child(
-                div()
-                    .flex_shrink_0()
-                    .px(px(32.0))
-                    .pt(px(18.0))
-                    .pb(px(14.0))
-                    .flex()
-                    .flex_row()
-                    .items_center()
-                    .gap(px(10.0))
-                    .child(
-                        div()
-                            .text_size(px(26.0))
-                            .font_weight(FontWeight::BOLD)
-                            .child(t!("settings.title").to_string()),
-                    )
-                    .child(version_chip())
-                    .child(div().flex_1())
-                    .child(self.filter_bar(cx)),
-            )
-            .child(
-                div()
-                    .flex_1()
-                    .min_h_0()
-                    .flex()
-                    .flex_row()
-                    .child(self.nav(cx))
-                    .child({
-                        let content = div()
-                            .id("settings-content")
-                            .flex_1()
-                            .min_w_0()
-                            .overflow_y_scroll()
-                            .px(px(24.0))
-                            .pb(px(24.0))
-                            .flex()
-                            .flex_col()
-                            .gap(px(16.0));
-                        match self.tab {
-                            Tab::Notebooks => content
-                                .child(self.section_card(
-                                    "settings.section.notebooks",
-                                    "settings.desc.notebooks",
-                                    notebooks_control,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.data_location",
-                                    "settings.desc.data_location",
-                                    location_control,
-                                )),
-                            Tab::General => content
-                                .child(self.section_card(
-                                    "settings.section.language",
-                                    "settings.desc.language",
-                                    Select::new(&self.language_select).small().w_full(),
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.remember_window",
-                                    "settings.desc.remember_window",
-                                    remember_window_control,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.unused_images",
-                                    "settings.desc.unused_images",
-                                    image_gc_control,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.date_format",
-                                    "settings.desc.date_format",
-                                    Select::new(&self.date_format_select).small().w_full(),
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.time_format",
-                                    "settings.desc.time_format",
-                                    Select::new(&self.time_format_select).small().w_full(),
-                                )),
-                            Tab::Appearance => content
-                                .child(self.section_card(
-                                    "settings.section.app_theme",
-                                    "settings.desc.app_theme",
-                                    Select::new(&self.theme_select).small().w_full(),
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.appearance",
-                                    "settings.desc.appearance",
-                                    Select::new(&self.appearance_select).small().w_full(),
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.font",
-                                    "settings.desc.font",
-                                    font_control,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.text_size",
-                                    "settings.desc.text_size",
-                                    Select::new(&self.text_size_select).small().w_full(),
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.line_numbers",
-                                    "settings.desc.line_numbers",
-                                    line_numbers_switch,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.mouse_cursor",
-                                    "settings.desc.mouse_cursor",
-                                    cursor_control,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.sidebar_position",
-                                    "settings.desc.sidebar_position",
-                                    sidebar_side_switch,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.installed_themes",
-                                    "settings.desc.installed_themes",
-                                    installed,
-                                )),
-                            Tab::Pdf => content.child(self.section_card(
-                                "settings.section.pdf_quality",
-                                "settings.desc.pdf_quality",
-                                quality_control,
-                            )),
-                            Tab::Markdown => content
-                                .child(self.section_card(
-                                    "settings.section.wysiwyg",
-                                    "settings.desc.wysiwyg",
-                                    wysiwyg_switch,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.list_indent",
-                                    "settings.desc.list_indent",
-                                    Select::new(&self.indent_select).small().w_full(),
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.autolink",
-                                    "settings.desc.autolink",
-                                    auto_link_switch,
-                                )),
-                            Tab::Keyboard => {
-                                let app_rows: Vec<(String, Vec<&str>)> = vec![
-                                    (t!("settings.kb.new_tab").to_string(), vec![keys::MOD, "T"]),
-                                    (
-                                        t!("settings.kb.new_window").to_string(),
-                                        vec![keys::MOD, "N"],
-                                    ),
-                                    (
-                                        t!("settings.kb.close_tab").to_string(),
-                                        vec![keys::MOD, "W"],
-                                    ),
-                                    (
-                                        t!("settings.kb.next_tab").to_string(),
-                                        vec![keys::CTRL, "Tab"],
-                                    ),
-                                    (
-                                        t!("settings.kb.prev_tab").to_string(),
-                                        vec![keys::CTRL, keys::SHIFT, "Tab"],
-                                    ),
-                                    (
-                                        t!("settings.kb.find_in_page").to_string(),
-                                        vec![keys::MOD, "F"],
-                                    ),
-                                    (
-                                        t!("settings.kb.search_all").to_string(),
-                                        vec![keys::MOD, keys::SHIFT, "F"],
-                                    ),
-                                    (
-                                        t!("settings.kb.fit_images").to_string(),
-                                        vec![keys::MOD, keys::SHIFT, "I"],
-                                    ),
-                                    (
-                                        t!("settings.kb.export_pdf").to_string(),
-                                        vec![keys::MOD, "P"],
-                                    ),
-                                    (
-                                        t!("settings.kb.open_settings").to_string(),
-                                        vec![keys::MOD, ","],
-                                    ),
-                                    // Windows quits with the OS convention.
-                                    #[cfg(target_os = "windows")]
-                                    (t!("settings.kb.quit").to_string(), vec!["Alt", "F4"]),
-                                    #[cfg(not(target_os = "windows"))]
-                                    (t!("settings.kb.quit").to_string(), vec![keys::MOD, "Q"]),
-                                ];
-                                let edit_rows: Vec<(String, Vec<&str>)> = vec![
-                                    (t!("settings.kb.slash_menu").to_string(), vec!["/"]),
-                                    (t!("settings.kb.menu_nav").to_string(), vec!["↑", "↓"]),
-                                    (t!("settings.kb.menu_insert").to_string(), vec!["Enter"]),
-                                    (t!("settings.kb.menu_close").to_string(), vec!["Esc"]),
-                                    (t!("settings.kb.indent").to_string(), vec!["Tab"]),
-                                    (
-                                        t!("settings.kb.outdent").to_string(),
-                                        vec![keys::SHIFT, "Tab"],
-                                    ),
-                                    (t!("settings.kb.copy").to_string(), vec![keys::MOD, "C"]),
-                                    (t!("settings.kb.cut").to_string(), vec![keys::MOD, "X"]),
-                                    (t!("settings.kb.paste").to_string(), vec![keys::MOD, "V"]),
-                                    (t!("settings.kb.undo").to_string(), vec![keys::MOD, "Z"]),
-                                    (t!("settings.kb.redo").to_string(), keys::redo()),
-                                    (
-                                        t!("settings.kb.select_all").to_string(),
-                                        vec![keys::MOD, "A"],
-                                    ),
-                                ];
-                                let wb_tool_rows: Vec<(String, Vec<&str>)> = vec![
-                                    (t!("settings.kb.select").to_string(), vec!["V"]),
-                                    (t!("settings.kb.pan").to_string(), vec!["H"]),
-                                    (t!("settings.kb.pen").to_string(), vec!["P"]),
-                                    (t!("settings.kb.rectangle").to_string(), vec!["R"]),
-                                    (t!("settings.kb.ellipse").to_string(), vec!["O"]),
-                                    (t!("settings.kb.diamond").to_string(), vec!["D"]),
-                                    (t!("settings.kb.triangle").to_string(), vec!["G"]),
-                                    (t!("settings.kb.rounded_rect").to_string(), vec!["U"]),
-                                    (t!("settings.kb.star").to_string(), vec!["S"]),
-                                    (t!("settings.kb.hexagon").to_string(), vec!["X"]),
-                                    (t!("settings.kb.line").to_string(), vec!["L"]),
-                                    (t!("settings.kb.arrow").to_string(), vec!["A"]),
-                                    (t!("settings.kb.text").to_string(), vec!["T"]),
-                                    (t!("settings.kb.image").to_string(), vec!["I"]),
-                                ];
-                                let wb_edit_rows: Vec<(String, Vec<&str>)> = vec![
-                                    (t!("settings.kb.undo").to_string(), vec![keys::MOD, "Z"]),
-                                    (t!("settings.kb.redo").to_string(), keys::redo()),
-                                    (t!("settings.kb.copy").to_string(), vec![keys::MOD, "C"]),
-                                    (t!("settings.kb.cut").to_string(), vec![keys::MOD, "X"]),
-                                    (t!("settings.kb.paste").to_string(), vec![keys::MOD, "V"]),
-                                    (
-                                        t!("settings.kb.bring_forward").to_string(),
-                                        vec![keys::MOD, "]"],
-                                    ),
-                                    (
-                                        t!("settings.kb.bring_front").to_string(),
-                                        vec![keys::MOD, keys::SHIFT, "]"],
-                                    ),
-                                    (
-                                        t!("settings.kb.send_backward").to_string(),
-                                        vec![keys::MOD, "["],
-                                    ),
-                                    (
-                                        t!("settings.kb.send_back").to_string(),
-                                        vec![keys::MOD, keys::SHIFT, "["],
-                                    ),
-                                    (t!("settings.kb.delete_sel").to_string(), vec!["Delete"]),
-                                    (t!("settings.kb.deselect").to_string(), vec!["Esc"]),
-                                ];
-                                let pdf_rows: Vec<(String, Vec<&str>)> = vec![
-                                    (t!("settings.kb.next_page").to_string(), vec!["PageDown"]),
-                                    (t!("settings.kb.prev_page").to_string(), vec!["PageUp"]),
-                                    (t!("settings.kb.first_page").to_string(), vec!["Home"]),
-                                    (t!("settings.kb.last_page").to_string(), vec!["End"]),
-                                    (t!("settings.kb.zoom_in").to_string(), vec![keys::MOD, "="]),
-                                    (t!("settings.kb.zoom_out").to_string(), vec![keys::MOD, "−"]),
-                                    (
-                                        t!("settings.kb.reset_zoom").to_string(),
-                                        vec![keys::MOD, "0"],
-                                    ),
-                                    (t!("settings.kb.find").to_string(), vec![keys::MOD, "F"]),
-                                    (
-                                        t!("settings.kb.next_match").to_string(),
-                                        vec![keys::MOD, "G"],
-                                    ),
-                                    (
-                                        t!("settings.kb.prev_match").to_string(),
-                                        vec![keys::MOD, keys::SHIFT, "G"],
-                                    ),
-                                    (
-                                        t!("settings.kb.toggle_highlight").to_string(),
-                                        vec![keys::MOD, keys::SHIFT, "H"],
-                                    ),
-                                    (
-                                        t!("settings.kb.go_to_page").to_string(),
-                                        vec![keys::MOD, keys::ALT, "G"],
-                                    ),
-                                ];
-                                content
-                                    .child(self.section_list(
-                                        "settings.section.application",
-                                        "settings.desc.application",
-                                        app_rows,
-                                    ))
-                                    .child(self.section_list(
-                                        "settings.section.editing",
-                                        "settings.desc.editing",
-                                        edit_rows,
-                                    ))
-                                    .child(self.section_list(
-                                        "settings.section.wb_tools",
-                                        "settings.desc.wb_tools",
-                                        wb_tool_rows,
-                                    ))
-                                    .child(self.section_list(
-                                        "settings.section.wb_editing",
-                                        "settings.desc.wb_editing",
-                                        wb_edit_rows,
-                                    ))
-                                    .child(self.section_list(
-                                        "settings.section.pdf_viewer",
-                                        "settings.desc.pdf_viewer",
-                                        pdf_rows,
-                                    ))
-                            }
-                            Tab::Security => content
-                                .child(self.section_card(
-                                    "settings.section.password",
-                                    "settings.desc.password",
-                                    password_control,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.remember_device",
-                                    if cfg!(target_os = "linux") {
-                                        "settings.desc.remember_device_linux"
-                                    } else {
-                                        "settings.desc.remember_device"
-                                    },
-                                    remember_control,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.autolock",
-                                    "settings.desc.autolock",
-                                    auto_lock_control,
-                                )),
-                            Tab::Updates => content
-                                .child(self.section_card(
-                                    "settings.section.updates",
-                                    "settings.desc.updates",
-                                    updates_control,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.auto_check",
-                                    "settings.desc.auto_check",
-                                    check_updates_switch,
-                                ))
-                                .child(self.section_card(
-                                    "settings.section.prereleases",
-                                    "settings.desc.prereleases",
-                                    prerelease_switch,
-                                )),
-                        }
-                    }),
+                div().flex_1().min_h_0().child(
+                    Settings::new("zorite-settings")
+                        .small()
+                        .sidebar_width(px(190.0))
+                        // Appearance is the page people open Settings for most.
+                        .default_selected_index(SelectIndex {
+                            page_ix: 2,
+                            group_ix: None,
+                        })
+                        .pages(pages),
+                ),
             )
             // gpui-component's `Root` stores dialog state but doesn't draw it;
             // the host view must render the dialog layer (as the main window
             // does), or the data-location confirm dialog stays invisible.
             .children(Root::render_dialog_layer(window, cx))
     }
+}
+
+// --- Card / field helpers ---------------------------------------------------
+
+/// One settings card: the localized title + description as a group, with
+/// every item tagged with the card's words so the sidebar search finds it by
+/// them (the component only matches an item's own title/description/keywords).
+fn card(title_key: &str, desc_key: &str, items: Vec<SettingItem>) -> SettingGroup {
+    let title = t!(title_key).into_owned();
+    let desc = t!(desc_key).into_owned();
+    let kws: Vec<SharedString> = vec![
+        title.clone().into(),
+        desc.clone().into(),
+        keywords_for(title_key).into(),
+    ];
+    SettingGroup::new()
+        .title(title)
+        .description(desc)
+        .items(items.into_iter().map(|it| {
+            // `keywords` replaces, so carry over what the item brought (a
+            // dropdown's option labels, a shortcut list's row labels).
+            let own = match &it {
+                SettingItem::Item { keywords, .. } | SettingItem::Element { keywords, .. } => {
+                    keywords.clone()
+                }
+            };
+            it.keywords(own.into_iter().chain(kws.iter().cloned()))
+        }))
+}
+
+/// A full-width custom row.
+fn custom(render: impl Fn(&mut Window, &mut App) -> AnyElement + 'static) -> SettingItem {
+    SettingItem::render(move |_opts, window, cx| render(window, cx))
+}
+
+/// A switch bound to an `AppView` getter/setter, with its default so the
+/// page's reset button knows when it's changed.
+fn switch_item(
+    label_key: &str,
+    app: &WeakEntity<AppView>,
+    get: impl Fn(&AppView) -> bool + 'static,
+    set: impl Fn(&mut AppView, bool, &mut Context<AppView>) + 'static,
+    default: bool,
+    weak: &WeakEntity<SettingsView>,
+) -> SettingItem {
+    let get_app = app.clone();
+    let set_app = app.clone();
+    SettingItem::new(
+        t!(label_key).into_owned(),
+        SettingField::switch(
+            move |cx| {
+                get_app
+                    .upgrade()
+                    .map(|a| get(a.read(cx)))
+                    .unwrap_or(default)
+            },
+            notify_after(weak, move |on, cx| {
+                if let Some(a) = set_app.upgrade() {
+                    a.update(cx, |a, cx| set(a, on, cx));
+                }
+            }),
+        )
+        .default_value(default),
+    )
+}
+
+fn dropdown_item(
+    label_key: &str,
+    options: Options,
+    get: impl Fn(&App) -> SharedString + 'static,
+    set: impl Fn(SharedString, &mut App) + 'static,
+    default: &str,
+    weak: &WeakEntity<SettingsView>,
+) -> SettingItem {
+    let labels: Vec<SharedString> = options.iter().map(|(_, label)| label.clone()).collect();
+    SettingItem::new(
+        t!(label_key).into_owned(),
+        SettingField::dropdown(options, get, notify_after(weak, set))
+            .default_value(SharedString::from(default.to_string())),
+    )
+    .keywords(labels)
+}
+
+/// [`dropdown_item`] whose menu scrolls — for long lists (installed fonts).
+fn dropdown_item_scrollable(
+    label_key: &str,
+    options: Options,
+    get: impl Fn(&App) -> SharedString + 'static,
+    set: impl Fn(SharedString, &mut App) + 'static,
+    default: &str,
+    weak: &WeakEntity<SettingsView>,
+) -> SettingItem {
+    let labels: Vec<SharedString> = options.iter().map(|(_, label)| label.clone()).collect();
+    SettingItem::new(
+        t!(label_key).into_owned(),
+        SettingField::scrollable_dropdown(options, get, notify_after(weak, set))
+            .default_value(SharedString::from(default.to_string())),
+    )
+    .keywords(labels)
+}
+
+/// Wrap a field setter so the Settings view re-renders after it runs: the
+/// fields read their values at render time, and a setter that only touches
+/// `AppView` (or a sidecar file) would otherwise leave the control stale.
+fn notify_after<T: 'static>(
+    weak: &WeakEntity<SettingsView>,
+    set: impl Fn(T, &mut App) + 'static,
+) -> impl Fn(T, &mut App) + 'static {
+    let weak = weak.clone();
+    move |v, cx| {
+        set(v, cx);
+        let _ = weak.update(cx, |_, cx| cx.notify());
+    }
+}
+
+/// Run an `AppView` setter that needs a `Window` (theme / font apply) against
+/// the main window — a field's setter only gets the `App`.
+fn with_main_window(
+    app: &WeakEntity<AppView>,
+    cx: &mut App,
+    f: impl FnOnce(&mut AppView, &mut Window, &mut Context<AppView>),
+) {
+    let Some(a) = app.upgrade() else {
+        return;
+    };
+    let handle = a.read(cx).window_handle;
+    let _ = handle.update(cx, move |_, window, cx| {
+        a.update(cx, |a, cx| f(a, window, cx))
+    });
+}
+
+/// Muted small text under a control: an outcome, a note, a value readout.
+fn status_line(text: impl Into<SharedString>) -> gpui::Div {
+    div()
+        .text_size(px(12.0))
+        .text_color(theme::text_tertiary())
+        .child(text.into())
+}
+
+/// One notebook in the Notebooks card: name + path on the left, its actions
+/// on the right (the active row swaps Switch/Remove for a "current" tag).
+fn notebook_row(nb: crate::paths::Notebook, weak: &WeakEntity<SettingsView>) -> impl IntoElement {
+    let active = nb.is_active();
+    let name = nb.name.clone();
+    let dir = nb.dir.clone();
+    let nb_switch = nb.clone();
+    let nb_rename = nb.clone();
+    let nb_forget = nb.clone();
+    let reveal_dir = PathBuf::from(&nb.dir);
+    let mut actions = div().flex().flex_row().items_center().gap(px(6.0));
+    if active {
+        actions = actions.child(
+            div()
+                .px(px(8.0))
+                .py(px(3.0))
+                .rounded(px(6.0))
+                .bg(theme::accent_tint())
+                .text_size(px(11.0))
+                .text_color(theme::accent())
+                .child(t!("settings.label.current").to_string()),
+        );
+    } else {
+        actions = actions.child(nb_button(
+            SharedString::from(format!("nb-switch:{}", nb.dir)),
+            &t!("settings.nb.switch"),
+            weak,
+            move |this, window, cx| this.switch_notebook(nb_switch.clone(), window, cx),
+        ));
+    }
+    actions = actions
+        .child(nb_button(
+            SharedString::from(format!("nb-rename:{}", nb.dir)),
+            &t!("settings.nb.rename"),
+            weak,
+            move |this, window, cx| this.rename_notebook(nb_rename.clone(), window, cx),
+        ))
+        .child(nb_button(
+            SharedString::from(format!("nb-reveal:{}", nb.dir)),
+            &t!("settings.nb.reveal"),
+            weak,
+            move |_this, _window, _cx| {
+                crate::app::AppView::reveal_folder(&reveal_dir);
+            },
+        ));
+    if !active {
+        actions = actions.child(nb_button(
+            SharedString::from(format!("nb-forget:{}", nb.dir)),
+            &t!("settings.nb.remove"),
+            weak,
+            move |this, _window, cx| this.forget_notebook(nb_forget.clone(), cx),
+        ));
+    }
+    div()
+        .px(px(10.0))
+        .py(px(8.0))
+        .rounded(px(8.0))
+        .bg(theme::glass())
+        .border_1()
+        .border_color(theme::border_subtle())
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap(px(10.0))
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .flex()
+                .flex_col()
+                .gap(px(2.0))
+                .child(
+                    div()
+                        .text_size(px(13.0))
+                        .text_color(theme::text_primary())
+                        .child(name),
+                )
+                .child(
+                    div()
+                        .text_size(px(11.0))
+                        .text_color(theme::text_tertiary())
+                        .truncate()
+                        .child(dir),
+                ),
+        )
+        .child(actions)
+}
+
+/// [`text_button`]'s small sibling for the notebook rows: a dynamic id (one
+/// per notebook) and tighter padding.
+fn nb_button(
+    id: SharedString,
+    label: &str,
+    weak: &WeakEntity<SettingsView>,
+    on: impl Fn(&mut SettingsView, &mut Window, &mut Context<SettingsView>) + 'static,
+) -> impl IntoElement {
+    let weak = weak.clone();
+    div()
+        .id(id)
+        .px(px(8.0))
+        .py(px(4.0))
+        .rounded(px(6.0))
+        .border_1()
+        .border_color(theme::border_subtle())
+        .bg(theme::glass())
+        .text_color(theme::text_secondary())
+        .text_size(px(12.0))
+        .cursor_pointer()
+        .hover(|h| {
+            h.bg(theme::glass_strong())
+                .text_color(theme::text_primary())
+        })
+        .child(label.to_string())
+        .on_click(move |_, window, cx| {
+            let _ = weak.update(cx, |this, cx| on(this, window, cx));
+        })
+}
+
+/// A small action button beside a card's control, sized to sit next to
+/// gpui-component's `.small()` fields. The handler runs on the settings view
+/// (the fields' closures only get the `App`, so buttons hold a weak handle).
+fn text_button(
+    id: &'static str,
+    label: &str,
+    weak: &WeakEntity<SettingsView>,
+    on: impl Fn(&mut SettingsView, &mut Window, &mut Context<SettingsView>) + 'static,
+) -> impl IntoElement {
+    let weak = weak.clone();
+    div()
+        .id(id)
+        .px(px(10.0))
+        .py(px(5.0))
+        .rounded(px(7.0))
+        .border_1()
+        .border_color(theme::border_subtle())
+        .bg(theme::glass())
+        .text_color(theme::text_secondary())
+        .text_size(px(12.0))
+        .cursor_pointer()
+        .hover(|h| {
+            h.bg(theme::glass_strong())
+                .text_color(theme::text_primary())
+        })
+        .child(label.to_string())
+        .on_click(move |_, window, cx| {
+            let _ = weak.update(cx, |this, cx| on(this, window, cx));
+        })
 }
 
 /// Open a URL in the user's default browser (the "View release" button).
@@ -2629,109 +2379,6 @@ fn open_url(url: &str) {
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     let cmd = "xdg-open";
     let _ = std::process::Command::new(cmd).arg(url).spawn();
-}
-
-/// One left-nav category. Highlights when active; clicking switches the pane.
-fn nav_item(
-    id: &'static str,
-    label: &str,
-    tab: Tab,
-    active: Tab,
-    dimmed: bool,
-    cx: &mut Context<SettingsView>,
-) -> impl IntoElement {
-    div()
-        .id(id)
-        .px(px(12.0))
-        .py(px(8.0))
-        .rounded(px(8.0))
-        .text_size(px(14.0))
-        .cursor_pointer()
-        .when(dimmed, |d| d.opacity(0.35))
-        .when(tab == active, |d| {
-            d.bg(theme::accent_tint()).text_color(theme::text_primary())
-        })
-        .when(tab != active, |d| {
-            d.text_color(theme::text_secondary())
-                .hover(|h| h.bg(theme::hover()))
-        })
-        .child(label.to_string())
-        .on_click(cx.listener(move |this, _, _window, cx| {
-            this.tab = tab;
-            cx.notify();
-        }))
-}
-
-fn version_chip() -> impl IntoElement {
-    div()
-        .px(px(8.0))
-        .py(px(2.0))
-        .rounded(px(6.0))
-        .bg(theme::glass())
-        .border_1()
-        .border_color(theme::border_subtle())
-        .text_size(px(12.0))
-        .text_color(theme::text_secondary())
-        .child(concat!("v", env!("CARGO_PKG_VERSION")))
-}
-
-/// A settings card: bold title, muted description, then the control.
-fn card(title: &str, desc: &str, control: impl IntoElement) -> gpui::Div {
-    div()
-        .flex()
-        .flex_col()
-        .gap(px(12.0))
-        .p(px(18.0))
-        .rounded(px(12.0))
-        .bg(theme::elevated())
-        .border_1()
-        .border_color(theme::border_subtle())
-        .child(
-            div()
-                .text_size(px(16.0))
-                .font_weight(FontWeight::SEMIBOLD)
-                .child(title.to_string()),
-        )
-        .child(
-            div()
-                .text_size(px(13.0))
-                .text_color(theme::text_secondary())
-                .child(desc.to_string()),
-        )
-        .child(control)
-}
-
-/// Modifier glyphs for the read-only shortcut list. `MOD` is the platform's
-/// primary modifier (Cmd on macOS, Ctrl elsewhere) — matching `secondary-` in
-/// the keymap; `CTRL` is the literal Control key (for Ctrl+Tab).
-#[cfg(target_os = "macos")]
-mod keys {
-    pub const MOD: &str = "⌘";
-    pub const CTRL: &str = "⌃";
-    pub const SHIFT: &str = "⇧";
-    pub const ALT: &str = "⌥";
-    pub fn redo() -> Vec<&'static str> {
-        vec![MOD, SHIFT, "Z"]
-    }
-}
-#[cfg(not(target_os = "macos"))]
-mod keys {
-    pub const MOD: &str = "Ctrl";
-    pub const CTRL: &str = "Ctrl";
-    pub const SHIFT: &str = "Shift";
-    pub const ALT: &str = "Alt";
-    pub fn redo() -> Vec<&'static str> {
-        vec!["Ctrl", "Y"]
-    }
-}
-
-/// A settings card whose body is a list of `(label, key combo)` shortcut rows.
-fn card_list(title: &str, desc: &str, rows: Vec<(String, Vec<&str>)>) -> gpui::Div {
-    let mut list = div().flex().flex_col().gap(px(2.0));
-    for (label, combo) in rows {
-        list = list.child(shortcut_row(&label, &combo));
-    }
-    card(title, desc, list)
 }
 
 /// One shortcut row: description on the left, key caps on the right.
@@ -2782,56 +2429,16 @@ fn fmt_size(bytes: u64) -> String {
     }
 }
 
-/// [`text_button`]'s small sibling for the notebook rows: a dynamic id (one
-/// per notebook) and tighter padding.
-fn nb_button(
-    id: SharedString,
-    label: &str,
-    cx: &mut Context<SettingsView>,
-    on: impl Fn(&mut SettingsView, &mut Window, &mut Context<SettingsView>) + 'static,
-) -> impl IntoElement {
-    div()
-        .id(id)
-        .px(px(8.0))
-        .py(px(4.0))
-        .rounded(px(6.0))
-        .border_1()
-        .border_color(theme::border_subtle())
-        .bg(theme::glass())
-        .text_color(theme::text_secondary())
-        .text_size(px(12.0))
-        .cursor_pointer()
-        .hover(|h| {
-            h.bg(theme::glass_strong())
-                .text_color(theme::text_primary())
-        })
-        .child(label.to_string())
-        .on_click(cx.listener(move |this, _, window, cx| on(this, window, cx)))
-}
-
-fn text_button(
-    id: &'static str,
-    label: &str,
-    cx: &mut Context<SettingsView>,
-    on: impl Fn(&mut SettingsView, &mut Window, &mut Context<SettingsView>) + 'static,
-) -> impl IntoElement {
-    // Sized to sit beside gpui-component's `.small()` controls (the cards'
-    // dropdowns/switches) — a notch above the per-notebook row buttons.
-    div()
-        .id(id)
-        .px(px(10.0))
-        .py(px(5.0))
-        .rounded(px(7.0))
-        .border_1()
-        .border_color(theme::border_subtle())
-        .bg(theme::glass())
-        .text_color(theme::text_secondary())
-        .text_size(px(12.0))
-        .cursor_pointer()
-        .hover(|h| {
-            h.bg(theme::glass_strong())
-                .text_color(theme::text_primary())
-        })
-        .child(label.to_string())
-        .on_click(cx.listener(move |this, _, window, cx| on(this, window, cx)))
+/// Modifier glyphs for the read-only shortcut list. `MOD` is the platform's
+/// primary modifier (Cmd on macOS, Ctrl elsewhere) — matching `secondary-` in
+/// the keymap; `CTRL` is the literal Control key (for Ctrl+Tab).
+#[cfg(target_os = "macos")]
+mod keys {
+    pub const MOD: &str = "⌘";
+    pub const CTRL: &str = "⌃";
+    pub const SHIFT: &str = "⇧";
+    pub const ALT: &str = "⌥";
+    pub fn redo() -> Vec<&'static str> {
+        vec![MOD, SHIFT, "Z"]
+    }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -527,6 +527,15 @@ fn apply_to_component_theme(p: &Palette, cx: &mut App) {
     t.slider_thumb = p.accent;
     // Focus ring on inputs/selects — stock is a bright near-white in dark mode.
     t.ring = p.accent;
+    // The Settings window's page list is gpui-component's Sidebar, with a
+    // token family of its own (stock: near-white labels on every theme).
+    t.sidebar = p.bg_sidebar;
+    t.sidebar_foreground = p.text_primary;
+    t.sidebar_border = p.border_subtle;
+    t.sidebar_accent = p.hover;
+    t.sidebar_accent_foreground = p.text_primary;
+    t.sidebar_primary = p.accent;
+    t.sidebar_primary_foreground = on_accent;
     // gpui-component is mid-migration to a parallel `tokens` color store;
     // newer widget paths (Button, Slider, some Tab styles) read
     // `theme.tokens.*` instead of the legacy fields above — without this,

--- a/src/ui/embed.rs
+++ b/src/ui/embed.rs
@@ -48,6 +48,7 @@ impl Render for EmbedView {
         let app = self.app.clone();
         let nav = self.nav_target.clone();
         let wiki_app = self.app.clone();
+        let hover_app = self.app.clone();
         // Hover-revealed scrollbar thumb, exact from the handle's last-painted
         // geometry (content height = viewport + max scroll).
         let thumb = {
@@ -80,6 +81,12 @@ impl Render for EmbedView {
         .on_wiki_link(std::rc::Rc::new(move |title, window, cx| {
             let _ = wiki_app.update(cx, |this, cx| this.open_page_title(&title, window, cx));
         }))
+        .on_link_hover({
+            let app = hover_app;
+            std::rc::Rc::new(move |hover, _window, cx| {
+                let _ = app.update(cx, |this, cx| this.set_link_hover(hover, cx));
+            })
+        })
         // The full renderer set, like the note this content came from — images
         // arrive through the read-only path (see `EmbedView::image`).
         .on_image(self.image.clone())

--- a/src/ui/journal.rs
+++ b/src/ui/journal.rs
@@ -391,6 +391,12 @@ fn rendered_day(
             .on_wiki_link(std::rc::Rc::new(move |title, window, cx| {
                 let _ = weak.update(cx, |this, cx| this.open_page_title(&title, window, cx));
             }))
+            .on_link_hover({
+                let weak = cx.entity().downgrade();
+                std::rc::Rc::new(move |hover, _window, cx| {
+                    let _ = weak.update(cx, |this, cx| this.set_link_hover(hover, cx));
+                })
+            })
             // Click the rendered text → enter edit mode with the caret at the click.
             // Deferred so we don't swap to the editor mid-click.
             .on_click_source(std::rc::Rc::new(move |offset, click_y, window, cx| {

--- a/src/ui/page_view.rs
+++ b/src/ui/page_view.rs
@@ -382,6 +382,12 @@ fn page_rendered(app: &AppView, pe: &PageEditor, cx: &mut Context<AppView>) -> i
             .on_wiki_link(std::rc::Rc::new(move |title, window, cx| {
                 let _ = weak.update(cx, |this, cx| this.open_page_title(&title, window, cx));
             }))
+            .on_link_hover({
+                let weak = cx.entity().downgrade();
+                std::rc::Rc::new(move |hover, _window, cx| {
+                    let _ = weak.update(cx, |this, cx| this.set_link_hover(hover, cx));
+                })
+            })
             // Click the rendered text → enter edit mode with the caret at the click.
             // Deferred so we don't swap to the editor mid-click.
             .on_click_source(std::rc::Rc::new(move |offset, click_y, window, cx| {


### PR DESCRIPTION
## Summary

Adopts the gpui-kit components from the TODO adoption list, plus the fixes found along the way.

- **Settings window** rebuilt on gpui-component's `setting` module (pages / groups / typed fields with defaults and Reset, sidebar search over titles, descriptions, synonyms, option labels and shortcut labels). `settings.rs` 2,837 → ~2,180 lines.
- **Link hover previews** (`HoverCard`) in both views: wiki links, tags, block refs, URLs and property pills. The card renders the target page's first lines as real markdown through the reader, so RTL pages, headings, lists and math look like the page. `EditorEvent::HoverLink` / `MarkdownView::on_link_hover` documented in the crate API.md files.
- **Command palette** on ⌘⇧P / Ctrl+Shift+P (also View menu): every menu command grouped by menu with its shortcut, the active page's context-menu verbs, navigation (today, jump to date, All pages, Graph, sidebar) and quick settings (WYSIWYG, line numbers, sidebar side, theme mode). Confirm closes the dialog before dispatching so a command's own focus isn't undone.
- **Dev tooling**: `cargo run --features fps` overlays the gpui-fps HUD; `src/app/ui_tests.rs` starts headless UI tests on a real `AppView` (first: the palette flow). Under `cfg(test)` `paths::data_dir` is a per-process temp dir.

Fixes: opening a page whose title starts with a non-ASCII letter panicked the unlinked-mentions scan; the Settings sidebar ignored the skin (stock white labels on CRT); Esc now reaches an open dialog while a note is being edited.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (191 app tests incl. the new headless UI test)
- [x] Live: Settings pages + search, hover cards on Persian/Arabic/Hebrew/mixed/English pages and URLs, palette open/filter/confirm/Esc on every group, CRT theme sidebar and palette framing, fps HUD build

🤖 Generated with [Claude Code](https://claude.com/claude-code)